### PR TITLE
fix(qbittorrent): longer SIGTERM grace + stale-lockfile cleanup

### DIFF
--- a/modules/nixos/services/qbittorrent/default.nix
+++ b/modules/nixos/services/qbittorrent/default.nix
@@ -76,6 +76,13 @@ mylib.mkContainerService {
     # Extra podman options
     extraOptions = { cfg, config }: [
       "--umask=0027"
+      # Give qBittorrent up to 60s to flush state on SIGTERM before podman
+      # falls back to SIGKILL. Default of 10s wasn't enough during the
+      # 5.1.4 → 5.2.0 upgrade on 2026-05-01 — qBittorrent got SIGKILL'd
+      # mid-shutdown and left a stale /config/qBittorrent/lockfile that
+      # blocked all subsequent restarts for 3 days. See preStart hook
+      # below for the matching belt-and-suspenders cleanup.
+      "--stop-timeout=60"
     ] ++ lib.optionals (cfg.macAddress != null) [
       "--mac-address=${cfg.macAddress}"
     ];
@@ -245,6 +252,28 @@ mylib.mkContainerService {
         Preferences."Connection\\PortRangeMin" = toString cfg.torrentPort;
       }
     ];
+
+    # Container service overrides:
+    #   preStart removes any stale lockfile left behind by a SIGKILL'd
+    #   qBittorrent. The lockfile is purely a "another instance running"
+    #   check — systemd already serializes service starts, so the only
+    #   way it ever exists at start time is if a previous shutdown was
+    #   ungraceful. Pre-cleaning prevents the restart-loop death spiral
+    #   we hit on 2026-05-01 (lockfile from 18:14 deploy blocked every
+    #   restart attempt for 3 days until manually deleted).
+    #
+    #   The matching `--stop-timeout=60` in spec.extraOptions above gives
+    #   qBittorrent enough time to flush state during normal shutdowns,
+    #   so the preStart cleanup is belt-and-suspenders for actual crashes.
+    #
+    #   systemd-side TimeoutStopSec is left at the nixpkgs podman wrapper
+    #   default (currently 120s) which is already > podman's 60s.
+    systemd.services."${config.virtualisation.oci-containers.backend}-qbittorrent".preStart = lib.mkAfter ''
+      # Remove stale lockfile from any prior ungraceful shutdown.
+      # Safe because systemd already serializes service starts; if a
+      # lockfile exists at this point, no qBittorrent process owns it.
+      rm -f ${cfg.dataDir}/qBittorrent/lockfile
+    '';
 
     # Config generator script for INI file
     modules.services.qbittorrent.configGenerator.script = ''


### PR DESCRIPTION
## Background

qbittorrent has been in a failed CrashLoop on forge for 3 days. Today's investigation found the cascade:

1. **2026-05-01 04:16:20**: deploy restarts qbittorrent (image bump 5.1.4 → 5.2.0).
2. **04:16:20**: qBittorrent receives SIGTERM, starts saving resume data.
3. **04:16:30**: podman default `--stop-timeout=10` fires, SIGKILL the still-flushing process. Lockfile at `/var/lib/qbittorrent/qBittorrent/lockfile` is left behind (mtime captured this).
4. **04:16:31** onwards: every restart attempt sees the stale lockfile, qbittorrent prints 'Another qBittorrent instance is already running.' and exits cleanly within ~1s.
5. **04:16:31**: systemd `Restart=always` bursts through `StartLimitBurst=5` in <10s. Service marked failed.
6. **04:16:31 → 2026-05-04 10:13**: 3 days of failed cascade (config-generator, preseed-qbittorrent, podman-qbittorrent, notify@preseed-critical-failure all marked failed).
7. **2026-05-04 10:13**: manual recovery — `rm /var/lib/qbittorrent/qBittorrent/lockfile`, `systemctl reset-failed`, `systemctl start podman-qbittorrent.service`. Container came back cleanly, restored torrents, VueTorrent loaded.

## Fix

Two complementary changes to [modules/nixos/services/qbittorrent/default.nix](modules/nixos/services/qbittorrent/default.nix):

### 1. `--stop-timeout=60` in spec.extraOptions

Bumps podman's SIGTERM-to-SIGKILL grace period from 10s → 60s. qBittorrent's `Saving resume data completed.` log line in the original incident appeared at 04:16:21 (just 1s after SIGTERM) — but that was on a healthy run; on a high-state instance the flush can legitimately take 30-50s. 60s is conservative enough.

systemd-side `TimeoutStopSec` is left at the nixpkgs podman wrapper default (currently 120s) which is already > 60s, so the two limits stay consistent.

### 2. `preStart` lockfile cleanup

Added a `preStart` hook on the container service unit that `rm -f`s any stale lockfile before container start. Safe because systemd already serializes service starts — if a lockfile exists at this point, no qBittorrent process owns it. Belt-and-suspenders for the case where SIGKILL still happens (true crash, OOM-kill, etc).

## Verification

```
$ nix eval --raw .#nixosConfigurations.forge.config.systemd.services.podman-qbittorrent.preStart
# Remove stale lockfile from any prior ungraceful shutdown.
# Safe because systemd already serializes service starts; if a
# lockfile exists at this point, no qBittorrent process owns it.
rm -f /var/lib/qbittorrent/qBittorrent/lockfile

$ nix eval .#nixosConfigurations.forge.config.virtualisation.oci-containers.containers.qbittorrent.extraOptions
[ ... "--stop-timeout=60" ... ]
```

## After this lands

Tonight's auto-upgrade (or any future restart) won't re-trip the same lockfile pattern. Worth deploying soon since qbittorrent only recovered 30 minutes ago via manual cleanup.