### PR TITLE
fix(forge/pgbackrest): auto-retry transient NFS coherency errors

### DIFF
--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -271,6 +271,17 @@ Services using `pkgs.unstable.*` instead of stable packages:
 | **Check** | When restic itself ships meaningful index-memory improvements (tracking issue: <https://github.com/restic/restic/issues/2523>) or if forge moves to a smaller-RAM host. |
 | **Related** | Same OOM pattern previously addressed per-service for scrypted (2026-02-21) and plex; this generalises the fix to the host default so future services benefit automatically. |
 
+### pgBackRest Auto-Retry on Transient NFS Errors
+
+| Field | Value |
+|-------|-------|
+| **Added** | 2026-05-08 |
+| **Location** | `hosts/forge/services/pgbackrest.nix` (`retryPolicy` applied to all 3 backup units) |
+| **Reason** | pgBackRest backup units occasionally fail with NFS-coherency errors against `/mnt/nas-postgresql`: `[073] unable to sync missing path '.../pg_dynshmem'` and `[061] unable to remove path '.../base/<oid>': Directory not empty`. These are intermittent (~once per week, 22 lifetime [073] events in the file log going back to Dec 2025). Without `Restart=`, a single transient failure took out the entire daily full backup until 02:00 the next night, triggering `PgBackRestFullBackupStale` alerts. |
+| **Workaround** | Set `Restart=on-failure`, `RestartSec=15min`, `StartLimitBurst=3`, `StartLimitIntervalSec=2h` on `pgbackrest-full-backup`, `pgbackrest-incr-backup`, `pgbackrest-incr-r2-backup`. The 15-minute backoff is long enough for transient NFS issues to clear; the burst cap surfaces sustained failures via `OnFailure=` notifications and `PgBackRestFullBackupStale` rather than looping forever. |
+| **Check** | If errors persist after this is deployed, consider enabling pgBackRest file bundling (`--bundle=y` / `repo1-bundle=y`) to reduce per-backup file count by 10-100×, which directly attacks the NFS-many-small-files surface. Bundling is a one-time per-stanza decision and doesn't break existing backups. |
+| **Related** | An earlier related workaround (`EXCLUDE_OPTS="--exclude=.config --exclude=.local"`, 2026-02-02) addressed a different `[073]` instance where `.config`/`.local` dirs polluted PGDATA. Today's `pg_dynshmem` failure is a normal PG directory and can't be excluded that way. |
+
 ---
 
 ## Custom Packages with doCheck=false

--- a/hosts/forge/services/pgbackrest.nix
+++ b/hosts/forge/services/pgbackrest.nix
@@ -20,6 +20,34 @@ let
     RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ];
     MemoryDenyWriteExecute = true;
   };
+
+  # Restart policy for pgBackRest backup units.
+  #
+  # WORKAROUND (2026-05-08): pgBackRest occasionally hits transient NFS
+  # write/sync coherency errors against /mnt/nas-postgresql, observed as:
+  #   ERROR [073]: unable to sync missing path '.../pg_dynshmem'
+  #   ERROR [061]: unable to remove path '.../base/<oid>': Directory not empty
+  # These are intermittent (~once a week per pgBackRest's main-backup.log,
+  # 22 lifetime [073] occurrences). Without a restart policy, a single failure
+  # wipes out the entire daily full backup until 02:00 the next night, which
+  # was triggering PgBackRestFullBackupStale alerts.
+  #
+  # Settings rationale:
+  #   Restart=on-failure   - retry on any non-zero exit (NFS error class)
+  #   RestartSec=15min     - long enough for transient NFS issues to clear,
+  #                          short enough to recover within the same backup window
+  #   StartLimitBurst=3    - cap retries to 3 per StartLimitIntervalSec window
+  #   StartLimitIntervalSec=2h - if 3 retries fail in 2h, surface the failure
+  #                              instead of looping forever (the OnFailure
+  #                              alerts and PgBackRestFullBackupStale will fire)
+  #
+  # Tracked in docs/workarounds.md.
+  retryPolicy = {
+    Restart = "on-failure";
+    RestartSec = "15min";
+    StartLimitBurst = 3;
+    StartLimitIntervalSec = "2h";
+  };
 in
 {
   # pgBackRest - PostgreSQL Backup & Recovery
@@ -539,12 +567,19 @@ in
         RequiresMountsFor = [ "/mnt/nas-postgresql" ];
         # Trigger metrics collection on success to immediately update Prometheus
         OnSuccess = "pgbackrest-metrics.service";
+        # Bound the auto-retries so a sustained outage surfaces as an alert
+        # instead of looping forever (see retryPolicy comment above).
+        StartLimitBurst = retryPolicy.StartLimitBurst;
+        StartLimitIntervalSec = retryPolicy.StartLimitIntervalSec;
       };
       serviceConfig = hardenedServiceConfig // {
         Type = "oneshot";
         User = "postgres";
         Group = "postgres";
         IPAddressDeny = [ "169.254.169.254" ];
+        # Self-heal transient NFS coherency errors (see retryPolicy comment above).
+        Restart = retryPolicy.Restart;
+        RestartSec = retryPolicy.RestartSec;
       };
       script = ''
         set -euo pipefail
@@ -577,12 +612,19 @@ in
         RequiresMountsFor = [ "/mnt/nas-postgresql" ];
         # Trigger metrics collection on success to immediately update Prometheus
         OnSuccess = "pgbackrest-metrics.service";
+        # Bound the auto-retries so a sustained outage surfaces as an alert
+        # instead of looping forever (see retryPolicy comment above).
+        StartLimitBurst = retryPolicy.StartLimitBurst;
+        StartLimitIntervalSec = retryPolicy.StartLimitIntervalSec;
       };
       serviceConfig = hardenedServiceConfig // {
         Type = "oneshot";
         User = "postgres";
         Group = "postgres";
         IPAddressDeny = [ "169.254.169.254" ];
+        # Self-heal transient NFS coherency errors (see retryPolicy comment above).
+        Restart = retryPolicy.Restart;
+        RestartSec = retryPolicy.RestartSec;
       };
       script = ''
         set -euo pipefail
@@ -610,12 +652,19 @@ in
       unitConfig = {
         RequiresMountsFor = [ "/mnt/nas-postgresql" ];
         OnSuccess = "pgbackrest-metrics.service";
+        # Bound the auto-retries so a sustained outage surfaces as an alert
+        # instead of looping forever (see retryPolicy comment above).
+        StartLimitBurst = retryPolicy.StartLimitBurst;
+        StartLimitIntervalSec = retryPolicy.StartLimitIntervalSec;
       };
       serviceConfig = hardenedServiceConfig // {
         Type = "oneshot";
         User = "postgres";
         Group = "postgres";
         IPAddressDeny = [ "169.254.169.254" ];
+        # Self-heal transient NFS coherency errors (see retryPolicy comment above).
+        Restart = retryPolicy.Restart;
+        RestartSec = retryPolicy.RestartSec;
       };
       script = ''
         set -euo pipefail


### PR DESCRIPTION
## Symptom

\`PgBackRestFullBackupStale\` (HIGH severity) alert fired this morning. The 02:00 daily full backup failed with:

\`\`\`
ERROR: [073]: unable to sync missing path
              '/mnt/nas-postgresql/pgbackrest/backup/main/20260508-020006F/pg_data/pg_dynshmem'
\`\`\`

Because the backup unit's script runs **repo1 (NFS) before repo2 (R2) sequentially**, the failure took out both repositories for the day. The unit had **no \`Restart=\` directive**, so the next attempt wasn't until tomorrow 02:00 — a 24-hour gap from a transient NFS hiccup.

## Root cause analysis

Searched pgBackRest's own log file (\`/var/log/pgbackrest/main-backup.log\`, 11.5 GB going back to Dec 2025):

| Pattern | Count | Notes |
|---|---|---|
| \`ERROR: [073]\` (unable to sync missing path) | 22 lifetime | ~once a week |
| \`ERROR: [061]\` (Directory not empty during remove) | ~10 (Mar–May) | Same NFS coherency class, hits \`pg_data/base/<oid>\` cleanup |
| Successful runs around the failure | 100% before/after | The 2026-05-07 02:13 full ran in 12.6 min, 02:19 ran in 200 sec — the path itself works |

This is a well-known pgBackRest+NFS interaction: the many-small-files I/O pattern occasionally races against NFS attribute caching, and pgBackRest doesn't auto-recover. Examples like \`pg_dynshmem\` and \`pg_data/base/<oid>\` are normal PostgreSQL directories — can't be excluded.

## Fix

Add a bounded auto-retry policy to all three pgBackRest backup units in [\`hosts/forge/services/pgbackrest.nix\`](hosts/forge/services/pgbackrest.nix):

\`\`\`nix
retryPolicy = {
  Restart = \"on-failure\";
  RestartSec = \"15min\";       # transient NFS issues clear quickly
  StartLimitBurst = 3;        # max 3 attempts per window
  StartLimitIntervalSec = \"2h\"; # cap the burst before surfacing failure
};
\`\`\`

Applied to:
- \`pgbackrest-full-backup.service\` (daily 02:00, NFS+R2)
- \`pgbackrest-incr-backup.service\` (hourly, NFS only)
- \`pgbackrest-incr-r2-backup.service\` (daily 14:00, R2 only)

**Behaviour after fix:**
- Transient NFS hiccup → systemd waits 15 min, retries. Existing pattern in the log file shows the same path succeeds within minutes most of the time.
- Sustained outage (NFS server actually down, R2 credentials revoked, etc.) → 3 attempts over 2h, then existing \`OnFailure=backup-failure-notification\` and the \`PgBackRestFullBackupStale\` alert fire as designed.

## Today's recovery (already done)

Manually ran \`sudo systemctl start pgbackrest-full-backup.service\` on forge before opening this PR:

| Repo | Duration | Result |
|---|---|---|
| repo1 (NFS) | 199 sec | ✅ completed successfully |
| repo2 (R2)  | 747 sec | ✅ completed successfully |

The \`PgBackRestFullBackupStale\` alert cleared on the next Prometheus scrape.

## Verification

\`\`\`bash
nix fmt -- --check .                           # 0 / 392 reformatted
nix flake check --no-build                     # all 8 hosts evaluate clean
nix eval ...pgbackrest-full-backup.serviceConfig  → Restart=on-failure, RestartSec=15min
nix eval ...pgbackrest-full-backup.unitConfig     → StartLimitBurst=3, IntervalSec=2h
                                                    OnSuccess + RequiresMountsFor preserved
nix eval ...pgbackrest-incr-backup.serviceConfig  → Restart=on-failure, RestartSec=15min
nix eval ...pgbackrest-incr-r2-backup.serviceConfig → Restart=on-failure, RestartSec=15min
\`\`\`

## Follow-up (deliberately out of scope)

If [073]/[061] errors keep happening after this is deployed, the next-tier fix is enabling pgBackRest file bundling (\`--bundle=y\` in the global stanza config). Bundling reduces per-backup file count by 10-100×, directly attacking the NFS-many-small-files surface area. That's a one-time per-stanza decision and is non-destructive (existing backups continue to work). Tracked as a forward-pointer in the new docs/workarounds.md entry.

## Why not just enable bundling now?

Bundling changes the on-disk layout of the repository going forward, so it's worth its own evaluation pass (storage delta, restore-time impact, retention semantics) and probably its own PR with explicit before/after numbers. The retry policy in this PR is the minimum-viable fix that immediately stops a 24-hour gap caused by what is demonstrably a transient class of error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)