### PR TITLE
fix(teslamate): bump dashboards tarball hash after upstream re-pack

### DIFF
--- a/modules/nixos/services/teslamate/default.nix
+++ b/modules/nixos/services/teslamate/default.nix
@@ -20,7 +20,11 @@ let
   teslamateDashboardsVersion = "3.0.0";
   teslamateDashboardsSrc = pkgs.fetchzip {
     url = "https://github.com/adriankumpf/teslamate/archive/refs/tags/v${teslamateDashboardsVersion}.tar.gz";
-    sha256 = "sha256-M4Bte5MCZGzKJoFcXzTVLFRHmgqVjR5TyQb5bTeEBws=";
+    # WORKAROUND (2026-04-28): GitHub re-packs archive tarballs occasionally,
+    # breaking pinned hashes for fetchzip without any upstream version change.
+    # If a future re-pack drifts again, swap to fetchFromGitHub (git checkout)
+    # which is more stable, or pin to a release asset with a stable digest.
+    sha256 = "sha256-VWolbrAGEBFZCf0SFNS3rd5h6i5GzX6958OA35kxuQ4=";
   };
   defaultDashboardsPath = "${teslamateDashboardsSrc}/grafana/dashboards";
   grafanaCredentialName = "teslamate-db-password";


### PR DESCRIPTION
Final follow-up to the post-aiounittest fallout.

## Problem

After PRs #387 and #389 unblocked the python-3.14 evaluation chain and the caddy plugin source, the manually-triggered `Flake Health` run on main hit one more long-masked failure:

```
error: hash mismatch in fixed-output derivation '/nix/store/.../source.drv':
  specified: sha256-M4Bte5MCZGzKJoFcXzTVLFRHmgqVjR5TyQb5bTeEBws=
  got:       sha256-VWolbrAGEBFZCf0SFNS3rd5h6i5GzX6958OA35kxuQ4=
```

The version (v3.0.0) is unchanged in [modules/nixos/services/teslamate/default.nix](modules/nixos/services/teslamate/default.nix). GitHub's archive endpoint occasionally re-packs release tarballs (different gzip metadata, gitattributes export-subst markers, etc.) which breaks pinned `fetchzip` hashes without any upstream version change.

## Fix

Update the hash to the new computed value. Added an inline comment about the long-term mitigation: switch to `fetchFromGitHub` (git checkout, more stable) or pin to a release asset with a stable digest.

## Why we're seeing all this fallout

Three latent build failures (aiounittest, httpx-auth, caddy plugin hash, this teslamate hash) were all masked for weeks by the python-3.14 evaluation failure — HA's closure blew up early, so deeper dependencies were never reached. Now that the closure builds end-to-end, the remaining hash drifts surfaced one by one. After this PR, all hosts should build cleanly on main.