### PR TITLE
fix(factory): add startup-phase healthcheck to silence transient unit noise

### DIFF
--- a/lib/service-factory.nix
+++ b/lib/service-factory.nix
@@ -620,6 +620,9 @@ in
                   retries = specHealthcheck.retries or cfg.healthcheck.retries;
                   startPeriod = specHealthcheck.startPeriod or cfg.healthcheck.startPeriod;
                   onFailure = specHealthcheck.onFailure or cfg.healthcheck.onFailure;
+                  startupInterval = specHealthcheck.startupInterval or cfg.healthcheck.startupInterval;
+                  startupRetries = specHealthcheck.startupRetries or cfg.healthcheck.startupRetries;
+                  startupTimeout = specHealthcheck.startupTimeout or cfg.healthcheck.startupTimeout;
                 in
                 [
                   # -L follows redirects (308/301/302) which *arr apps use for /ping endpoint
@@ -629,6 +632,19 @@ in
                   "--health-retries=${toString retries}"
                   "--health-start-period=${startPeriod}"
                   "--health-on-failure=${onFailure}"
+                ]
+                # Startup-phase healthcheck. Polls more frequently (--health-startup-interval)
+                # but only fails the unit after startupRetries consecutive failures —
+                # eliminating the noisy "transient systemd-run unit failed" warnings during
+                # nixos-rebuild switches caused by the regular --health-interval timer firing
+                # before the container's HTTP server was ready. Once the startup check
+                # succeeds once, podman switches over to the regular healthcheck.
+                # Disabled by setting startupRetries = 0.
+                ++ lib.optionals (startupRetries > 0) [
+                  "--health-startup-cmd=${healthCmd}"
+                  "--health-startup-interval=${startupInterval}"
+                  "--health-startup-timeout=${startupTimeout}"
+                  "--health-startup-retries=${toString startupRetries}"
                 ]
               )
               ++ lib.optionals (cfg.podmanNetwork or null != null) [

--- a/lib/types/healthcheck.nix
+++ b/lib/types/healthcheck.nix
@@ -34,6 +34,49 @@ in
         description = ''
           Grace period for the container to initialize before failures are counted.
           Allows time for DB migrations, preseed operations, and first-run initialization.
+
+          Note: when `startupRetries > 0` (default), the startup-phase healthcheck
+          (--health-startup-*) is what actually gates "is the container ready",
+          and `startPeriod` becomes a backstop. The startup healthcheck polls
+          on `startupInterval` and only fails after `startupRetries` consecutive
+          failures, eliminating the noisy transient-unit failures we used to
+          see during nixos-rebuild switches when the regular --health-interval
+          timer fired before the container's HTTP server was ready.
+        '';
+      };
+
+      startupInterval = mkOption {
+        type = types.str;
+        default = "10s";
+        description = ''
+          Interval between startup-phase health checks (--health-startup-interval).
+          Faster than the regular interval so the container is marked ready
+          quickly once it's actually serving. Only used when startupRetries > 0.
+        '';
+      };
+
+      startupRetries = mkOption {
+        type = types.int;
+        default = 30;
+        description = ''
+          Number of startup-phase health checks before declaring startup failed
+          (--health-startup-retries). At the default startupInterval=10s, this
+          allows up to 5 minutes for the container to come up cleanly without
+          producing failed transient systemd-run units.
+
+          Set to 0 to disable the startup-phase healthcheck and fall back to
+          --health-start-period only (legacy behavior, produces noisy failed
+          transient units during nixos-rebuild switches).
+        '';
+      };
+
+      startupTimeout = mkOption {
+        type = types.str;
+        default = "5s";
+        description = ''
+          Timeout for each startup-phase health check (--health-startup-timeout).
+          Shorter than the regular timeout because we're polling more often.
+          Only used when startupRetries > 0.
         '';
       };
 


### PR DESCRIPTION
## Problem

`task nix:apply-nixos` (and the underlying `nixos-rebuild switch`) has been reporting exit 1 on every container deploy due to **failed transient `systemd-run` units** like:

```
× <container-id>-<random>.service - [systemd-run] /nix/store/.../podman healthcheck run <container-id>
   Active: failed (Result: exit-code) since Mon 2026-05-04 10:54:08 EDT
   Process: 1041713 ExecStart=... podman ... healthcheck run ... (code=exited, status=1/FAILURE)
   Mem peak: 13.4M
   CPU: 43ms
```

The container is healthy. The Taskfile already `systemctl reset-failed`s before the rebuild. But fresh failed units appear *during* the rebuild and stick around for nixos-rebuild's post-activation `systemctl --failed` check to surface, which makes the deploy report failure.

## Root cause

When a container starts:

1. systemd starts the container; podman creates and starts it.
2. Container init takes 1-2s. The actual workload (qBittorrent loading 45MB torrents.db, Sonarr opening SQLite DB, etc) takes 10-20s+ to be ready to serve HTTP.
3. Podman immediately schedules the regular healthcheck timer with `--health-interval=30s`. The first check fires after 30s — too early for a container still loading state.
4. Each healthcheck is run as a transient systemd-run unit. When curl returns non-200 (HTTP server not up yet), the **transient runner** exits status=1, which systemd marks 'failed'.
5. nixos-rebuild's post-activation pass over `systemctl --failed` surfaces these transient units, and the whole task exits 1 — even though podman itself knows we're inside the `--health-start-period=300s` grace window and isn't acting on the failures.

## Fix

Use podman's `--health-startup-*` flags to add a startup-phase healthcheck that polls more frequently (every 10s instead of 30s) but only fails after 30 consecutive failures (5 min worth). Once the startup check succeeds once, podman switches over to the regular healthcheck.

The startup-phase check has its own retry policy that **podman handles internally** — it does NOT produce per-attempt failed transient units. So the deploy noise goes away.

### Changes

**`lib/types/healthcheck.nix`** — add three options to `healthcheckSubmodule`:
- `startupInterval` (default `"10s"`)
- `startupRetries` (default `30` — gives 5 min at 10s interval)
- `startupTimeout` (default `"5s"`)

Set `startupRetries = 0` in a service's `spec.healthcheck` override to disable and fall back to the legacy `--health-start-period`-only behavior.

**`lib/service-factory.nix`** — emit `--health-startup-cmd`, `--health-startup-interval`, `--health-startup-timeout`, and `--health-startup-retries` flags whenever `startupRetries > 0` (the default).

## Verification

```
$ nix eval .#nixosConfigurations.forge.config.virtualisation.oci-containers.containers.qbittorrent.extraOptions
[ ... "--health-startup-cmd=..." "--health-startup-interval=10s" "--health-startup-timeout=5s" "--health-startup-retries=30" ... ]

$ nix eval .#nixosConfigurations.forge.config.virtualisation.oci-containers.containers.sonarr.extraOptions
# (also includes the four new flags)

$ nix flake check --no-build
# passes for all 7 hosts
```

## Scope

Benefits all 10 services that use the factory's healthcheck system (qbittorrent, sonarr, radarr, plex, tracearr, cross-seed, seerr, tdarr, netvisor, termix, dispatcharr, qbit-manage, etc).

## Compatibility

- Requires podman >= 4.0 for `--health-startup-cmd`. We're on 5.7. ✅
- Existing `onFailure = "kill"` etc. semantics unchanged.
- Existing `startPeriod` still in effect as a backstop.
- Per-service `spec.healthcheck.startupRetries = 0` override available if any service needs the old behavior.