### PR TITLE
fix(flake): expand directory args in nix fmt wrapper to skip _sources/

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -318,19 +318,69 @@
           };
 
           # Code formatter (nix fmt)
-          # Wraps nixpkgs-fmt to exclude nvfetcher-generated files that use
-          # their own formatting style and would cause CI failures.
+          # Wraps nixpkgs-fmt to exclude nvfetcher-generated files which use
+          # their own formatting style and would otherwise cause CI failures.
+          #
+          # nixpkgs-fmt has no native --exclude flag, and walking a directory
+          # arg (e.g. `nix fmt -- --check .`) would silently include
+          # pkgs/_sources/generated.nix. We therefore expand any directory
+          # args to an explicit file list with the excluded paths removed.
+          #
+          # The excluded paths mirror the pre-commit `excludes` block in this
+          # flake (^tmp/, ^site/, ^result, ^pkgs/_sources/) plus tooling dirs
+          # (.direnv, .git, .beads) so local runs match CI behaviour.
           formatter = pkgs.writeShellScriptBin "nixpkgs-fmt" ''
-            # Filter out nvfetcher-generated files, pass the rest to nixpkgs-fmt
-            args=()
+            set -euo pipefail
+
+            flags=()
+            paths=()
             for arg in "$@"; do
               case "$arg" in
-                -*)           args+=("$arg") ;;   # pass flags through
-                */pkgs/_sources/*) ;;              # skip generated files
-                *)            args+=("$arg") ;;   # keep other paths
+                -*) flags+=("$arg") ;;
+                *)  paths+=("$arg") ;;
               esac
             done
-            exec ${pkgs.nixpkgs-fmt}/bin/nixpkgs-fmt "''${args[@]}"
+
+            # Default to current directory when no path is given (matches
+            # `nixpkgs-fmt`'s native behaviour).
+            if [ ''${#paths[@]} -eq 0 ]; then
+              paths=(".")
+            fi
+
+            files=()
+            for p in "''${paths[@]}"; do
+              if [ -d "$p" ]; then
+                while IFS= read -r f; do
+                  files+=("$f")
+                done < <(${pkgs.findutils}/bin/find "$p" \
+                  \( -type d \( \
+                       -name _sources \
+                    -o -name tmp \
+                    -o -name site \
+                    -o -name result \
+                    -o -name .direnv \
+                    -o -name .git \
+                    -o -name .beads \
+                  \) -prune \) -o \
+                  -type f -name '*.nix' -print)
+              elif [ -f "$p" ]; then
+                case "$p" in
+                  */pkgs/_sources/*|pkgs/_sources/*) ;;  # nvfetcher-generated
+                  */tmp/*|tmp/*) ;;
+                  */site/*|site/*) ;;
+                  */.direnv/*|.direnv/*) ;;
+                  */.git/*|.git/*) ;;
+                  *) files+=("$p") ;;
+                esac
+              fi
+            done
+
+            # No-op when nothing to format (avoids nixpkgs-fmt's "no input" error)
+            if [ ''${#files[@]} -eq 0 ]; then
+              exit 0
+            fi
+
+            exec ${pkgs.nixpkgs-fmt}/bin/nixpkgs-fmt "''${flags[@]}" "''${files[@]}"
           '';
 
           # Custom packages - available via 'nix build .#<name>'


### PR DESCRIPTION
## Problem

The CI `Nix Lint` job (`nix fmt -- --check .`) silently included `pkgs/_sources/generated.nix`, which is nvfetcher-generated and uses its own formatting style. The previous wrapper only filtered `*/pkgs/_sources/*` when given individual file paths, so the directory arg `.` was forwarded as-is and `nixpkgs-fmt` walked the whole tree.

The bug had been latent — locally `generated.nix` happened to be `nixpkgs-fmt`-clean, so `nix fmt -- --check .` passed. The nvfetcher PR #411 reliably tripped it because the regenerated file produced one formatting diff against `nixpkgs-fmt`.

## Fix

Rewrite the wrapper to expand directory args via `find`, pruning:
- `_sources/` (nvfetcher-generated, the original target)
- `tmp/`, `site/`, `result/` (mirrors the flake's own pre-commit `excludes` list)
- `.direnv/`, `.git/`, `.beads/` (tooling dirs)

Individual file args match both relative (`pkgs/_sources/...`) and absolute (`*/pkgs/_sources/...`) forms so pre-commit invocation still works.

## Verification

| Scenario | Before | After |
|----------|--------|-------|
| `nix fmt -- --check .` (clean tree) | pass | pass (0/401) |
| `nix fmt -- --check .` with broken `_sources/generated.nix` | **fail** | pass |
| `nix fmt -- --check pkgs/_sources/generated.nix` | fail | pass (skipped) |
| `nix fmt -- --check flake.nix` | pass | pass |
| `nix flake check --no-build` | pass | pass |

## Impact

Unblocks the recurring `Nix Lint` failure on every nvfetcher dependency-update PR (currently #411). No behaviour change for hand-written `.nix` files.