### PR TITLE
fix(forge): repair postgres-backup-verification + disable defunct profilarr

### DIFF
--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -281,6 +281,18 @@ Services using `pkgs.unstable.*` instead of stable packages:
 | **Workaround** | Set `Restart=on-failure`, `RestartSec=15min`, `StartLimitBurst=3`, `StartLimitIntervalSec=2h` on `pgbackrest-full-backup`, `pgbackrest-incr-backup`, `pgbackrest-incr-r2-backup`. The 15-minute backoff is long enough for transient NFS issues to clear; the burst cap surfaces sustained failures via `OnFailure=` notifications and `PgBackRestFullBackupStale` rather than looping forever. |
 | **Check** | If errors persist after this is deployed, consider enabling pgBackRest file bundling (`--bundle=y` / `repo1-bundle=y`) to reduce per-backup file count by 10-100×, which directly attacks the NFS-many-small-files surface. Bundling is a one-time per-stanza decision and doesn't break existing backups. |
 | **Related** | An earlier related workaround (`EXCLUDE_OPTS="--exclude=.config --exclude=.local"`, 2026-02-02) addressed a different `[073]` instance where `.config`/`.local` dirs polluted PGDATA. Today's `pg_dynshmem` failure is a normal PG directory and can't be excluded that way. |
+| **Verified** | 2026-05-11: the retry fired exactly as designed in production. The 2026-05-11 02:00 full backup hit a `[061]` error at 02:02, systemd waited 15 min, retried at 02:17, and completed successfully at 02:24 (NFS) and 02:44 (R2). No alert fired. |
+
+### Profilarr - Disabled (Upstream Image Gone)
+
+| Field | Value |
+|-------|-------|
+| **Added** | 2026-05-11 |
+| **Location** | `hosts/forge/services/profilarr.nix` (`enable = false`) |
+| **Reason** | The original `ghcr.io/profilarr/profilarr` image registry returns 403 Forbidden as of May 2026. The project moved to <https://github.com/Dictionarry-Hub/profilarr> but no public container image is published yet at the new location (the org's packages page shows "No packages published"). The README documents `ghcr.io/dictionarry-hub/profilarr:latest` but that path is also unauthorized. The service had also never produced any output on this host: `/var/lib/profilarr/` was empty and the journal had zero successful runs in retention. |
+| **Workaround** | `enable = false` with a FIXME comment pointing at the upstream situation. `recyclarr` (still enabled) does the equivalent TRaSH-guides sync work, so disabling profilarr has no functional impact on this host. |
+| **Check** | Periodically check <https://github.com/orgs/Dictionarry-Hub/packages?repo_name=profilarr> for a published image. When V2 ships and an image lands, update the `image` ref in `hosts/forge/services/profilarr.nix` and toggle `enable = true`. |
+| **Related** | Same FIXME-disable pattern used for n8n in `hosts/forge/services/n8n.nix`. |
 
 ---
 

--- a/hosts/forge/services/profilarr.nix
+++ b/hosts/forge/services/profilarr.nix
@@ -7,8 +7,22 @@ in
   config = lib.mkMerge [
     {
       modules.services.profilarr = {
-        # Profilarr - Profile sync for *arr services
-        enable = true;
+        # FIXME (2026-05-11): Disabled - upstream image is gone.
+        # The original ghcr.io/profilarr/profilarr container registry returns 403
+        # Forbidden as of May 2026. The project moved to Dictionarry-Hub/profilarr
+        # but no public container image is published yet at the new location
+        # (https://github.com/orgs/Dictionarry-Hub/packages?repo_name=profilarr
+        # shows "No packages published"). The README documents `ghcr.io/dictionarry-hub/
+        # profilarr:latest` but the image is not actually pushed there.
+        #
+        # Notes for re-enabling:
+        #   1. Verify the new image is publicly pullable (check the org packages page).
+        #   2. Update `image` to the new ref + digest (Renovate will keep it pinned).
+        #   3. The container's data directory at /var/lib/profilarr/ is empty -
+        #      this service has never produced output on this host (recyclarr
+        #      has been doing the equivalent TRaSH-guides sync work).
+        # Tracked in docs/workarounds.md.
+        enable = false;
         image = "ghcr.io/profilarr/profilarr:latest";
         podmanNetwork = forgeDefaults.podmanNetwork; # Enable DNS resolution to *arr services
 

--- a/modules/nixos/services/backup/postgres.nix
+++ b/modules/nixos/services/backup/postgres.nix
@@ -160,7 +160,10 @@ in
           set -euo pipefail
 
           METRICS_FILE="/var/lib/node_exporter/textfile_collector/postgres_verification.prom"
-          START_TIME=$(date +%s)
+          # Lowercase to match the cleanup trap below; mismatched case under
+          # `set -u` raised "start_time: unbound variable" and aborted the script
+          # before metrics were written (observed 2026-05-11).
+          start_time=$(date +%s)
 
           # Cleanup function for metrics
           cleanup() {
@@ -188,14 +191,18 @@ in
 
           echo "Starting PostgreSQL backup verification..."
 
-          # Check pgBackRest repository status
-          if ! ${pkgs.pgbackrest}/bin/pgbackrest --config=/etc/pgbackrest/pgbackrest.conf info; then
+          # Check pgBackRest repository status. Use the default config path
+          # (/etc/pgbackrest.conf); previously this script passed
+          # --config=/etc/pgbackrest/pgbackrest.conf which doesn't exist on this
+          # host (the file is at /etc/pgbackrest.conf, no subdirectory) and
+          # caused error [055] "unable to open missing file" on every run.
+          if ! ${pkgs.pgbackrest}/bin/pgbackrest --stanza=main check; then
             echo "ERROR: pgBackRest repository check failed"
             exit 1
           fi
 
           # Verify recent backup exists
-          if ! ${pkgs.pgbackrest}/bin/pgbackrest --config=/etc/pgbackrest/pgbackrest.conf info \
+          if ! ${pkgs.pgbackrest}/bin/pgbackrest --stanza=main info \
               | grep -q "$(date -d '1 day ago' '+%Y-%m-%d')"; then
             echo "WARNING: No recent backup found within 24 hours"
           fi


### PR DESCRIPTION
## Three forge alerts triaged this morning

After a 3-day window with no activity on the repo, `systemctl --failed` on forge surfaced three failed services. This PR addresses the two that need code changes; the third was already cleaned up out-of-band.

## 1. \`postgres-backup-verification\` — two real bugs in the script

Failing daily since deploy with:

\`\`\`
ERROR: [055]: unable to open missing file '/etc/pgbackrest/pgbackrest.conf' for read
ERROR: pgBackRest repository check failed
line 11: start_time: unbound variable
\`\`\`

Two bugs in [\`modules/nixos/services/backup/postgres.nix\`](modules/nixos/services/backup/postgres.nix):

| # | Bug | Fix |
|---|---|---|
| a | Script passed \`--config=/etc/pgbackrest/pgbackrest.conf\` (with subdirectory) but the actual file is at \`/etc/pgbackrest.conf\`. The bogus path caused \`[055]\`. | Drop the \`--config=\` flag (default path is correct on this host). Add \`--stanza=main\` for explicitness. |
| b | Script set \`START_TIME\` (uppercase) but the cleanup trap read \`start_time\` (lowercase). With \`set -euo pipefail\`, the unbound-variable check aborted the script before the metric file got written. | Use \`start_time\` consistently. |

Verified by manually running \`pgbackrest --stanza=main check\` as the postgres user during diagnosis — completes successfully in ~1.5 sec.

## 2. \`profilarr-sync\` — disable until upstream stabilizes

Failing daily since image lookup started returning:

\`\`\`
unable to retrieve auth token: ... 403 Forbidden
ghcr.io/profilarr/profilarr
\`\`\`

The original \`profilarr/profilarr\` GitHub org and container registry are gone (404). Project moved to <https://github.com/Dictionarry-Hub/profilarr> but no public container image is published there yet (the org's packages page says **"No packages published"** — their README documents \`ghcr.io/dictionarry-hub/profilarr:latest\` but the path is also unauthorized).

Decision context that pushed me to disable rather than re-pin:
- Forge's \`/var/lib/profilarr/\` has been **empty since November 2025** (~6 months). The service has **never produced output** on this host — verified via journal (zero successful runs in retention) and data-dir inspection.
- \`recyclarr\` (enabled, working) does the **equivalent TRaSH-guides sync** work. Disabling profilarr has zero functional impact.

Fix: \`enable = false\` with a FIXME comment pointing at the upstream situation and explicit notes for re-enabling when an image lands. Same pattern as the n8n FIXME-disable.

Not deleting the module — upstream may publish soon and the stub is small. If still defunct in 3-6 months, that's a future cleanup PR.

## 3. \`restic-prune-nas-primary\` — recovered out-of-band (no code change)

15-day-old stale lock from 2026-04-26 03:45 (no owning process, journal too short to identify origin), 3270 accumulated lock files. Manually:

\`\`\`bash
sudo -u restic-backup env RESTIC_REPOSITORY=/mnt/nas-backup \\
  RESTIC_PASSWORD_FILE=/run/secrets/restic/password \\
  /nix/store/.../restic unlock --remove-all
# successfully removed 3270 locks

sudo systemctl start restic-prune-nas-primary.service
# completed: repacked 2072 packs, rebuilt 4220 indexes, removed 6862 old packs,
# freed 2.39 GiB. result=success exit=0.
\`\`\`

No code change needed; the lock-buildup is a one-shot recovery. If it recurs, that's a signal the auto-retry on the long-running backup units is leaving locks behind on cancellation, and a forward-pointer is to consider adding a \`restic unlock\` pre-step or shorter \`--retry-lock\` on the prune unit.

## Bonus validation: previous OOM and pgbackrest-retry fixes still working

While checking, I confirmed both fixes from this session's earlier PRs are functioning correctly in production:

- **Restic OOM fix (PR #441):** all backup jobs completed within last 8.79h (well under the 30h alert threshold).
- **pgBackRest retry fix (PR #442):** **fired exactly as designed last night.** The 2026-05-11 02:00 full backup hit a \`[061]\` error at 02:02, systemd waited 15 min, retried at 02:17, completed at 02:24 (NFS) and 02:44 (R2). \`PgBackRestFullBackupStale\` did not fire. Added a verification line to the workarounds.md entry.

## Verification

\`\`\`bash
nix fmt -- --check .                      # 0 / 392 reformatted
nix flake check --no-build                # all 8 hosts evaluate clean
grep ... modules/.../backup/postgres.nix  # confirms start_time + --stanza=main
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)