### PR TITLE
fix(scrypted): correct AssertPathIsMountPoint for NFS subdirectory NVR paths

### DIFF
--- a/hosts/forge/services/scrypted.nix
+++ b/hosts/forge/services/scrypted.nix
@@ -44,6 +44,7 @@ in
           datasetName = "scrypted-nvr";
           mountMode = "rw";
           manageStorage = false; # recordings live on NAS share mounted at /mnt/data
+          mountPoint = mediaMount; # assert the NFS mount itself is active before starting
           group = "media";
         };
 

--- a/modules/nixos/services/scrypted/default.nix
+++ b/modules/nixos/services/scrypted/default.nix
@@ -203,6 +203,28 @@ in
         default = true;
         description = "Automatically manage the NVR ZFS dataset when true.";
       };
+
+      mountPoint = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = "/mnt/data";
+        description = ''
+          Optional explicit mount point that backs `nvr.path`. Only relevant
+          when `manageStorage = false` and the NVR data lives on an external
+          mount (e.g. NFS) where `nvr.path` is a *subdirectory* of that
+          mount rather than the mount itself.
+
+          When set, the container unit will refuse to start unless this
+          path is an active mount point (via `AssertPathIsMountPoint`),
+          providing a clean failure mode if the mount is missing rather
+          than silently writing recordings to the underlying local
+          directory.
+
+          When null (the default), only `RequiresMountsFor = nvr.path` is
+          used, which still orders/blocks on the most specific mount that
+          contains the path but does not assert it.
+        '';
+      };
     };
 
     timezone = lib.mkOption {
@@ -580,13 +602,22 @@ in
           # camera recordings to the underlying local directory, which will
           # be shadowed (but not freed) the moment the mount comes up.
           # See the matching tmpfiles guard above.
+          #
+          # `RequiresMountsFor` always finds the most specific mount unit
+          # that *contains* `cfg.nvr.path` and orders/requires it, which
+          # works correctly when `cfg.nvr.path` is a subdirectory of the
+          # mount (the common NFS case).
+          #
+          # `AssertPathIsMountPoint` is stricter: it requires the asserted
+          # path to be a literal mount point. Only enable it when the user
+          # has explicitly told us what the actual mount point is via
+          # `cfg.nvr.mountPoint` — otherwise it would falsely fail for
+          # subdirectories of valid mounts.
           (lib.mkIf (cfg.nvr.enable && !cfg.nvr.manageStorage) {
             unitConfig = {
               RequiresMountsFor = [ cfg.nvr.path ];
-              # AssertPathIsMountPoint causes a clean failure (vs hang) if
-              # the mount is missing — easier to debug than mysterious
-              # write-to-wrong-place behavior.
-              AssertPathIsMountPoint = cfg.nvr.path;
+            } // lib.optionalAttrs (cfg.nvr.mountPoint != null) {
+              AssertPathIsMountPoint = cfg.nvr.mountPoint;
             };
           })
         ];


### PR DESCRIPTION
## Problem

PR #420 introduced `AssertPathIsMountPoint = cfg.nvr.path` to refuse to start the scrypted container when its NVR storage mount is missing. PR #421 fixed the attribute-key bug that was silently no-op'ing all our `systemd.services` overrides — which then activated the assertion for the first time and immediately broke production:

```
$ systemctl status podman-scrypted.service
... Assert: start assertion failed at ... Mon 2026-05-04 12:56:40 EDT
   AssertPathIsMountPoint=/mnt/data/scrypted was not met
```

The assertion is wrong for the common NFS case. On forge, `cfg.nvr.path = /mnt/data/scrypted`, which is a *subdirectory* of the `/mnt/data` NFS mount — not a separate mount point. `AssertPathIsMountPoint` requires a literal mount point.

## Fix

Add a new optional `nvr.mountPoint` to the scrypted module so the user can explicitly name the actual mount point to assert. When unset (default), only `RequiresMountsFor = nvr.path` is used — that primitive already understands subdirectories and orders on the most specific containing mount.

Wire `hosts/forge/services/scrypted.nix` to set `mountPoint = mediaMount` (`/mnt/data`), so the assertion now checks the actual NFS mount.

## Validation

```
$ nix eval --raw .#nixosConfigurations.forge.config.systemd.services.podman-scrypted.unitConfig.AssertPathIsMountPoint
/mnt/data
$ nix eval --json .#nixosConfigurations.forge.config.systemd.services.podman-scrypted.unitConfig.RequiresMountsFor
["/mnt/data/scrypted"]
```

After deploy, `podman-scrypted.service` should start cleanly because `/mnt/data` IS an active mount point on forge.

## Defense-in-depth chain

1. **`RequiresMountsFor=/mnt/data/scrypted`** — orders the unit after `mnt-data.mount` and refuses to start if it's not active. Works for subdirectory paths.
2. **`AssertPathIsMountPoint=/mnt/data`** — second belt-and-suspenders check that the mount really is mounted (not just "the unit is up"). Provides clean Assert-failed status vs hang.
3. **tmpfiles guard** (already exists from PR #420) — refuses to create the host directory if the mount is missing.

## Risk

Low. Only changes scrypted module unitConfig and forge host wiring. Other consumers of the scrypted module continue to work because `mountPoint` defaults to `null` (assertion not added).

## Related

- Follows PR #420 (NVR mount safety) and PR #421 (mainServiceName fix)
- Resolves the regression introduced when PR #421 made the previously no-op'd assertion effective