### PR TITLE
fix(hashes): bump VueTorrent + caddy plugin source hashes

### DIFF
--- a/modules/nixos/services/qbittorrent/default.nix
+++ b/modules/nixos/services/qbittorrent/default.nix
@@ -18,7 +18,9 @@ let
   # VueTorrent package (pinned for reproducibility)
   vuetorrentPackage = pkgs.fetchzip {
     url = "https://github.com/VueTorrent/VueTorrent/releases/download/v2.32.1/vuetorrent.zip";
-    hash = "sha256-mthdc2pXLKTjDv7iTxbwFJuT/lHTQcT1QtzxaZFuXBo=";
+    # Hash refreshed 2026-04-28: GitHub re-packed the v2.32.1 release zip.
+    # Same upstream version, different bytes — common with GitHub release assets.
+    hash = "sha256-md6UckHoMhnUAg2Kn3FqvzgEOBvfi8fTaTdbErvU73s=";
     stripRoot = false;
   };
 in

--- a/pkgs/caddy-custom.nix
+++ b/pkgs/caddy-custom.nix
@@ -19,7 +19,11 @@ pkgs.caddy.withPlugins {
   ];
   # WORKAROUND (2025-01-01): Hash updated after plugin version changes
   # Run `nix build .#caddy` with lib.fakeHash to get new hash when plugins update
-  # Updated 2026-04-28: nixpkgs caddy.withPlugins source bundle drift (same plugin
-  # versions, but the underlying derivation now produces a different vendor hash).
-  hash = "sha256-KvAIO5JR7LDGvgZvl5E1GFts0ux1qEu/0u66r1zAjls=";
+  # Updated 2026-04-28 (2nd time): the source bundle drifted again after the
+  # 14:17 UTC `update-flake-lock` workflow bumped nixpkgs, which shifted
+  # caddy's Go vendor closure. Plugin versions and caddy version are still
+  # identical — the only thing that changed is the upstream packaging.
+  # Long-term: switch to a hash-less builder or accept that every nixpkgs
+  # bump that touches the caddy package will require a hash refresh here.
+  hash = "sha256-3c0AYH1OJvciUfi+xY2ULzIK4fn4+CEyF7ZncZoJm3c=";
 }


### PR DESCRIPTION
Two hash drifts hitting back-to-back after this morning's flake.lock bump. Stacking them so Flake Health goes green in one shot rather than playing whack-a-mole.

## Changes

### `modules/nixos/services/qbittorrent/default.nix`
VueTorrent v2.32.1 release zip was re-packed by GitHub (same upstream version, different bytes) — same class of issue as the teslamate dashboards tarball in #390:
```
specified: sha256-mthdc2pXLKTjDv7iTxbwFJuT/lHTQcT1QtzxaZFuXBo=
got:       sha256-md6UckHoMhnUAg2Kn3FqvzgEOBvfi8fTaTdbErvU73s=
```

### `pkgs/caddy-custom.nix`
The successful `update-flake-lock` workflow that ran on main at 14:17 UTC bumped nixpkgs, which shifted caddy's Go vendor closure. Plugin and caddy versions are unchanged:
```
specified: sha256-KvAIO5JR7LDGvgZvl5E1GFts0ux1qEu/0u66r1zAjls=  (set in #389, ~2h ago)
got:       sha256-3c0AYH1OJvciUfi+xY2ULzIK4fn4+CEyF7ZncZoJm3c=  (after flake.lock bump)
```

## Long-term followup

`pkgs/caddy-custom.nix` will continue to need a hash refresh on every nixpkgs bump that touches caddy. Future cleanup options:
- Switch to a hash-less builder, or
- Pre-build via Renovate's caddy-security/caddy-dns-cloudflare PR cycle (#329, #376) — when those land they bump versions and refresh the hash naturally