### PR TITLE
refactor(eval): remove selective service-category loading

### DIFF
--- a/docs/analysis/deployment-runtime-policy-audit.md
+++ b/docs/analysis/deployment-runtime-policy-audit.md
@@ -126,10 +126,11 @@ second, top-level module system.
   database interface because it and the PostgreSQL module define incompatible
   shapes under `modules.services.postgresql`. Resolve this before introducing
   deferred-module merging under another module layer.
-4. **Low: NAS-0 and NAS-1 still use the legacy all-services path.** They do not
-  pass `serviceCategories` to `mkNixosSystem`, so they evaluate the entire
-  service tree. Give both hosts explicit categories before using evaluation
-  performance as evidence for or against Dendritic.
+4. **Resolved (2026-07): selective category loading removed.** A controlled
+  measurement (same host, nixpi, 24 vs 87 imported service modules) showed
+  identical eval time — the December 2025 numbers compared different hosts and
+  attributed enabled-service cost to module imports. All hosts now import the
+  full service tree; enable gates carry the actual cost.
 5. **Low: all systems evaluate, but the baseline is not warning-free.** The
   current warnings include intentional root ownership for Valhalla without the
   corresponding `rootOwnedReason`, two deprecated `system` accesses that may

--- a/flake.nix
+++ b/flake.nix
@@ -746,42 +746,16 @@
             rydev = mkNixosSystem {
               system = "aarch64-linux";
               hostname = "rydev";
-              serviceCategories = [
-                "infrastructure"
-                "observability"
-              ];
             };
             # Luna - DNS/network infrastructure server
             luna = mkNixosSystem {
               system = "x86_64-linux";
               hostname = "luna";
-              serviceCategories = [
-                "auth"
-                "development"
-                "infrastructure"
-                "network"
-                "observability"
-              ];
             };
             # Forge - main homelab server (all categories)
             forge = mkNixosSystem {
               system = "x86_64-linux";
               hostname = "forge";
-              serviceCategories = [
-                "ai"
-                "auth"
-                "automotive"
-                "backup"
-                "development"
-                "downloads"
-                "home-automation"
-                "infrastructure"
-                "media"
-                "media-automation"
-                "network"
-                "observability"
-                "productivity"
-              ];
             };
             # NAS-0 - Primary bulk storage NAS (117TB) - not yet deployed
             nas-0 = mkNixosSystem {
@@ -789,37 +763,22 @@
               hostname = "nas-0";
               # Storage services use native NixOS modules in the host config;
               # no custom service category is required.
-              serviceCategories = [ ];
             };
             # NAS-1 - Secondary NAS / Backup target - not yet deployed
             nas-1 = mkNixosSystem {
               system = "x86_64-linux";
               hostname = "nas-1";
-              serviceCategories = [
-                # Attic server/admin modules.
-                "development"
-                # Caddy reverse proxy and shared service infrastructure.
-                "infrastructure"
-              ];
             };
             # Raspberry Pi RV system
             nixpi = mkNixosSystem {
               system = "aarch64-linux";
               hostname = "nixpi";
-              serviceCategories = [
-                "infrastructure"
-                "observability"
-              ];
             };
             # Flashable SD image for nixpi (512 MiB firmware so the kernel fits).
             # Build: nix build .#nixosConfigurations.nixpi-image.config.system.build.sdImage
             nixpi-image = mkNixosSystem {
               system = "aarch64-linux";
               hostname = "nixpi";
-              serviceCategories = [
-                "infrastructure"
-                "observability"
-              ];
               extraModules = [ ./hosts/nixpi/sd-image.nix ];
             };
           };

--- a/hosts/forge/services/frigate.nix
+++ b/hosts/forge/services/frigate.nix
@@ -19,6 +19,9 @@ in
     {
       modules.services.frigate = {
         enable = false;
+        # Keep the frigate account while the service is staged-but-disabled so
+        # the tank/services/frigate dataset ownership stays stable.
+        ensureSystemUser = true;
         hostname = serviceDomain;
         dataDir = dataDir;
         mediaDir = dataDir;

--- a/lib/mkSystem.nix
+++ b/lib/mkSystem.nix
@@ -29,40 +29,12 @@
   mkNixosSystem =
     { system
     , hostname
-    , serviceCategories ? null  # null = all categories, list = selective
     , extraModules ? [ ]        # extra modules (e.g. sd-image builder)
     , extraHomeModules ? [ ]    # feature modules shared with Home Manager
     }:
     let
       # Import custom library helpers for injection into modules
       mylib = import ./default.nix { lib = inputs.nixpkgs.lib; };
-
-      categoryModules = import ../modules/nixos/services/_categories/registry.nix;
-
-      # Select which service modules to import
-      serviceModules =
-        if serviceCategories == null then
-        # Import all services (backward compatible - uses default.nix which imports all)
-          [ ../modules/nixos/services ]
-        else
-        # Import only selected categories
-          let
-            unknownCategories = builtins.filter
-              (category: !(builtins.hasAttr category categoryModules))
-              serviceCategories;
-          in
-          assert inputs.nixpkgs.lib.assertMsg (unknownCategories == [ ])
-            "Unknown service categories: ${builtins.concatStringsSep ", " unknownCategories}";
-          map (category: categoryModules.${category}) serviceCategories;
-
-      # Select which base module to use
-      # When using selective categories, use base.nix (excludes services)
-      # When importing all, use default.nix (includes services)
-      nixosBaseModule =
-        if serviceCategories == null then
-          ../modules/nixos           # default.nix includes ./services
-        else
-          ../modules/nixos/base.nix; # base.nix excludes services
     in
     inputs.nixpkgs.lib.nixosSystem {
       inherit system;
@@ -100,8 +72,11 @@
           };
         }
         ../modules/common
-        nixosBaseModule
-      ] ++ serviceModules ++ [
+        # All NixOS modules including every service module. Service modules are
+        # enable-gated and default off, so importing them everywhere is free:
+        # measured eval cost of all 87 vs a 2-category subset is identical
+        # (within noise) — selective category loading was removed accordingly.
+        ../modules/nixos
         ../hosts/${hostname}
       ] ++ extraModules;
       specialArgs = {

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -1,14 +1,13 @@
-# Backwards-compatible NixOS module entry point.
+# NixOS module entry point: base.nix plus the full services tree.
 #
-# Imports everything from base.nix plus the full services tree. This is the
-# legacy "all services" path used by hosts that don't pass `serviceCategories`
-# in mkNixosSystem (currently: nixos-bootstrap, nas-0, nas-1).
-#
-# Hosts that opt into selective category loading import `base.nix` directly
-# from `lib/mkSystem.nix` and then add the categories they need.
+# Every host imports everything. Service modules are enable-gated and default
+# off, so the import itself is free — measured eval time with all 87 service
+# modules vs a 2-category subset is identical (selective category loading was
+# removed on that basis; categories remain under services/_categories as
+# organized import lists only).
 #
 # This wrapper exists so we have a single source of truth (base.nix) for the
-# OS-level concerns and don't drift between the two entry points.
+# OS-level concerns.
 { ... }: {
   imports = [
     ./base.nix

--- a/modules/nixos/services/frigate/default.nix
+++ b/modules/nixos/services/frigate/default.nix
@@ -284,14 +284,14 @@ in
 
     ensureSystemUser = lib.mkOption {
       type = lib.types.bool;
-      default = true;
-      description = "Create the frigate system user/group even when the upstream service is disabled (useful when other modules reference the account).";
+      default = false;
+      description = "Create the frigate system user/group even when the upstream service is disabled (useful when other modules reference the account, e.g. for dataset ownership). Hosts that stage frigate config with enable = false must set this explicitly.";
     };
   };
 
   config =
     lib.mkMerge [
-      (lib.mkIf cfg.ensureSystemUser {
+      (lib.mkIf (cfg.enable || cfg.ensureSystemUser) {
         users.users.${frigateUser} = {
           isSystemUser = true;
           group = frigateGroup;

--- a/modules/nixos/services/observability/default.nix
+++ b/modules/nixos/services/observability/default.nix
@@ -29,9 +29,14 @@ let
       # Extract all modules.services.* configurations (excluding observability to prevent recursion)
       allServices = lib.filterAttrs (name: _service: name != "observability") (config.modules.services or { });
 
-      # Filter services that have metrics enabled
+      # Filter services that are enabled AND have metrics enabled.
+      # The service-level enable check matters: every service module is
+      # imported on every host, and several metrics submodules default to
+      # enabled — without this check, disabled services produce phantom
+      # scrape targets.
       servicesWithMetrics = lib.filterAttrs
         (_name: service:
+          (service.enable or false) &&
           (service.metrics or null) != null &&
           (service.metrics.enable or false)
         )


### PR DESCRIPTION
## Summary

Removes the `serviceCategories` selective-loading mechanism from `mkNixosSystem` — every host now imports the full module tree. The category files under `services/_categories/` remain as organized import lists only.

**Why:** the mechanism was added (Dec 2025) based on eval-time comparisons across *different hosts* (rydev 11.6s vs forge 33.9s), which attributed forge's enabled-service cost to module imports. A controlled same-host measurement (nixpi, 24 vs 87 imported service modules, `toplevel.drvPath` eval) shows **identical eval time** — importing enable-gated modules that default off is free. The selection machinery carried real complexity (per-host category lists in flake.nix, dual base entry points, registry plumbing) for no measurable benefit.

## Latent bugs unmasked and fixed

Going imports-everywhere surfaced two gates that were leaking, one of which is a live production bug:

1. **Phantom Prometheus scrape targets (live bug on rydev).** The observability auto-discovery filtered on `metrics.enable` (which several services default to true) but never checked the service's own `enable`. rydev's Prometheus is scraping **8 targets for disabled services** today (blocky, dnsdist, gatus, glances, grafana, grafana-oncall, loki, promtail); without the fix, imports-everywhere would have added 22 more. The filter now requires `service.enable`.
2. **frigate `ensureSystemUser` defaulted to true**, creating the frigate account on any host that imported the module. Now defaults to false (or implied by `enable`); forge opts in explicitly to keep `tank/services/frigate` ownership stable while frigate stays staged-but-disabled.

## Verification (origin/main vs this branch, per host)

- **Semantic hash identical on all hosts** over: user names, group names, sorted tmpfiles rules, `/etc` file names, systemd unit names, timer names, sorted package name set
- **Scrape job lists identical** on forge/luna/nixpi; **rydev loses exactly the 8 phantom jobs**, each confirmed `enable = false`
- **nixos-bootstrap drv byte-identical** (doesn't use `mkNixosSystem`)
- Remaining drv-hash differences on the other hosts were inspected with `nix-diff` and are pure line-reordering from module traversal order (`types.lines` concatenation — e.g. chrony.conf directives swap positions, same content)
- `statix`, `deadnix`, `nixpkgs-fmt` clean

## Notes

- Net −58 lines; deletes the `serviceCategories` argument, category selection/assert logic, and dual `base.nix`/`default.nix` entry-point switch in `lib/mkSystem.nix`
- Follow-up candidate: auto-import `modules/nixos/services/` and forge's `core/`/`infrastructure/`/`services/` import walls (same `discoverModules` approach as `features/`), now that selective loading no longer needs the category lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)