### PR TITLE
docs(omada): refresh v5 pin workaround, document planned forge migration

### DIFF
--- a/docs/container-image-management.md
+++ b/docs/container-image-management.md
@@ -140,7 +140,7 @@ Create or update `renovate.json` in your repository root:
 ## Current Status
 
 ### Services with Pinned Versions ✅
-- **Omada Controller**: `mbentley/omada-controller:5.14`
+- **Omada Controller**: `mbentley/omada-controller:5.15.24.19` (pinned to v5.x — see [`workarounds.md`](workarounds.md#omada-controller---pinned-to-v5x-no-avx-on-luna))
 - **UniFi Controller**: `jacobalberty/unifi-docker:v8.4.62`
 - **1Password Connect API**: `1password/connect-api:1.7.2`
 - **1Password Connect Sync**: `1password/connect-sync:1.7.2`

--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -216,11 +216,14 @@ Services using `pkgs.unstable.*` instead of stable packages:
 | Field | Value |
 |-------|-------|
 | **Added** | 2026-03-10 |
+| **Last reviewed** | 2026-05-04 |
 | **Location** | `modules/nixos/services/omada/default.nix` (container image) |
-| **Reason** | Luna's Intel Celeron J3455 (Apollo Lake) lacks AVX instruction support. Omada Controller v6.x ships MongoDB 8 which requires AVX. Container exits immediately with `ERROR: your system does not support AVX`. |
-| **Workaround** | Pinned to `omada-controller:5.15.24.18` (last v5.x release, uses MongoDB 7 which has no AVX requirement) |
-| **Upstream** | https://github.com/mbentley/docker-omada-controller/blob/master/KNOWN_ISSUES.md#your-system-does-not-support-avx-or-armv82-a |
-| **Check** | If luna is replaced with AVX-capable hardware, or if upstream offers a v6+ image with MongoDB 7 |
+| **Reason** | Luna's Intel Celeron J3455 (Apollo Lake) lacks AVX instruction support. Omada Controller v6.x ships MongoDB 8 which requires AVX (or armv8.2-a on arm64). Container exits immediately with `ERROR: your system does not support AVX`. |
+| **Workaround** | Pinned to `mbentley/omada-controller:5.15.24.19` — currently the latest v5.x release. v5.x uses the embedded MongoDB 3.6 which has no AVX requirement. The image is still being refreshed by upstream as of 2026-05-04. |
+| **Upstream** | <https://github.com/mbentley/docker-omada-controller/blob/master/README.md#your-system-does-not-support-avx-or-armv82-a> |
+| **Available v6 path (not chosen)** | Set `MONGO_EXTERNAL=true` + `EAP_MONGOD_URI=…` and run a separate non-AVX MongoDB container. Upstream documents this as the only AVX-free way onto v6. Rejected because the chosen MongoDB build would need to be a custom or non-default image (TP-Link officially specs MongoDB 8 for v6; older versions may lack required features), and the long-term plan is to move Omada off Luna entirely. |
+| **Planned resolution** | **Migrate Omada controller to forge** (Intel Xeon, has AVX). This unblocks the upstream-supported v6 path with no surgery. Tracked in [#434](https://github.com/carpenike/nix-config/issues/434). |
+| **Re-check trigger** | (a) Omada migrated to forge (then drop this entry entirely), (b) Luna replaced with AVX-capable hardware, (c) `mbentley` archives the v5 line (would force the migration). |
 
 ### NFS Media Mount - Soft Mount to Prevent System Freeze
 

--- a/modules/nixos/services/omada/default.nix
+++ b/modules/nixos/services/omada/default.nix
@@ -262,10 +262,16 @@ in
       };
 
       # Omada Controller with embedded MongoDB
-      # WORKAROUND (2026-03-10): Pinned to v5.x because luna's Celeron J3455 lacks AVX
+      # WORKAROUND (2026-03-10, last reviewed 2026-05-04): Pinned to v5.x because
+      # luna's Celeron J3455 lacks AVX. Omada v6.x bundles MongoDB 8 which requires
+      # AVX (or armv8.2-a on arm64). v5.15.24.19 is the latest of the v5 line and
+      # is still being refreshed by upstream.
       # Affects: Omada Controller on luna (any non-AVX host)
-      # Upstream: https://github.com/mbentley/docker-omada-controller/blob/master/KNOWN_ISSUES.md#your-system-does-not-support-avx-or-armv82-a
-      # Check: Re-evaluate if luna is replaced with AVX-capable hardware, or if upstream ships a MongoDB 7 option for v6+
+      # Upstream: https://github.com/mbentley/docker-omada-controller/blob/master/README.md#your-system-does-not-support-avx-or-armv82-a
+      # Planned resolution: migrate this controller to forge (Intel Xeon, has AVX),
+      # then bump to the v6 line. See docs/workarounds.md and #434 for details.
+      # Check: re-evaluate if luna is replaced, the controller is migrated to forge,
+      # or upstream archives the v5 line.
       virtualisation.oci-containers.containers.omada = podmanLib.mkContainer "omada" {
         image = "docker.io/mbentley/omada-controller:5.15.24.19@sha256:ec46fc504934ca7df10ce249a6a688281520f4d69febb512e551541629a9ef78";
         environment = {


### PR DESCRIPTION
Doc-only refresh of the Omada/AVX workaround entry, plus a tracked migration plan via #434. **No code or container behaviour changes** — the v5 image pin is unchanged.

## Trigger

Investigating whether a newer Omada Controller version supports luna's CPU yet. Confirmed against [upstream README](https://github.com/mbentley/docker-omada-controller/blob/master/README.md) and [Docker Hub tags](https://hub.docker.com/r/mbentley/omada-controller/tags) on 2026-05-04:

- Latest of the v5 line is **5.15.24.19** (already pinned).
- v6.x still requires AVX (or armv8.2-a on arm64); MongoDB 8 dependency is unchanged.
- mbentley is deprecating the `latest` tag and v5 is on a sunset path, but is still being actively refreshed (last image push: 1 day ago).
- Documented escape hatch for v6 on non-AVX hosts: `MONGO_EXTERNAL=true` + external MongoDB. Possible but messy on luna.

## Changes

| File | Change |
|---|---|
| [`docs/workarounds.md`](docs/workarounds.md) | Pin version corrected (`5.15.24.18` → `5.15.24.19` to match the actual image), embedded MongoDB version corrected (`7` → `3.6`, per the upstream v5→v6 upgrade README), upstream link updated (KNOWN_ISSUES.md was merged into README.md three months ago), added the rejected external-MongoDB escape hatch, recorded the chosen long-term resolution (migrate to forge), tightened re-check triggers, added `Last reviewed` field. Migration tracked in #434. |
| [`docs/container-image-management.md`](docs/container-image-management.md) | Stale `5.14` reference under 'Services with Pinned Versions' updated to the actual current pin `5.15.24.19` and cross-linked to the workaround entry. |
| [`modules/nixos/services/omada/default.nix`](modules/nixos/services/omada/default.nix) | Inline `WORKAROUND` comment block updated to match — README anchor instead of stale KNOWN_ISSUES file, notes the planned forge migration, links #434, adds `last reviewed` date. |

## Why a separate PR (not bundled with the migration)

The migration itself (#434) is a multi-step ops effort — provision on forge, take an Omada UI backup on luna, restore on forge, re-adopt devices, decommission luna's controller, then bump to v6 with the manual MongoDB 3.6→8 upgrade. Each step is its own PR + change window.

This PR is just the doc refresh that surfaced from today's investigation, so the workaround entry is accurate and links to the tracking issue.

## Verification

```
nix flake check --no-build  →  no new warnings, no errors
```

Renovate's existing `<6` `allowedVersions` pin in [`.github/renovate.json5`](.github/renovate.json5) is unchanged and still correct.