### PR TITLE
fix(autobrr): add extraHosts to escape hairpin-NAT for OIDC discovery

### DIFF
--- a/hosts/forge/services/autobrr.nix
+++ b/hosts/forge/services/autobrr.nix
@@ -8,6 +8,7 @@
 let
   forgeDefaults = import ../lib/defaults.nix { inherit config lib; };
   serviceEnabled = config.modules.services.autobrr.enable or false;
+  inherit (config.networking) domain;
 in
 {
   config = lib.mkMerge [
@@ -16,6 +17,15 @@ in
         enable = true;
         podmanNetwork = forgeDefaults.podmanNetwork;
         healthcheck.enable = true;
+
+        # Hairpin-NAT workaround: id.holthome.net resolves to forge's LAN IP
+        # (10.20.0.30), but autobrr's podman bridge can't reach the LAN — so
+        # OIDC discovery (https://id.holthome.net/.well-known/openid-configuration)
+        # times out from inside the container. Override the hosts file to point
+        # at the podman bridge IP where Caddy also listens. Same pattern as qui.
+        extraHosts = {
+          "id.${domain}" = "10.89.0.1";
+        };
 
         settings = {
           host = "0.0.0.0";

--- a/modules/nixos/services/autobrr/default.nix
+++ b/modules/nixos/services/autobrr/default.nix
@@ -65,6 +65,13 @@ mylib.mkContainerService {
     # Health check endpoint
     healthEndpoint = "/api/healthz/liveness";
 
+    # Extra podman flags. Currently used to inject `--add-host` entries from
+    # cfg.extraHosts so the container can override DNS for hosts that aren't
+    # routable via its podman bridge (hairpin-NAT workaround for OIDC).
+    extraOptions = { cfg, config, ... }:
+      lib.optionals (cfg.extraHosts != { })
+        (lib.mapAttrsToList (host: ip: "--add-host=${host}:${ip}") cfg.extraHosts);
+
     # Default resources (based on observed usage: 26M peak × 2.5 = 65M)
     resources = {
       memory = "128M";
@@ -214,6 +221,26 @@ mylib.mkContainerService {
         };
       };
       description = "Prometheus metrics collection configuration for Autobrr";
+    };
+
+    # Hairpin-NAT escape hatch. When the container needs to reach a host-side
+    # service that resolves to the LAN IP (e.g. https://id.holthome.net for
+    # OIDC discovery), routing back via the LAN address typically fails because
+    # the podman bridge gateway is not the default LAN router. Map the FQDN to
+    # the host's podman bridge IP (e.g. 10.89.0.1) so the container reaches
+    # Caddy directly. Mirrors the option in modules/nixos/services/qui.
+    extraHosts = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      example = { "id.holthome.net" = "10.89.0.1"; };
+      description = ''
+        Extra /etc/hosts entries to inject into the container (rendered as
+        `--add-host=<host>:<ip>` podman flags).
+
+        Useful for overriding DNS resolution when the container needs to
+        reach a host-side service whose A record points at the LAN IP but
+        is only reachable from the container via the podman bridge gateway.
+      '';
     };
   };
 


### PR DESCRIPTION
## Problem

The autobrr web UI was returning login errors with the backend logging:

```
GET https://autobrr.holthome.net/api/auth/oidc/config  500 (Internal Server Error)
GET https://autobrr.holthome.net/api/auth/onboard      503 (Service Unavailable)
```

Backend can't fetch the OIDC discovery doc → no OIDC config → onboarding refuses → UI dead-ends.

## Root cause: container-side hairpin NAT

```
$ sudo podman exec autobrr nslookup id.holthome.net
id.holthome.net canonical name = forge.holthome.net.
Address: 10.20.0.30                                   ← forge's LAN IP

$ sudo podman exec autobrr ip route
default via 10.89.1.1 dev eth0                        ← podman bridge gateway

$ sudo podman exec autobrr wget https://id.holthome.net/.well-known/openid-configuration
wget: download timed out
```

DNS works. Routing doesn't. Autobrr's container is on `media-services` (gw `10.89.1.1`), not the LAN. Packets leave the bridge addressed to `10.20.0.30`, but reverse-path validation (or just the LAN router not knowing how to send traffic back into the podman subnet) drops the response.

Pocket-id itself is fine — it's been serving 200 OKs to other Caddy-mediated clients (Gatus, paperless-ai, oncall) for days.

## Fix

Mirror the workaround [`modules/nixos/services/qui`](modules/nixos/services/qui/default.nix) already uses for the **same problem on the same network**:

1. Add `extraHosts` (`attrsOf str`) to the autobrr module
2. Wire it through the factory's `spec.extraOptions` so it renders as `--add-host=<host>:<ip>` podman flags
3. Set `extraHosts."id.${domain}" = "10.89.0.1"` in the host file

`10.89.0.1` is the `podman1` bridge IP where Caddy also binds (forge runs Caddy on `10.20.0.30:443`, `10.89.0.1:443`, and `127.0.0.1:443`). The host kernel routes between podman bridges, so traffic from `media-services` reaches Caddy directly without going via the LAN.

## Verification

```
nix flake check --no-build  →  no errors, no warnings

nix eval -- container.autobrr.extraOptions  contains:
  --network=media-services
  --add-host=id.holthome.net:10.89.0.1   ← new
  --memory=128M
  ...
```

After deploy, the local probe should succeed:
```
sudo podman exec autobrr wget -qO- https://id.holthome.net/.well-known/openid-configuration
```

## Out of scope

- Other forge OIDC clients (sonarr/radarr/qbit-manage/etc.) don't currently use OIDC, but if they ever do they can adopt this same option.
- Lifting `extraHosts` into the service-factory itself was considered. Deferred — only 2 services need it right now and qui's pattern proves the per-module approach works.
