### PR TITLE
fix(forge): remove duplicate node-exporter enabledCollectors override

### DIFF
--- a/hosts/forge/infrastructure/observability/prometheus.nix
+++ b/hosts/forge/infrastructure/observability/prometheus.nix
@@ -252,14 +252,9 @@ in
     };
   };
 
-  # Host-specific overrides for the node-exporter agent on 'forge'.
-  # Note: ZFS collector disabled due to kernel hangs when snapshot unmount operations are pending.
-  # The ZFS collector calls statfs() which can block indefinitely in zfsctl_snapshot_unmount_delay().
-  # We use custom textfile collectors for critical ZFS metrics instead.
-  services.prometheus.exporters.node = {
-    # Note: monitoring-agent.nix enables [ "systemd" ], monitoring module adds "textfile"
-    enabledCollectors = lib.mkForce [ "systemd" "textfile" ];
-  };
+  # Host-specific node-exporter overrides for forge are defined in
+  # ./monitoring.nix (alongside the GPU metrics module enable). Keep them
+  # in one place so module merging doesn't duplicate the collector flags.
 
   # Define the scrape targets for this instance of the monitoring hub.
   # If the hub were moved to another host, this block would move with it.


### PR DESCRIPTION
## Problem

After this evening's deploy of the months-of-pending changes to forge, `prometheus-node-exporter.service` is in a CrashLoop:

```
node_exporter: error: flag 'collector.systemd' cannot be repeated, try --help
```

The systemd ExecStart had `--collector.systemd --collector.textfile` twice:

```
ExecStart=/nix/store/.../node_exporter \
  --collector.systemd --collector.textfile \
  --collector.systemd --collector.textfile \
  --web.listen-address 0.0.0.0:9100 \
  --collector.textfile.directory=/var/lib/node_exporter/textfile_collector
```

## Root cause

The same exact block existed in both:
- [hosts/forge/infrastructure/monitoring.nix:111](hosts/forge/infrastructure/monitoring.nix#L111)
- [hosts/forge/infrastructure/observability/prometheus.nix:259](hosts/forge/infrastructure/observability/prometheus.nix#L259)

Both defined:
```nix
services.prometheus.exporters.node = {
  enabledCollectors = lib.mkForce [ "systemd" "textfile" ];
};
```

Module-system list merging at the same `mkForce` priority concatenates lists rather than picking one, so the resulting list was `[ "systemd" "textfile" "systemd" "textfile" ]` — which renders to the duplicated flags.

## Fix

Remove the duplicate from `observability/prometheus.nix`. Kept the one in `monitoring.nix` because its comment is the canonical explanation (re: ZFS collector kernel hang) AND that file also enables `modules.services.gpuMetrics` — keeping the host-level node-exporter overrides next to the gpu-metrics enable is more cohesive.

## Verification

- ✅ `nix eval .#nixosConfigurations.forge.config.services.prometheus.exporters.node.enabledCollectors` returns `[ "systemd" "textfile" ]`
- After deploy: `prometheus-node-exporter.service` should reach `active (running)` without crash-loop.