### PR TITLE
ci: drop cachix push action from nix-build workflow

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -116,12 +116,13 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/determinate-nix-action@v3
 
-      # Cachix - persistent binary cache shared between CI and local machines
-      - name: Set up Cachix
-        uses: cachix/cachix-action@v17
-        with:
-          name: carpenike
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      # NOTE: We previously used cachix/cachix-action@v17 to push CI builds to
+      # carpenike.cachix.org, but it became a frequent failure mode every time
+      # cachix.org returned 502s during the `cachix use` setup step (their API
+      # is not highly available). carpenike.cachix.org is still listed as a
+      # nixConfig.extra-substituter in flake.nix, so existing cached paths
+      # continue to be fetched - we just no longer push from CI. Most build
+      # output is also covered by cache.garnix.io and nix-community.cachix.org.
 
       # Check flake health (outdated inputs, etc.).
       - name: Flake health check


### PR DESCRIPTION
## Why

`cachix/cachix-action@v17` was failing intermittently because the `cachix use carpenike` setup step makes a `GET https://cachix.org/api/v1/cache/<name>` to fetch the public key, and that endpoint returns `502 Bad Gateway` whenever cachix.org has any kind of incident. A 502 there hard-fails the whole job before nix even runs.

This morning's audit cleanup work made the impact obvious: of the four PRs I shipped (#387, #388, #389, #390), three had at least one host build flap because of cachix-action 502s — the actual nix builds were all green; cachix push failures masked real CI signal.

Example from PR #390 (`fix(teslamate)`):
```
cachix: FailureResponse … responseStatusCode = Status {statusCode = 502, statusMessage = "Bad Gateway"}
Error: The process '/home/runner/.nix-profile/bin/cachix' failed with exit code 1
```

## What changes

- Remove the `Set up Cachix` step from [.github/workflows/nix-build.yml](.github/workflows/nix-build.yml).
- Replace it with a comment explaining the deliberate decision and the failure mode that drove it.
- **Keep `carpenike.cachix.org` listed as a `nixConfig.extra-substituter`** in [flake.nix](flake.nix) — any historical cached paths still get fetched on local machines and CI; we just stop *pushing* from CI.

## Why this is safe

- We get most of our cache value from `cache.garnix.io` and `nix-community.cachix.org`, both still in the substituter list.
- Per-PR builds are largely ephemeral and host-specific, so push-side hits are mostly between sequential CI runs of the same PR — a small benefit that doesn't justify the recurring failure surface.
- The `CACHIX_AUTH_TOKEN` secret can stay in repo settings unused, or be removed later — no rush.

## After this lands

Trigger Flake Health on main again to confirm scheduled workflows recover end-to-end (the morning's run failed on cachix; the run before that failed on the teslamate hash; the run before that failed on aiounittest).