### PR TITLE
fix(forge/backup): raise restic MemoryMax default to 2G to stop OOM kills

### DIFF
--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -260,6 +260,17 @@ Services using `pkgs.unstable.*` instead of stable packages:
 | **Check** | If NFS reliability becomes an issue (data corruption from partial writes), consider switching back to `hard` with `timeo=300` and adding a systemd watchdog. |
 | **Tradeoff** | `soft` mount risks returning EIO on transient network issues, which could cause media service errors. This is far safer than `hard`-mount freezes that require physical intervention. |
 
+### Restic Backup Memory Limit Raised to 2G on Forge
+
+| Field | Value |
+|-------|-------|
+| **Added** | 2026-05-07 |
+| **Location** | `hosts/forge/infrastructure/backup.nix` (`modules.services.backup.performance.resources`) |
+| **Reason** | The module-default 512 MiB `MemoryMax` for auto-discovered restic backup jobs (`modules/nixos/services/backup/default.nix`) was too low for forge: services with thousands of snapshots (paperless / home-assistant: 1545 each) consistently hit the cgroup limit at ~511 MB RSS just loading the restic index. On 2026-05-07, six services (`paperless`, `worldmonitor`, `zigbee2mqtt`, `home-assistant`, `esphome`, `pinchflat`) were OOM-killed and never recovered, triggering `ResticBackupStale` alerts. Smaller-repo services hit the limit too but recovered on retry. |
+| **Workaround** | Set host-level defaults `performance.resources = { memory = "2G"; memoryReservation = "1G"; cpus = "1.5"; }`. Per-service overrides (scrypted, plex) still win because the orchestrator falls back to `performance.resources` only when `service.backup.resources` is null. |
+| **Check** | When restic itself ships meaningful index-memory improvements (tracking issue: <https://github.com/restic/restic/issues/2523>) or if forge moves to a smaller-RAM host. |
+| **Related** | Same OOM pattern previously addressed per-service for scrypted (2026-02-21) and plex; this generalises the fix to the host default so future services benefit automatically. |
+
 ---
 
 ## Custom Packages with doCheck=false

--- a/hosts/forge/infrastructure/backup.nix
+++ b/hosts/forge/infrastructure/backup.nix
@@ -99,6 +99,24 @@ in
         monitoring.enable = true;
         verification.enable = true;
 
+        # Host-level resource defaults for auto-discovered service backup jobs.
+        # The module default of 512M MemoryMax has caused repeated OOM kills on
+        # forge as restic repositories grow (paperless/home-assistant hit ~511MB
+        # RSS just loading the index — at 1545+ snapshots this is unavoidable).
+        # Forge has 31 GiB RAM with backup jobs staggered across the night, so
+        # raising the floor to 2G/1G is essentially free.
+        #
+        # Per-service overrides (scrypted, plex) still win because they set
+        # `service.backup.resources` explicitly — see the fallback logic in
+        # modules/nixos/services/backup/default.nix.
+        #
+        # WORKAROUND (2026-05-07): tracked in docs/workarounds.md.
+        performance.resources = {
+          memory = "2G";
+          memoryReservation = "1G";
+          cpus = "1.5";
+        };
+
         # PostgreSQL backup (pgBackRest with dual-repo PITR)
         # Restic meta-backup DISABLED - redundant now that repo2 has WAL archiving
         # Both repo1 (NFS) and repo2 (R2) now support full Point-in-Time Recovery


### PR DESCRIPTION
## Symptom

Six \`ResticBackupStale\` (HIGH severity) Prometheus alerts have been firing on forge since 2026-05-06:

- \`service-paperless\`
- \`service-worldmonitor\`
- \`service-zigbee2mqtt\`
- \`service-home-assistant\`
- \`service-esphome\`
- \`service-pinchflat\`

## Root cause

The cgroup \`MemoryMax\` for restic backup units is the module default of **512 MiB** (\`modules/nixos/services/backup/default.nix\` ⇒ \`performance.resources.memory = \"512M\"\`). The six services above have repos with **1545+ snapshots** — restic's in-memory index alone exceeds 512 MiB on load. Today's cgroup OOM logs name them explicitly:

\`\`\`
oom-kill: oom_memcg=/restic.slice/restic-backups.slice/restic-backup-service-paperless.service
Memory cgroup out of memory: Killed process 3427031 (.restic-wrapped)
total-vm:2620468kB, anon-rss:521512kB
\`\`\`

The OOM kill happened during the prepare-data step, **before** the .prom metric file was written, so the timestamp metric stayed at 2026-05-06 even though the systemd unit's \`Result=success\` masked it (a subsequent retry started but also OOM'd). Smaller-repo services (\`cooklang\`: 192 snapshots) hit the same limit but recovered after one restart.

## Fix

Set host-level defaults in [\`hosts/forge/infrastructure/backup.nix\`](hosts/forge/infrastructure/backup.nix):

\`\`\`nix
modules.services.backup.performance.resources = {
  memory = \"2G\";
  memoryReservation = \"1G\";
  cpus = \"1.5\";
};
\`\`\`

The orchestrator falls back to \`performance.resources\` only when \`service.backup.resources\` is null, so existing per-service overrides (\`scrypted\` 2G/1G/2.0, \`plex\`) are preserved. \`forge\` has 31 GiB RAM with backup jobs staggered across the night, so raising the floor is essentially free.

## Verification

\`\`\`bash
nix fmt -- --check .                       # 0 / 392 reformatted
nix flake check --no-build                 # all 8 hosts evaluate clean
nix eval --json ...service-paperless.resources
  → {\"cpus\":\"1.5\",\"memory\":\"2G\",\"memoryReservation\":\"1G\"}
nix eval --json ...service-scrypted.resources
  → {\"cpus\":\"2.0\",\"memory\":\"2G\",\"memoryReservation\":\"1G\"}  # per-svc override preserved
\`\`\`

After deploy, the next nightly backup cycle (00:00–02:30 EDT) will run inside the new cgroup limits and write fresh metric files; the alerts will clear automatically.

## Same pattern, prior precedents

This is the third occurrence of the same OOM pattern; the previous two were patched per-service and the explanatory comments are still in the tree:

- [hosts/forge/services/scrypted.nix#L64](hosts/forge/services/scrypted.nix#L64) — 'restic-backup-service-scrypted killed at ~498MB RSS on 2026-02-21'
- [hosts/forge/services/plex.nix#L73](hosts/forge/services/plex.nix#L73) — 'restic-backup-service-plex killed at ~467MB RSS on 2026-02-21'

This PR generalises the fix so future services don't have to discover the limit by hitting it. Tracked in [docs/workarounds.md](docs/workarounds.md).

## Out of scope (mentioned for follow-up)

While investigating I noticed forge's swap is essentially exhausted (\`7.7 GiB / 7.8 GiB used\`). That's a separate memory-pressure concern worth its own dive, not blocking this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)