### PR TITLE
fix(caddy): bump withPlugins source hash (unblock Flake Health)

### DIFF
--- a/pkgs/caddy-custom.nix
+++ b/pkgs/caddy-custom.nix
@@ -19,5 +19,7 @@ pkgs.caddy.withPlugins {
   ];
   # WORKAROUND (2025-01-01): Hash updated after plugin version changes
   # Run `nix build .#caddy` with lib.fakeHash to get new hash when plugins update
-  hash = "sha256-Nyhz5j+rmARfVtEmZmvjV3fMLKqRyTy/s5Qq5O+Kv0A=";
+  # Updated 2026-04-28: nixpkgs caddy.withPlugins source bundle drift (same plugin
+  # versions, but the underlying derivation now produces a different vendor hash).
+  hash = "sha256-KvAIO5JR7LDGvgZvl5E1GFts0ux1qEu/0u66r1zAjls=";
 }


### PR DESCRIPTION
## Problem

After PR #387 unblocked the python-3.14 evaluation failure, a long-masked latent bug surfaced in the manually-triggered Flake Health run on main:

```
error: hash mismatch in fixed-output derivation 'caddy-src-with-plugins-...-2.11.2.drv':
  specified: sha256-Nyhz5j+rmARfVtEmZmvjV3fMLKqRyTy/s5Qq5O+Kv0A=
  got:       sha256-KvAIO5JR7LDGvgZvl5E1GFts0ux1qEu/0u66r1zAjls=
```

Plugin versions in [pkgs/caddy-custom.nix](pkgs/caddy-custom.nix) are unchanged (cloudflare 0.2.3, caddy-security 1.1.31). The drift came from nixpkgs' `caddy.withPlugins` implementation — likely a Go module / vendoring change in a recent caddy 2.11.2 update.

This was masked by the python-3.14 evaluation failure (home-assistant blew up before caddy was reached) and only surfaced once PR #387 unblocked the closure.

## Fix

Update the hash to the new value reported by CI; tracking comment in `pkgs/caddy-custom.nix` updated.

The PR-level builds for the renovate stack (#329 caddy-security, #376 caddy-dns-cloudflare) will need their own hash bumps when they merge — that's expected behavior for this file.