### PR TITLE
fix(cooklang): bump npmDepsHash for v0.29.1

### DIFF
--- a/pkgs/cooklang-cli.nix
+++ b/pkgs/cooklang-cli.nix
@@ -11,7 +11,7 @@ let
     pname = "cooklang-tailwind-assets";
     inherit (src) version;
     inherit (src) src;
-    npmDepsHash = "sha256-KnVtLFD//Nq7ilu6bY6zrlLpyrHVmwxxojOzlu7DdLQ=";
+    npmDepsHash = "sha256-tBOBa2plgJ0dG5eDD9Yc9YS+Dh6rhBdqU6JiZUjTUY4=";
     npmBuildScript = "build-css";
     installPhase = ''
       runHook preInstall


### PR DESCRIPTION
## Problem

cooklang-cli was bumped from v0.26.0 → v0.29.1 by nvfetcher in PR #404, but the `npmDepsHash` for the `cooklang-tailwind-assets` sub-derivation wasn't updated. The `update-nvfetcher.yml` workflow's `nix-update` auto-fix step couldn't catch this because `cooklang-tailwind-assets` isn't a top-level package — `nix-update` only refreshes hashes for the attribute it's invoked on (`cooklang-cli`), not the inner `buildNpmPackage`.

Caught at deploy time on forge:

```
error: hash mismatch in fixed-output derivation 'cooklang-tailwind-assets-v0.29.1-npm-deps.drv':
  specified: sha256-KnVtLFD//Nq7ilu6bY6zrlLpyrHVmwxxojOzlu7DdLQ=
  got:       sha256-tBOBa2plgJ0dG5eDD9Yc9YS+Dh6rhBdqU6JiZUjTUY4=
```

## Fix

Update the hash. CI build-on-PR will validate it.

## Followup (not in this PR)

The `update-nvfetcher.yml` workflow's auto-fix step should also try to refresh sub-derivation hashes — or at least each nvfetcher-managed package's nix file should be parsed for any `*Hash` attribute and refreshed. Worth filing as a Beads issue.