### PR TITLE
fix(home-assistant): unblock 2026.4 fallout + wire gh PAT for ryan

### DIFF
--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -2,8 +2,8 @@
 
 This document tracks temporary workarounds, package overrides, and unstable package usage that should be periodically reviewed. These exist due to upstream bugs, missing features in stable, or test failures in the Nix build sandbox.
 
-**Last Reviewed**: 2026-04-28
-**Next Review**: 2026-05-28 (monthly)
+**Last Reviewed**: 2026-05-07
+**Next Review**: 2026-06-07 (monthly)
 
 ---
 
@@ -18,6 +18,30 @@ When reviewing workarounds:
 ---
 
 ## Package Overrides (overlays/default.nix)
+
+### homekit-audio-proxy - Custom Package (not yet in nixpkgs)
+
+| Field | Value |
+|-------|-------|
+| **Added** | 2026-05-07 |
+| **Affects** | `pythonPackagesExtensions` (unstable overlay) |
+| **Reason** | Home Assistant 2026.4's `homekit` integration unconditionally `from homekit_audio_proxy import AudioProxy` at module top of `homeassistant/components/homekit/type_cameras.py`. The HASS Bridge (port 21064) — i.e. all Apple Home exposure — fails to load without it. The package is on PyPI (v1.2.1, Apache-2.0, runtime dep `cryptography>=43`) but had not landed in nixos-unstable as of this date. |
+| **Workaround** | Custom `buildPythonPackage` definition in the unstable overlay (mirrors the `thermoworks-cloud` pattern), wired into HA via `services.home-assistant.extraPackages`. |
+| **Check** | When `homekit-audio-proxy` lands in nixpkgs |
+| **Upstream** | https://github.com/bdraco/homekit-audio-proxy |
+| **Impact** | Without fix: HomeKit Bridge fails to start; no Apple Home device exposure works. |
+
+### aioacaia - Custom Package (not yet in nixpkgs)
+
+| Field | Value |
+|-------|-------|
+| **Added** | 2026-05-07 |
+| **Affects** | `pythonPackagesExtensions` (unstable overlay) |
+| **Reason** | Home Assistant's built-in `acaia` integration imports `aioacaia` at config-flow time. Without it, opening the Acaia config flow raises ModuleNotFoundError. PyPI v0.1.18 (AGPL-3.0). |
+| **Workaround** | Custom `buildPythonPackage` definition in the unstable overlay, wired into HA via `services.home-assistant.extraPackages`. Runtime deps: `bleak`, `bleak-retry-connector`. |
+| **Check** | When `aioacaia` lands in nixpkgs |
+| **Upstream** | https://github.com/zweckj/aioacaia |
+| **Impact** | Without fix: the Acaia integration can't be configured; runtime use blocked. |
 
 ### aiounittest - Re-enabled on Python 3.14
 

--- a/home/_modules/shell/bash/default.nix
+++ b/home/_modules/shell/bash/default.nix
@@ -37,6 +37,14 @@ in
         if [[ -r "/run/secrets/home-assistant/bearer-token" ]]; then
           export HA_BEARER_TOKEN="$(cat /run/secrets/home-assistant/bearer-token)"
         fi
+
+        # Load GitHub personal access token for the gh CLI.
+        # gh reads $GH_TOKEN natively and prefers it over its own config file,
+        # so this avoids the read-only home-manager hosts.yml problem entirely.
+        # Token is managed via SOPS and only readable by the owning user.
+        if [[ -r "/run/secrets/users/ryan/github-token" ]]; then
+          export GH_TOKEN="$(cat /run/secrets/users/ryan/github-token)"
+        fi
       '' + lib.optionalString cfg.launchFishForInteractive ''
         # Launch fish for interactive sessions, but not for VS Code terminals
         # or other non-interactive contexts that need POSIX shell compatibility

--- a/hosts/forge/secrets.nix
+++ b/hosts/forge/secrets.nix
@@ -856,6 +856,18 @@ in
             owner = "root";
             group = "root";
           };
+        }
+        // {
+          # Per-user secrets (always present, not gated on a service flag)
+          # GitHub personal access token for ryan's interactive shell.
+          # Read at login by home/_modules/shell/bash/default.nix and exported
+          # as GH_TOKEN, which the `gh` CLI consumes natively (no `gh auth
+          # login` required, and no oauth_token written to managed config).
+          "users/ryan/github-token" = {
+            mode = "0400";
+            owner = "ryan";
+            group = "users";
+          };
         };
 
       # Templates for generating .env files for containers.

--- a/hosts/forge/secrets.sops.yaml
+++ b/hosts/forge/secrets.sops.yaml
@@ -184,6 +184,9 @@ tududi:
     session_secret: ENC[AES256_GCM,data:EmeqMM6qRog1jtXjpSlyrYuez8zz6cGJtSn/W6/5yJ/ke3sqjotKYTz4+ahb+A2Kg/LHKMWzBM8cWxwjMeF+1ZcMMYeL0aJPsMYA3cetg3ILy9fUDK66j/HCFA0EDtnWRYebbFubqJSC2DcRK5cQc/YVusmOU8/GXz6iVHAmY3c=,iv:UvaQrWo2b4KLe9ClxQRRmmCBMsDGaBF1ATH94kIzMHE=,tag:nx10xTqlwWCiWQNfskWRjQ==,type:str]
 worldmonitor:
     env: ENC[AES256_GCM,data:iVhpHzmcMBitz7x+7FIaq+5O6gWxKE6hfAnqZhmsMqUr4Hym3K3jkSvkKMYDx4fbZHO4JHy9hokPnThRmc1ug234B5HHJH00z50Pu17FJhsZbHlbhhBULPVwbHrG4Z0ZI7NimrxUe7IwhZV0JLZDfV1sNGUf2ErhZASkPUsg92mXZosJtAiTUGCjF4Wa4yc8g8V7/NWHp+zz7U6cDxLAR2bJwoXLwIe0MBavDwTyyI3BsJJh3ff7ogPOESPYroVH9m4VuPu4Qmu8Sd6g/P3aiA==,iv:sIztB3+/149quwpBpnyq4dT2k8GjZ1+bMRZBaliDtlc=,tag:7FFQE4+krBole91e7+2/QA==,type:str]
+users:
+    ryan:
+        github-token: ENC[AES256_GCM,data:kZEtbbkp/L90xmgDr6cfwU5VxN4oSWGnfSdt6BLGdmmRNn5E2vfdGZ5KJbv7e17FZtLVcdHHLUH8T9Xv926N+Zv0Ptl98YuCWSn3Q81/gbYKhr/aKg0BHUaixXib,iv:w7BeU8Ums2zgxCyFB+NARLNeG8P+dOwz+WCaQ+60r1o=,tag:FXxZ14MHXMdg/3CXECT50A==,type:str]
 sops:
     age:
         - recipient: age1m6xc7mn9wdpla4yhfu7aupr4pkqv5mwgmrsnydssu8kd3ks6e40s5d6qpq
@@ -222,8 +225,8 @@ sops:
             YTR3bWdHNDZlaW1tTC9SV2dZQk9URUUKvWH9XLMocdcVv+tMQHirXdLHj8k0l+Dd
             p625irbx1i5WSLYj/LgZXJwssTrYXV9YY0jn/tALyYMoGXZo1ZyFCw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-02T15:23:57Z"
-    mac: ENC[AES256_GCM,data:GG5RyDCqZKoL6tTbCbAYpbdUXKX6zyeXCSxwrlvQxTvMuSX75CdmxggytEI13+31HVcKxbH0q6CYn7erUkYUwen110CzLaoRb9/VckM/Gqu7WhWfogBKwsl+VaSnotCBnJ6FDygxs+vkTE1fQTJsk/eLsfBUsS22GQtIy0+16mg=,iv:ZGFHH+dVLa0/5TMGjYRVe9onpCPUXjCM8PxVlmyAA90=,tag:I6elfT1j8rV/ublIybQC6Q==,type:str]
+    lastmodified: "2026-05-07T13:14:24Z"
+    mac: ENC[AES256_GCM,data:7A0jpKcw4P47YEEPmzFXmxPV53P3wrFMMdY9Cc9pVOouIjZFn1ASaHXpUQgr7915zO5ybHd9RCjGFsNfO+s0A5zcG5JyQ29vEAfn4vWal6lDZhGx+x4J++sGTGfyguiAj+WU0blcbCImedNyGMC4eNr0USFTr29PHjqJzfdjKFI=,iv:sU6yC7UQf4okjfW/2ygPk5Lw9HwDYpmgR3bLVaOvGmk=,tag:6ILhZe3+JEWTTZf3TmCn+Q==,type:str]
     pgp:
         - created_at: "2025-11-03T23:54:53Z"
           enc: |-
@@ -246,4 +249,4 @@ sops:
             -----END PGP MESSAGE-----
           fp: DA8002060402EC39B195451D5CED80362B5A4EF2
     unencrypted_suffix: _unencrypted
-    version: 3.11.0
+    version: 3.12.1

--- a/hosts/forge/services/home-assistant.nix
+++ b/hosts/forge/services/home-assistant.nix
@@ -140,6 +140,16 @@ in
             logs = {
               "homeassistant.components.http" = "warning";
               "homeassistant.components.recorder" = "warning";
+
+              # Suppress benign upstream noise (verified 2026-05-07):
+              # - rest.util emits a WARNING any time a REST sensor's response
+              #   isn't valid JSON, even when the sensor is configured for
+              #   text/xml. Real REST failures still surface at ERROR.
+              # - llmvision's NWS Alerts coordinator logs an ERROR for every
+              #   benign upstream timeout/cache miss. The integration retries
+              #   automatically; only persistent failures matter.
+              "homeassistant.components.rest.util" = "error";
+              "custom_components.nws_alerts.coordinator" = "error";
             };
           };
           recorder = {
@@ -190,6 +200,16 @@ in
             hap-python
             pychromecast
             base36
+            # HA 2026.4+ unconditionally imports homekit_audio_proxy from
+            # homekit/type_cameras.py at module top. Without this the entire
+            # HomeKit Bridge fails to load. Custom package (overlays/default.nix)
+            # until upstream nixpkgs ships it.
+            homekit-audio-proxy
+
+            # Acaia smart scale integration (built-in `acaia` component).
+            # Custom package (overlays/default.nix) until upstream nixpkgs
+            # ships aioacaia.
+            aioacaia
 
             aiodiscover
             aiodhcpwatcher

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -82,6 +82,70 @@
                 };
               };
 
+              # CUSTOM PACKAGE (2026-05-07): homekit-audio-proxy
+              # SRTP audio proxy for HomeKit camera streaming. Required runtime
+              # dep of Home Assistant 2026.4's homekit integration
+              # (homeassistant/components/homekit/type_cameras.py imports it at
+              # module top, so the entire HASS Bridge fails to start without it).
+              # Required by: home-assistant homekit integration (Apple Home bridge)
+              # Upstream: https://github.com/bdraco/homekit-audio-proxy
+              # Check: When homekit-audio-proxy lands in nixpkgs
+              homekit-audio-proxy = pyFinal.buildPythonPackage rec {
+                pname = "homekit-audio-proxy";
+                version = "1.2.1";
+                pyproject = true;
+
+                src = pyFinal.fetchPypi {
+                  pname = "homekit_audio_proxy";
+                  inherit version;
+                  hash = "sha256-nGX1f8xOLFnxF7uk2sMyYPRdFdfKJuohWANb0UT9VJU=";
+                };
+
+                build-system = [ pyFinal.setuptools ];
+                dependencies = [ pyFinal.cryptography ];
+                doCheck = false;
+                pythonImportsCheck = [ "homekit_audio_proxy" ];
+
+                meta = with prev.lib; {
+                  description = "SRTP audio proxy for HomeKit camera streaming";
+                  homepage = "https://github.com/bdraco/homekit-audio-proxy";
+                  license = licenses.asl20;
+                };
+              };
+
+              # CUSTOM PACKAGE (2026-05-07): aioacaia
+              # Async Bluetooth client for Acaia coffee scales. Required by
+              # Home Assistant's built-in `acaia` integration; without it the
+              # integration raises ModuleNotFoundError when its config flow
+              # is opened.
+              # Required by: home-assistant acaia integration
+              # Upstream: https://github.com/zweckj/aioacaia
+              # Check: When aioacaia lands in nixpkgs
+              aioacaia = pyFinal.buildPythonPackage rec {
+                pname = "aioacaia";
+                version = "0.1.18";
+                pyproject = true;
+
+                src = pyFinal.fetchPypi {
+                  inherit pname version;
+                  hash = "sha256-KjCBDA+jScqMw9artTcykKxsGkRtOtkvOnist0dvsqc=";
+                };
+
+                build-system = [ pyFinal.setuptools ];
+                dependencies = [
+                  pyFinal.bleak
+                  pyFinal.bleak-retry-connector
+                ];
+                doCheck = false;
+                pythonImportsCheck = [ "aioacaia" ];
+
+                meta = with prev.lib; {
+                  description = "Async implementation of pyacaia for Acaia smart scales";
+                  homepage = "https://github.com/zweckj/aioacaia";
+                  license = licenses.agpl3Only;
+                };
+              };
+
               # WORKAROUND (2025-12-19): aio-georss-client test failure with Python 3.13
               # Tests fail in test_feed.py due to Python 3.13 compatibility issues
               # Check: When aio-georss-client is updated or Python 3.14 releases


### PR DESCRIPTION
## Summary

Fixes Home Assistant 2026.4 fallout on `forge` and gives `ryan` a usable `gh` CLI on the same host. All discovery, planning, and quick-eval was done via the `nix-config` agent workflow; the change set was confined to what cannot be fixed from inside the `hass-config` repo.

## Changes

| # | Item | Files |
|---|------|-------|
| 1 | Add `homekit-audio-proxy` 1.2.1 (Apache-2.0) — required runtime dep of HA 2026.4's `homekit` integration; without it the entire HASS Bridge (port 21064 / Apple Home) fails to load. | `overlays/default.nix`, `hosts/forge/services/home-assistant.nix` |
| 2 | Add `aioacaia` 0.1.18 (AGPL-3.0) — required by HA's built-in `acaia` integration (Acaia smart scales). | `overlays/default.nix`, `hosts/forge/services/home-assistant.nix` |
| 3 | Add two `logger.logs` overrides to silence confirmed-benign upstream noise: `homeassistant.components.rest.util` and `custom_components.nws_alerts.coordinator`. | `hosts/forge/services/home-assistant.nix` |
| 4 | Declare new sops secret `users/ryan/github-token` (mode 0400, owner `ryan:users`) and export it as `GH_TOKEN` from ryan's bash init. The `gh` CLI consumes `GH_TOKEN` natively, side-stepping the read-only `/nix/store/.../gh/config.yml` that broke `gh auth login`. | `hosts/forge/secrets.{nix,sops.yaml}`, `home/_modules/shell/bash/default.nix` |
| 5 | Document both new packages in the workarounds tracker. | `docs/workarounds.md` |

## Implementation notes

- Both new Python packages follow the existing `thermoworks-cloud` pattern in `overlays/default.nix` (inline `buildPythonPackage` in the unstable `pythonPackagesExtensions`). They will be removed once they land in nixpkgs.
- The new sops secret was placed inside the `secrets =` block (not the separate `templates =` block). Verified via flake eval that `cfg.sops.secrets."users/ryan/github-token"` resolves with the correct path/owner/mode.
- `programs.gh.enable = true` in `home/_modules/shell/git/default.nix` is preserved. No `programs.gh.settings` is declared, so there's no conflict with gh's runtime state — the env var path bypasses the managed `hosts.yml` entirely and no `oauth_token` is ever written there.
- The two suppressed log lines were verified by the user to be benign upstream noise; real REST and llmvision/NWS errors still surface at ERROR/CRITICAL.

## Validation

- `nixpkgs-fmt`, `statix`, `deadnix`, `yamllint`, `gitleaks`, `end-of-file-fixer`, `trim-trailing-whitespace` — all green via pre-commit hooks.
- `nix eval` of both new packages through the unstable overlay returns the expected versions.
- Full `nixosConfigurations.forge.config.system.build.toplevel.drvPath` evaluates without error.
- Sops secret resolves to `/run/secrets/users/ryan/github-token` (`ryan:users` `0400`).

## Out of scope (handled by user separately)

- LLM Vision Anthropic provider (`claude-3-7-sonnet-latest` → newer model) — UI-side fix in HA.
- HACS-installed `thermal_comfort 0.0.0` — broken HACS install, reinstall via HACS UI.
- Cleanup of permanently-unavailable entities from `core.entity_registry` — UI-side cleanup.
- ESPHome physical issues (`upstairs-caydan-heater-switch` offline, `upstairs-caydan-switch-lights` low RSSI) — network/placement, not nix.

## Post-deploy verification

```bash
# On forge, as ryan, in a fresh shell:
test -r /run/secrets/users/ryan/github-token && echo "secret OK"
echo "GH_TOKEN=${GH_TOKEN:+<set>}"
gh auth status
gh api user --jq .login

# Confirm the HASS Bridge starts cleanly:
journalctl -u home-assistant -b | grep -iE "homekit|audio_proxy" | tail -20

# Confirm the silenced log lines are gone:
sudo grep -E "rest\.util|nws_alerts\.coordinator" /var/lib/home-assistant/home-assistant.log | tail -5
```
