### PR TITLE
fix(scrypted): use unsuffixed attr key for systemd.services (was silent no-op)

### DIFF
--- a/modules/nixos/services/scrypted/default.nix
+++ b/modules/nixos/services/scrypted/default.nix
@@ -8,7 +8,13 @@ let
   storageCfg = config.modules.storage;
   serviceName = "scrypted";
   backend = config.virtualisation.oci-containers.backend;
-  mainServiceUnit = "${backend}-${serviceName}.service";
+  # NixOS systemd module attribute keys must NOT include the `.service`
+  # suffix \u2014 NixOS appends it when rendering the unit. Using the suffixed
+  # name as a key creates a phantom attribute that NixOS silently ignores.
+  # mainServiceUnit (with suffix) is for places that need the unit *name*
+  # for cross-references (OnFailure, Wants, After, etc).
+  mainServiceName = "${backend}-${serviceName}";
+  mainServiceUnit = "${mainServiceName}.service";
   datasetPath = "${storageCfg.datasets.parentDataset}/scrypted";
   domain = config.networking.domain or null;
   defaultHostname = if domain == null || domain == "" then "scrypted.local" else "scrypted.${domain}";
@@ -560,7 +566,7 @@ in
           ports = portMappings;
         };
 
-        systemd.services.${mainServiceUnit} = lib.mkMerge [
+        systemd.services.${mainServiceName} = lib.mkMerge [
           (lib.mkIf (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
             unitConfig.OnFailure = [ "notify@scrypted-failure:%n.service" ];
           })


### PR DESCRIPTION
## Background

While verifying PR #420's deploy on forge, I noticed the new `RequiresMountsFor` and `AssertPathIsMountPoint` settings didn't appear in the rendered `podman-scrypted.service` unit file:

```
$ systemctl show podman-scrypted --property=RequiresMountsFor,AssertPathIsMountPoint
RequiresMountsFor=/run/scrypted
# AssertPathIsMountPoint missing entirely
```

But the eval was correct:
```
$ nix eval '.#nixosConfigurations.forge.config.systemd.services."podman-scrypted.service".unitConfig'
{ AssertPathIsMountPoint = "/mnt/data/scrypted"; RequiresMountsFor = [ "/mnt/data/scrypted" ]; ... }
```

## Root cause

The scrypted module was using:

```nix
mainServiceUnit = "${backend}-${serviceName}.service";
# ...
systemd.services.${mainServiceUnit} = lib.mkMerge [ ... ];
```

This creates an attribute at `systemd.services."podman-scrypted.service"` (with a literal `.service` in the key name).

**NixOS's systemd module expects keys WITHOUT the `.service` suffix** \u2014 it appends `.service` itself when rendering the unit to disk. A suffixed key creates a phantom attribute that NixOS silently ignores.

So PR #420's `RequiresMountsFor`/`AssertPathIsMountPoint` were silently dropped. **And** \u2014 caught by accident here \u2014 the pre-existing `OnFailure` (notification dispatcher) and preseed `Wants`/`After` blocks have also been silently no-ops since they were originally added.

## Fix

Introduce `mainServiceName` (without `.service` suffix) and use it as the attribute key. Keep `mainServiceUnit` (with suffix) for places that need the unit *name string* for cross-references (e.g. `OnFailure = [ "${mainServiceUnit}" ]`).

```nix
mainServiceName = "${backend}-${serviceName}";
mainServiceUnit = "${mainServiceName}.service";
# ...
systemd.services.${mainServiceName} = lib.mkMerge [ ... ];
```

## Verification

```
$ nix eval .#nixosConfigurations.forge.config.systemd.services.podman-scrypted.unitConfig
{
  After = "network-online.target preseed-scrypted.service";
  AssertPathIsMountPoint = "/mnt/data/scrypted";
  OnFailure = [ "notify@scrypted-failure:%n.service" ];
  RequiresMountsFor = [ "/mnt/data/scrypted" ];
  Wants = "network-online.target preseed-scrypted.service";
}
```

`nix flake check --no-build` passes all 7 hosts.

## Side effect: enables long-broken behavior

Once this lands, scrypted will (for the first time):
1. Refuse to start without the NFS mount being active (PR #420's intent)
2. Wait for `preseed-scrypted.service` before starting (always intended)
3. Trigger the `notify@scrypted-failure` dispatcher on failure (always intended)

Items 2 and 3 have been broken since the module was first written. Worth noting in case the notification dispatcher generates a backlog of stale failure notifications when scrypted next has a hiccup.