### PR TITLE
fix(lib): replace dead 'or' fallbacks on validated spec fields in service factory

### DIFF
--- a/lib/service-factory.nix
+++ b/lib/service-factory.nix
@@ -134,7 +134,7 @@ let
     in
     serviceOptions.mkBaseOptions
       {
-        description = spec.description or name;
+        description = if spec.description != null then spec.description else name;
       }
     // serviceOptions.mkWebOptions {
       defaultPort = spec.port;
@@ -177,11 +177,12 @@ let
 
       resources = lib.mkOption {
         type = lib.types.nullOr sharedTypes.containerResourcesSubmodule;
-        default = spec.resources or {
-          memory = "512M";
-          memoryReservation = "256M";
-          cpus = "1.0";
-        };
+        default =
+          if spec.resources != null then spec.resources else {
+            memory = "512M";
+            memoryReservation = "256M";
+            cpus = "1.0";
+          };
         description = "Resource limits for the container";
       };
 
@@ -207,7 +208,7 @@ let
           labels = {
             service_type = profile.serviceType;
             exporter = name;
-            function = spec.function or name;
+            function = if spec.function != null then spec.function else name;
           };
         };
         description = "Prometheus metrics collection configuration";
@@ -234,7 +235,7 @@ let
             onFailure = [ profile.alertChannel ];
           };
           customMessages = {
-            failure = "${spec.displayName or name} service failed on \${config.networking.hostName}";
+            failure = "${if spec.displayName != null then spec.displayName else name} service failed on \${config.networking.hostName}";
           };
         };
         description = "Notification configuration";


### PR DESCRIPTION
## Summary
- `mkStandardOptions` in [lib/service-factory.nix](https://github.com/carpenike/nix-config/blob/main/lib/service-factory.nix) receives the *validated* spec from `validateServiceSpec`, which defines `resources`, `description`, `function`, and `displayName` with `null` defaults. Since those attributes always exist on the validated spec, every `spec.X or fallback` expression was dead code.
- Worst case: a factory service omitting `spec.resources` would get `resources = null` and run its container with **no memory/cpu limits** instead of the documented 512M/256M/1.0 defaults. Omitted `description`/`function`/`displayName` would yield `null` (or a string-interpolation eval error) instead of falling back to the service name.
- Replaced each with an explicit `if X != null then X else fallback` check. Other `or` uses (`startPeriod`, `metricsPath`, `useZfsSnapshots`, `backendScheme`, etc.) are unaffected because validation gives them real non-null defaults.

## Verification
- All ten current factory services set these fields explicitly, so this is a no-op today: `nix eval .#nixosConfigurations.forge.config.system.build.toplevel.drvPath` is byte-identical before and after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)