### PR TITLE
refactor(onepassword-connect): adopt sharedTypes.reverseProxySubmodule

### DIFF
--- a/hosts/luna/default.nix
+++ b/hosts/luna/default.nix
@@ -173,9 +173,10 @@ in
           credentialsFile = config.sops.secrets.onepassword-credentials.path;
           reverseProxy = {
             enable = true;
-            # NOTE: Uses native token-based auth (OP_CONNECT_TOKEN)
-            # No additional auth needed at reverse proxy level
-            requireAuth = false;
+            hostName = "vault.${config.networking.domain}";
+            # No external auth: Connect uses native token-based auth (OP_CONNECT_TOKEN);
+            # the shared submodule's `auth` defaults to null, so leaving it unset
+            # means Caddy will not enforce its own auth layer in front.
           };
         };
 

--- a/modules/nixos/services/onepassword-connect/default.nix
+++ b/modules/nixos/services/onepassword-connect/default.nix
@@ -1,9 +1,11 @@
 { lib
 , config
+, mylib
 , podmanLib
 , ...
 }:
 let
+  sharedTypes = mylib.types;
   cfg = config.modules.services.onepassword-connect;
   apiPort = 8000;
 in
@@ -55,36 +57,14 @@ in
       description = "Resource limits for the 1Password Connect containers (lightweight API services)";
     };
 
-    # Reverse proxy integration options
-    reverseProxy = {
-      enable = lib.mkEnableOption "Caddy reverse proxy integration for 1Password Connect";
-      subdomain = lib.mkOption {
-        type = lib.types.str;
-        default = "vault";
-        description = "Subdomain to use for the reverse proxy";
-      };
-      requireAuth = lib.mkOption {
-        type = lib.types.bool;
-        default = true;
-        description = "Whether to require authentication (highly recommended for vault access)";
-      };
-      auth = lib.mkOption {
-        type = lib.types.nullOr (lib.types.submodule {
-          options = {
-            user = lib.mkOption {
-              type = lib.types.str;
-              default = "vault";
-              description = "Username for basic authentication";
-            };
-            passwordHashEnvVar = lib.mkOption {
-              type = lib.types.str;
-              description = "Name of environment variable containing bcrypt password hash";
-            };
-          };
-        });
-        default = null;
-        description = "Authentication configuration for vault endpoint";
-      };
+    # Standard reverse proxy integration via the shared submodule.
+    # Caddy registration is wired up below when reverseProxy != null && .enable.
+    # Note: 1Password Connect uses native token-based auth (OP_CONNECT_TOKEN),
+    # so external Caddy auth is typically left null.
+    reverseProxy = lib.mkOption {
+      type = lib.types.nullOr sharedTypes.reverseProxySubmodule;
+      default = null;
+      description = "Reverse proxy configuration for the 1Password Connect API.";
     };
   };
 
@@ -92,35 +72,40 @@ in
     modules.services.podman.enable = true;
 
     # Automatically register with Caddy reverse proxy if enabled
-    modules.services.caddy.virtualHosts.${cfg.reverseProxy.subdomain} = lib.mkIf cfg.reverseProxy.enable {
-      enable = true;
-      hostName = "${cfg.reverseProxy.subdomain}.${config.modules.services.caddy.domain or config.networking.domain or "holthome.net"}";
+    modules.services.caddy.virtualHosts."${cfg.reverseProxy.hostName}" =
+      lib.mkIf (cfg.reverseProxy != null && cfg.reverseProxy.enable) {
+        enable = true;
+        hostName = cfg.reverseProxy.hostName;
 
-      # Use structured backend configuration
-      backend = {
-        scheme = "http"; # 1Password Connect uses HTTP locally
-        host = "localhost";
-        port = apiPort;
+        backend = lib.mkDefault {
+          scheme = "http"; # 1Password Connect serves HTTP locally
+          host = "localhost";
+          port = apiPort;
+        };
+
+        # Token-based auth is enforced by Connect itself; only attach Caddy
+        # auth when the consumer explicitly opts in.
+        auth = cfg.reverseProxy.auth;
+
+        # HSTS is on by default in the shared submodule. Layer extra
+        # browser-hardening headers on top of any consumer-provided ones.
+        security = cfg.reverseProxy.security // {
+          customHeaders = {
+            "X-Frame-Options" = "DENY";
+            "X-Content-Type-Options" = "nosniff";
+            "X-XSS-Protection" = "1; mode=block";
+            "Referrer-Policy" = "strict-origin-when-cross-origin";
+          } // (cfg.reverseProxy.security.customHeaders or { });
+        };
+
+        # Force JSON content-type on the v1 API surface (defensive, in case
+        # an upstream response omits the header).
+        extraConfig = ''
+          header /v1/* {
+            Content-Type "application/json"
+          }
+        '';
       };
-
-      # Authentication from shared types
-      auth = lib.mkIf (cfg.reverseProxy.requireAuth && cfg.reverseProxy.auth != null) cfg.reverseProxy.auth;
-
-      extraConfig = ''
-        # High security headers for vault access
-        header / {
-          X-Frame-Options "DENY"
-          X-Content-Type-Options "nosniff"
-          X-XSS-Protection "1; mode=block"
-          Referrer-Policy "strict-origin-when-cross-origin"
-          Strict-Transport-Security "max-age=31536000; includeSubDomains"
-        }
-        # API endpoint specific handling
-        header /v1/* {
-          Content-Type "application/json"
-        }
-      '';
-    };
 
     system.activationScripts.makeOnePasswordConnectDataDir = lib.stringAfter [ "var" ] ''
       mkdir -p "${cfg.dataDir}"


### PR DESCRIPTION
Bring 1Password Connect in line with sonarr/pgweb/etc. by replacing the inline `reverseProxy` submodule (which exposed a bespoke `subdomain`/`requireAuth`/`auth` shape) with the standardised [`mylib.types.reverseProxySubmodule`](lib/types/reverse-proxy.nix).

## Changes

**[`modules/nixos/services/onepassword-connect/default.nix`](modules/nixos/services/onepassword-connect/default.nix):**
- Add `mylib` argument; bind `sharedTypes = mylib.types`.
- `reverseProxy` is now `nullOr sharedTypes.reverseProxySubmodule` (default `null`), matching the established repo pattern.
- Caddy registration switches from `cfg.reverseProxy.subdomain` to `cfg.reverseProxy.hostName` — consumer now supplies the FQDN explicitly, same as every other service.
- Drop the bespoke `requireAuth` flag. Pass `cfg.reverseProxy.auth` through directly (`null` disables Caddy auth, matching the previous `requireAuth = false` behaviour).
- Migrate the inline `header /` block to `security.customHeaders` so it composes with the shared HSTS handling. The path-specific `header /v1/* { Content-Type "application/json" }` rule stays in `extraConfig` because it isn't expressible via the shared type.

**[`hosts/luna/default.nix`](hosts/luna/default.nix):**
- Set `hostName = "vault.${config.networking.domain}"` (was previously derived from the dropped `subdomain` option).
- Drop `requireAuth = false` (now expressed by leaving `auth = null`).

## Verification

```
nix flake check --no-build  →  no warnings, no errors
```

Rendered `vault.holthome.net` vhost preserves all the behaviour of the old inline config:

| Field | Value |
|---|---|
| `backend` | `http://localhost:8000` |
| `auth` | `null` (Connect uses native OP_CONNECT_TOKEN) |
| `security.customHeaders` | `X-Frame-Options=DENY`, `X-Content-Type-Options=nosniff`, `X-XSS-Protection=1; mode=block`, `Referrer-Policy=strict-origin-when-cross-origin` |
| `extraConfig` | `/v1/*` Content-Type rule |
| HSTS | Emitted by shared submodule's default `security.hsts.enable = true` |

No service restart should be required — only the rendered Caddyfile changes (logically equivalent).