### PR TITLE
chore(audit): drop redundant pinchflat uid + suppress scrypted root-owner warning

### DIFF
--- a/hosts/forge/services/pinchflat.nix
+++ b/hosts/forge/services/pinchflat.nix
@@ -25,9 +25,9 @@ in
         dataDir = "/var/lib/pinchflat";
         mediaDir = "/mnt/data/media/youtube";
 
-        # User configuration - UID 930, media group for NFS access
+        # User configuration - "pinchflat" user, media group for NFS access.
+        # UID is sourced from lib/service-uids.nix via the module default.
         user = "pinchflat";
-        uid = 930;
         group = "media";
 
         # NFS mount dependency for media storage

--- a/modules/nixos/services/scrypted/default.nix
+++ b/modules/nixos/services/scrypted/default.nix
@@ -641,6 +641,12 @@ in
           owner = cfg.dataOwner;
           group = cfg.dataGroup;
           mode = "0750";
+          # Scrypted runs in a privileged container with hardware passthrough
+          # (Intel iGPU, Coral USB) and executes as uid 0 inside the container.
+          # The host bind mount must therefore be owned by root. Acknowledged
+          # to suppress the storage module's "owner=root" advisory warning.
+          rootOwnedReason = lib.mkIf (cfg.dataOwner == "root")
+            "Scrypted runs privileged with hardware passthrough; container processes execute as uid 0";
         };
 
         modules.storage.datasets.services.${cfg.nvr.datasetName} = lib.mkIf (cfg.nvr.enable && cfg.nvr.manageStorage) {
@@ -654,6 +660,8 @@ in
           owner = cfg.nvr.owner;
           group = cfg.nvr.group;
           mode = "0750";
+          rootOwnedReason = lib.mkIf (cfg.nvr.owner == "root")
+            "Scrypted runs privileged with hardware passthrough; NVR recordings are written as uid 0";
         };
 
         modules.backup.restic.jobs.${serviceName} = lib.mkIf (cfg.backup != null && cfg.backup.enable) {

--- a/modules/nixos/storage/datasets.nix
+++ b/modules/nixos/storage/datasets.nix
@@ -119,6 +119,22 @@ in
               Only applies when mountpoint is not "none" or "legacy".
             '';
           };
+
+          rootOwnedReason = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "Privileged container runs as uid 0 for hardware passthrough";
+            description = ''
+              Suppress the "owner=root is usually unintentional" warning for
+              this dataset by documenting why root ownership is required.
+              Typical legitimate reasons:
+                - Privileged container that runs as uid 0 inside the container
+                - Service intentionally invokes setuid binaries from this path
+                - System-level dataset shared between multiple service users
+              When set to a non-null string, the warning is suppressed.
+              Has no effect when `owner` is not "root".
+            '';
+          };
         };
       });
       default = { };
@@ -468,30 +484,32 @@ in
     ];
 
     # Warn about datasets with root ownership that have real mountpoints
-    # Root ownership is usually unintentional for service datasets
+    # Root ownership is usually unintentional for service datasets.
+    # Suppress per-dataset by setting `rootOwnedReason` to document why.
     warnings =
       let
-        # Service datasets with root owner and a real mountpoint
+        # Service datasets with root owner, a real mountpoint, and no documented reason
         rootOwnedServices = lib.filterAttrs
-          (_name: cfg:
-            cfg.owner == "root" &&
-            cfg.mountpoint != null &&
-            cfg.mountpoint != "none" &&
-            cfg.mountpoint != "legacy"
+          (_name: dcfg:
+            dcfg.owner == "root" &&
+            dcfg.rootOwnedReason == null &&
+            dcfg.mountpoint != null &&
+            dcfg.mountpoint != "none" &&
+            dcfg.mountpoint != "legacy"
           )
           cfg.services;
 
         # Utility datasets with root owner and a real mountpoint
         rootOwnedUtility = lib.filterAttrs
-          (_name: cfg:
-            cfg.owner == "root" &&
-            cfg.mountpoint != "none" &&
-            cfg.mountpoint != "legacy"
+          (_name: dcfg:
+            dcfg.owner == "root" &&
+            dcfg.mountpoint != "none" &&
+            dcfg.mountpoint != "legacy"
           )
           cfg.utility;
 
         serviceWarnings = lib.mapAttrsToList
-          (name: _: "ZFS dataset '${name}' has owner=root - this is usually unintentional. Set 'owner' to the service user.")
+          (name: _: "ZFS dataset '${name}' has owner=root - this is usually unintentional. Set 'owner' to the service user, or set 'rootOwnedReason' to document why root ownership is required.")
           rootOwnedServices;
 
         utilityWarnings = lib.mapAttrsToList


### PR DESCRIPTION
Two low-risk audit follow-ups bundled because both are additive and behaviour-preserving.

## 1. `hosts/forge/services/pinchflat`: drop redundant `uid = 930`

The pinchflat module already defaults to `mylib.serviceUids.pinchflat.uid` (= 930) via [lib/service-uids.nix](lib/service-uids.nix). The host-level literal made the centralized registry not the source of truth and would silently drift if the registry ever changed.

## 2. `modules/nixos/storage/datasets`: add `rootOwnedReason` opt-out

`nix flake check` was emitting:
> evaluation warning: ZFS dataset 'scrypted' has owner=root - this is usually unintentional. Set 'owner' to the service user.

Scrypted runs as a privileged container with hardware passthrough (Intel iGPU + Coral USB) and executes as uid 0 inside the container, so the host bind-mount must legitimately be owned by root. Same reasoning for the NVR dataset when `manageStorage` is true.

This PR adds an explicit `rootOwnedReason` (`nullOr str`, default `null`) field to the service dataset submodule. When set, the warning is suppressed; when `null` (default), the warning still fires. The scrypted module sets it on both its config and NVR datasets when `owner == "root"`.

Net effect: the warning still catches accidental root ownership across the rest of the fleet, but legitimate cases can be acknowledged in-place with a documented reason rather than ignored fleet-wide.

## Verification

```
nix flake check --no-build  →  no warnings, no errors
pinchflat uid evaluates to 930 (unchanged)
scrypted dataset rootOwnedReason evaluates to the documented string
```

No changes to deployed unit/container behaviour; this is purely option- and warning-level cleanup.