### PR TITLE
fix(scrypted): never start container without NVR mount when storage is external

### DIFF
--- a/modules/nixos/services/scrypted/default.nix
+++ b/modules/nixos/services/scrypted/default.nix
@@ -514,11 +514,21 @@ in
           message = "Scrypted preseed.enable requires preseed.passwordFile to be set.";
         });
 
+        # tmpfiles.d rules. The dataDir is always managed by us (locally
+        # owned ZFS dataset). For the NVR path, only create the directory
+        # locally if cfg.nvr.manageStorage = true (i.e. it IS a local ZFS
+        # dataset we own). When manageStorage = false (the path is provided
+        # by an external mount such as NFS), creating the directory locally
+        # would silently shadow the upstream mount if the mount races us at
+        # boot — and any data written to the local path before the mount
+        # comes up gets stranded forever underneath it. forge accumulated
+        # 302 GB of orphaned scrypted recordings this way over a 4-day
+        # window in March 2026 before we caught it.
         systemd.tmpfiles.rules =
           [
             "d ${cfg.dataDir} 0750 ${cfg.dataOwner} ${cfg.dataGroup} -"
           ]
-          ++ lib.optionals cfg.nvr.enable [
+          ++ lib.optionals (cfg.nvr.enable && cfg.nvr.manageStorage) [
             "d ${cfg.nvr.path} 0750 ${cfg.nvr.owner} ${cfg.nvr.group} -"
           ];
 
@@ -557,6 +567,21 @@ in
           (lib.mkIf cfg.preseed.enable {
             wants = [ "preseed-scrypted.service" ];
             after = [ "preseed-scrypted.service" ];
+          })
+          # NVR mount safety. When the NVR path is provided by an external
+          # mount (manageStorage = false), refuse to start the container if
+          # that mount is not active. Otherwise scrypted will happily write
+          # camera recordings to the underlying local directory, which will
+          # be shadowed (but not freed) the moment the mount comes up.
+          # See the matching tmpfiles guard above.
+          (lib.mkIf (cfg.nvr.enable && !cfg.nvr.manageStorage) {
+            unitConfig = {
+              RequiresMountsFor = [ cfg.nvr.path ];
+              # AssertPathIsMountPoint causes a clean failure (vs hang) if
+              # the mount is missing — easier to debug than mysterious
+              # write-to-wrong-place behavior.
+              AssertPathIsMountPoint = cfg.nvr.path;
+            };
           })
         ];
 


### PR DESCRIPTION
## Background

Discovered today on forge: **302 GB of scrypted camera recordings** were sitting on `rpool/local/root` at `/mnt/data/scrypted`, hidden underneath the NFS mount that should have been the only thing at that path. Files dated **2026-03-12 to 2026-03-16** — a 4-day window during which scrypted started up before the NFS mount was active, created `/mnt/data/scrypted` on the local fs (because forge has `nvr.manageStorage = false`, meaning the NFS share is supposed to provide that path), wrote ~75 GB per camera × 3 cameras = 302 GB of NVR recordings, and then got shadowed (but not freed) when NFS came up.

The 302 GB was visible as `/` at 92% used (`315G/344G`). Manual cleanup via bind-mounting / and `rm -rf` reclaimed it (now down to **15%**). This PR makes sure it can't happen again.

## Root cause: two bugs combined

### 1. systemd.tmpfiles rule was unconditional on `nvr.enable`

```nix
# Old, in modules/nixos/services/scrypted/default.nix
systemd.tmpfiles.rules = [ ... ]
  ++ lib.optionals cfg.nvr.enable [
    "d ${cfg.nvr.path} 0750 ${cfg.nvr.owner} ${cfg.nvr.group} -"
  ];
```

`tmpfiles.d` runs early in boot, **before NFS mounts are up**. When `manageStorage = false` (the path is provided by an external mount, not a local ZFS dataset we own), this rule was creating the directory locally on whatever filesystem holds `/`. If the NFS mount races us, scrypted starts, and writes go to the wrong place.

### 2. `podman-scrypted.service` had no NFS mount dependency

systemd would happily start the container whenever `podman.service` was up, regardless of whether the NFS mount was active. So even after the tmpfiles rule, scrypted itself had no guard against the missing mount.

## Fix

### 1. Gate the tmpfiles rule on `manageStorage`

```nix
++ lib.optionals (cfg.nvr.enable && cfg.nvr.manageStorage) [
  "d ${cfg.nvr.path} 0750 ${cfg.nvr.owner} ${cfg.nvr.group} -"
];
```

When storage is external, we never pre-create the path. Either the external mount provides it or scrypted fails cleanly.

### 2. Add a hard mount dependency when `manageStorage = false`

```nix
  unitConfig = {
    RequiresMountsFor = [ cfg.nvr.path ];
    AssertPathIsMountPoint = cfg.nvr.path;
  };
})
```

`RequiresMountsFor` makes systemd refuse to start the container unless the relevant mount unit is active. `AssertPathIsMountPoint` causes a clean failure (rather than a hang) if the path is somehow present but not actually a mount.

## Verification

```
$ nix eval '.#nixosConfigurations.forge.config.systemd.services."podman-scrypted.service".unitConfig'
{
  After = "preseed-scrypted.service";
  AssertPathIsMountPoint = "/mnt/data/scrypted";
  OnFailure = [ "notify@scrypted-failure:%n.service" ];
  RequiresMountsFor = [ "/mnt/data/scrypted" ];
  Wants = "preseed-scrypted.service";
}
```

The tmpfiles output for forge no longer contains `d /mnt/data/scrypted ...` — only the `dataDir` (`/var/lib/scrypted`) which is on a local ZFS dataset.

Other hosts that have `nvr.manageStorage = true` (the default — local ZFS NVR dataset) are unaffected: tmpfiles still creates the path and the new `RequiresMountsFor` block is gated off.

`nix flake check --no-build` passes for all 7 hosts.