### PR TITLE
fix(taskfile): suppress cosmetic podman healthcheck noise from deploy

### DIFF
--- a/.taskfiles/nix/Taskfile.yaml
+++ b/.taskfiles/nix/Taskfile.yaml
@@ -74,7 +74,49 @@ tasks:
     cmds:
       # Clear any failed transient units (e.g., Podman healthcheck timers) before switch
       - ssh "{{.ssh_user}}@{{.host}}.{{.NIXOS_DOMAIN}}" 'sudo systemctl reset-failed' || true
-      - nix-shell -p nixos-rebuild --run 'nixos-rebuild switch --flake .#{{.host}} --fast --use-remote-sudo --build-host "{{.ssh_user}}@{{.host}}.{{.NIXOS_DOMAIN}}" --target-host "{{.ssh_user}}@{{.host}}.{{.NIXOS_DOMAIN}}"'
+      # Run the rebuild. Capture exit code; do NOT fail the task immediately on
+      # exit 1 — podman's healthcheck system uses transient `systemd-run`
+      # units that exit status=1 on each individual probe failure, including
+      # probes that fire while the container is still inside its
+      # --health-start-period grace window. switch-to-configuration's
+      # post-activation `systemctl --failed` check then surfaces these and
+      # makes nixos-rebuild exit 1 even though the actual containers are
+      # healthy. We post-process the failed list to filter that noise.
+      - |
+        rebuild_exit=0
+        nix-shell -p nixos-rebuild --run 'nixos-rebuild switch --flake .#{{.host}} --fast --use-remote-sudo --build-host "{{.ssh_user}}@{{.host}}.{{.NIXOS_DOMAIN}}" --target-host "{{.ssh_user}}@{{.host}}.{{.NIXOS_DOMAIN}}"' || rebuild_exit=$?
+
+        if [ "$rebuild_exit" -eq 0 ]; then
+          exit 0
+        fi
+
+        # Wait briefly for transient units to settle, then enumerate what's
+        # actually failed. Podman healthcheck transient units have names
+        # matching <64-hex-char-container-id>(-startup)?-<hex>.service.
+        sleep 2
+        all_failed=$(ssh "{{.ssh_user}}@{{.host}}.{{.NIXOS_DOMAIN}}" \
+          'systemctl --failed --no-pager --no-legend --plain --state=failed' 2>/dev/null \
+          | awk '{ print $1 }' || true)
+
+        # Strip podman healthcheck transient units. The container ID is 64
+        # hex chars, then optionally -startup, then -<hex-suffix>.service.
+        real_failures=$(echo "$all_failed" \
+          | grep -vE '^[0-9a-f]{64}(-startup)?-[0-9a-f]+\.service$' \
+          | grep -vE '^$' \
+          || true)
+
+        if [ -z "$real_failures" ]; then
+          echo ""
+          echo "ℹ️  nixos-rebuild reported failure but only podman healthcheck transient units were failed (cosmetic — containers still inside their --health-start-period). Treating as success."
+          # Clean up the transient noise so the next deploy starts clean
+          ssh "{{.ssh_user}}@{{.host}}.{{.NIXOS_DOMAIN}}" 'sudo systemctl reset-failed' || true
+          exit 0
+        fi
+
+        echo ""
+        echo "❌ nixos-rebuild failed AND these non-cosmetic units are also failed:"
+        echo "$real_failures"
+        exit "$rebuild_exit"
     preconditions:
       - sh: which nix
         msg: "nix not found"


### PR DESCRIPTION
## Problem

`task nix:apply-nixos` reports exit 1 on every container deploy because **podman healthcheck transient `systemd-run` units exit status=1** during the brief window between container-start and the container's HTTP server actually being ready. `switch-to-configuration`'s post-activation `systemctl --failed` check surfaces these and propagates the failure up the chain.

PR #418's startup-healthcheck addition was a real improvement (faster container-ready detection) but **didn't eliminate the noise**: podman's `podman healthcheck run` always exits 1 on probe failure, whether the probe is startup-phase or regular-phase, and `systemd-run` faithfully marks each transient unit as failed when its main process exits non-zero.

Visible effect: every deploy looks like `task: Failed to run task "nix:apply-nixos": exit status 1` even though all containers come up healthy and the transient units self-clean within minutes.

## Fix

Wrap the `nixos-rebuild switch` call in the Taskfile. After it returns non-zero:

1. Wait 2 seconds for transient units to settle.
2. Enumerate `systemctl --failed` and discard anything matching the podman healthcheck transient unit pattern: `^[0-9a-f]{64}(-startup)?-[0-9a-f]+\.service$`.
3. If only those are failed → cosmetic noise → exit 0 (and run a final `reset-failed` to leave forge clean).
4. If any non-cosmetic units are also failed → print them and propagate the original non-zero exit code.

So real failures still fail loudly. Only the known-cosmetic podman noise is suppressed.

## Regex validation

| Input | Filtered? |
|---|---|
| `5c6ef442d55c...-startup-50a6cee1854d92c7.service` | ✅ filtered (cosmetic) |
| `98a9ba0d18e0...-7b0a6483c4896667.service` | ✅ filtered (cosmetic) |
| `prometheus-node-exporter.service` | ✅ kept (real) |
| `notify@preseed-critical-failure:qbittorrent.service` | ✅ kept (real) |
| `podman-qbittorrent.service` | ✅ kept (real) |

## Limitations / caveats

- The auto-upgrade systemd unit on forge does NOT use this Taskfile so it will still log the same transient noise. But that path doesn't surface to a user-visible exit code anyway.
- If a real container service genuinely fails AND its healthcheck transient units also fail, the **real** failure will be in `real_failures` (unit name doesn't match the hex pattern), so the task still exits non-zero.

## Verification

- yamllint passes
- Manual deploy after merge will be the live test.

This complements PR #418 (which stays — faster startup detection is still valuable) — together they make the deploy quieter (faster startup probes) AND make the exit code reflect actual deploy success.