### PR TITLE
fix(ci): unblock Deploy Documentation and Flake Health workflows

### DIFF
--- a/.github/workflows/flake-health.yml
+++ b/.github/workflows/flake-health.yml
@@ -84,12 +84,31 @@ jobs:
             -w https://raw.githubusercontent.com/ckauhaus/nixos-vulnerability-roundup/master/whitelists/nixos-unstable.toml \
             ./profile | tee security.txt
 
+      # Snapshot of *what* was built so the artifact has debuggable provenance
+      # without uploading the full expanded closure (which can include filenames
+      # like `notify-pushover@system-boot:boot.path` that actions/upload-artifact
+      # rejects because `:` is illegal on NTFS).
+      - name: Generate closure manifest
+        if: always()
+        run: |
+          if [ -e ./profile ]; then
+            nix path-info -r ./profile > closure.txt
+            wc -l closure.txt
+          else
+            echo "profile/ does not exist (build failed); skipping manifest" > closure.txt
+          fi
+
       - name: Upload reports
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: flake-health-${{ matrix.host }}
+          # Intentionally NOT uploading `profile/` itself — it's a Nix profile
+          # symlink that dereferences to the entire expanded system (~70k
+          # files), which both blew the artifact size and tripped the NTFS
+          # filename validator on `:` in unit-name@instance:value paths.
+          # See `closure.txt` for the path manifest.
           path: |
             security.txt
-            profile
+            closure.txt
           if-no-files-found: ignore

--- a/docs/container-image-management.md
+++ b/docs/container-image-management.md
@@ -140,7 +140,7 @@ Create or update `renovate.json` in your repository root:
 ## Current Status
 
 ### Services with Pinned Versions ✅
-- **Omada Controller**: `mbentley/omada-controller:5.15.24.19` (pinned to v5.x — see [`workarounds.md`](workarounds.md#omada-controller---pinned-to-v5x-no-avx-on-luna))
+- **Omada Controller**: `mbentley/omada-controller:5.15.24.19` (pinned to v5.x — see [`workarounds.md`](workarounds.md#omada-controller-pinned-to-v5x-no-avx-on-luna))
 - **UniFi Controller**: `jacobalberty/unifi-docker:v8.4.62`
 - **1Password Connect API**: `1password/connect-api:1.7.2`
 - **1Password Connect Sync**: `1password/connect-sync:1.7.2`

--- a/docs/shared-config-library.md
+++ b/docs/shared-config-library.md
@@ -501,5 +501,5 @@ Category defaults are educated guesses, not guarantees:
 
 - [Modular Design Patterns](./modular-design-patterns.md) - Standardized submodule patterns
 - [Repository Architecture](./repository-architecture.md) - High-level structure
-- [host-defaults.nix](../lib/host-defaults.nix) - Host-specific factory
+- [`lib/host-defaults.nix`](https://github.com/carpenike/nix-config/blob/main/lib/host-defaults.nix) - Host-specific factory (source)
 - [Monitoring Strategy](./monitoring-strategy.md) - Metrics/alerting patterns


### PR DESCRIPTION
Two unrelated CI failures both surfaced in this morning's sweep. Bundled because both are small, isolated, and a single PR keeps the CI history readable.

## 1. Deploy Documentation (mkdocs --strict)

Two issues in the docs tree caused the strict build to abort:

**a. [`docs/shared-config-library.md`](docs/shared-config-library.md)** linked to `../lib/host-defaults.nix` which is outside the `docs/` tree, so mkdocs flagged it as a broken internal link. Switched to an absolute `github.com` URL pointing at the source file. The file is in a stable location on `main` and the link is for human readers, not docs cross-references.

> Note: this is the **long-standing blocker** — Deploy Documentation has been failing on **every run for months** (last 16 consecutive failures). Nobody noticed because the docs site isn't on the critical path.

**b. [`docs/container-image-management.md`](docs/container-image-management.md)** linked to `workarounds.md#omada-controller---pinned-to-v5x-no-avx-on-luna` using the GitHub-style triple-hyphen anchor slug. mkdocs's default `toc` plugin slugifies `- ` (hyphen + space) to a single `-`, not `---`, so the anchor didn't resolve. Switched to the mkdocs slug `#omada-controller-pinned-to-v5x-no-avx-on-luna`. Introduced in PR #435 yesterday.

**Verified** locally with the exact CI command:
```
mkdocs build --strict  →  exit 0, only INFO messages remain
```

## 2. Flake Health (forge closure upload)

The `forge closure` job has been failing daily because the artifact upload step rejects the path:
`/profile/etc/systemd/system/multi-user.target.wants/notify-pushover@system-boot:boot.path`

The colon is illegal on NTFS, so `actions/upload-artifact@v4+` refuses to ship it.

**Root issue:** the workflow uploaded the entire `./profile` symlink, which dereferences to the whole expanded system closure (~70,000 files). That was both wasteful (the closure already lives in cachix and the local nix store) and fragile (any systemd unit instance with `:` in the name breaks the upload).

**Fix:** replaced `profile` with a small text manifest from `nix path-info -r ./profile` written to `closure.txt`. Same provenance value — humans can see what was built — without uploading 70k files of expanded systemd unit drop-ins.

Diff for the workflow:
```diff
+      - name: Generate closure manifest
+        if: always()
+        run: |
+          if [ -e ./profile ]; then
+            nix path-info -r ./profile > closure.txt
+            wc -l closure.txt
+          else
+            echo "profile/ does not exist (build failed); skipping manifest" > closure.txt
+          fi
+
       - name: Upload reports
         ...
           path: |
             security.txt
-            profile
+            closure.txt
```

## Verification

```
mkdocs build --strict     →  exit 0
yamllint flake-health.yml →  passes (with repo config)
nix flake check --no-build → no warnings, no errors
```