### PR TITLE
refactor(services): migrate 9 container modules to mkContainerService factory

### DIFF
--- a/modules/nixos/services/apprise/default.nix
+++ b/modules/nixos/services/apprise/default.nix
@@ -1,3 +1,5 @@
+# modules/nixos/services/apprise/default.nix
+#
 # Apprise API - Notification gateway service
 #
 # Apprise API provides a REST API interface to the Apprise notification library,
@@ -16,87 +18,75 @@
 #   GET  /json/urls/{key}  - Get URLs for a key
 #   POST /add/{key}        - Add URLs to a key
 #
-{ config, lib, pkgs, mylib, podmanLib, ... }:
+# Factory-based implementation (see lib/service-factory.nix).
+{ lib
+, mylib
+, pkgs
+, config
+, podmanLib
+, ...
+}:
 
-let
-  inherit (lib)
-    mkOption
-    mkEnableOption
-    mkIf
-    types
-    ;
+mylib.mkContainerService {
+  inherit lib mylib pkgs config podmanLib;
 
-  cfg = config.modules.services.apprise;
-  sharedTypes = mylib.types;
-  storageHelpers = mylib.storageHelpers pkgs;
+  name = "apprise";
+  description = "Apprise API notification gateway";
 
-  # Service identity
-  serviceName = "apprise";
-  serviceIds = mylib.serviceUids.${serviceName};
-  storageCfg = config.modules.storage;
-  datasetPath = "${storageCfg.datasets.parentDataset}/${serviceName}";
-  replicationConfig = storageHelpers.mkReplicationConfig { inherit config datasetPath; };
-  allowEmptyBootstrap = storageHelpers.allowEmptyBootstrapFor {
-    inherit config;
-    datasetName = serviceName;
+  spec = {
+    # Core service configuration
+    # Note: Container version (1.3.0) differs from Python apprise package
+    # version (1.9.5) - the apprise-api container is versioned independently.
+    port = 8000;
+    image = "docker.io/caronc/apprise:1.3.0@sha256:e365025a7bf1fed39ef66b5f22c9855d500ee7bdea27441365e5b95ea972e843";
+    operationalProfile = "infrastructure";
+    displayName = "Apprise";
+    function = "notification_gateway";
+
+    # Health check via the /status endpoint; Apprise starts quickly.
+    healthCommand = "curl -sf http://localhost:8000/status || exit 1";
+    startPeriod = "10s";
+
+    # ZFS tuning - small config files
+    zfsRecordSize = "16K";
+    zfsCompression = "lz4";
+
+    # Lightweight API gateway
+    resources = {
+      memory = "256m";
+      memoryReservation = "128m";
+      cpus = "0.5";
+    };
+
+    environment = { cfg, config, ... }: {
+      PUID = cfg.user;
+      PGID = toString config.users.groups.${cfg.group}.gid;
+      APPRISE_STATEFUL_MODE = cfg.statefulMode;
+      APPRISE_WORKER_COUNT = toString cfg.workerCount;
+      APPRISE_ADMIN = if cfg.enableAdmin then "y" else "n";
+    } // cfg.extraEnvironment;
+
+    # Apprise uses split config/attach/plugin mounts instead of a single
+    # dataDir:/config mount.
+    skipDefaultConfigMount = true;
+    volumes = cfg: [
+      "${cfg.dataDir}/config:/config:rw"
+      "${cfg.dataDir}/attach:/attach:rw"
+      "${cfg.dataDir}/plugin:/plugin:ro"
+    ];
+
+    # Container hardening - Apprise runs read-only with a tmpfs scratch space
+    extraOptions = _: [
+      "--tmpfs=/tmp:rw,noexec,nosuid,nodev,size=64m"
+      "--cap-drop=ALL"
+      "--security-opt=no-new-privileges:true"
+      "--read-only"
+    ];
   };
-in
-{
-  options.modules.services.apprise = {
-    enable = mkEnableOption "Apprise API notification gateway";
 
-    image = mkOption {
-      type = types.str;
-      # Note: Container version (1.3.0) differs from Python apprise package version (1.9.5)
-      # The apprise-api container is versioned independently
-      default = "docker.io/caronc/apprise:1.3.0@sha256:e365025a7bf1fed39ef66b5f22c9855d500ee7bdea27441365e5b95ea972e843";
-      description = "Container image for Apprise API";
-    };
-
-    dataDir = mkOption {
-      type = types.path;
-      default = "/var/lib/${serviceName}";
-      description = "Data directory for Apprise configuration and state";
-    };
-
-    port = mkOption {
-      type = types.port;
-      default = 8000;
-      description = "Port for Apprise API to listen on";
-    };
-
-    user = mkOption {
-      type = types.str;
-      default = serviceName;
-      description = "User to run Apprise as";
-    };
-
-    group = mkOption {
-      type = types.str;
-      default = serviceName;
-      description = "Group to run Apprise as";
-    };
-
-    uid = mkOption {
-      type = types.int;
-      default = serviceIds.uid;
-      description = "UID for the Apprise user";
-    };
-
-    gid = mkOption {
-      type = types.int;
-      default = serviceIds.gid;
-      description = "GID for the Apprise group";
-    };
-
-    timezone = mkOption {
-      type = types.str;
-      default = config.time.timeZone or "UTC";
-      description = "Timezone for the Apprise container";
-    };
-
-    statefulMode = mkOption {
-      type = types.enum [ "disabled" "simple" "hash" ];
+  extraOptions = {
+    statefulMode = lib.mkOption {
+      type = lib.types.enum [ "disabled" "simple" "hash" ];
       default = "simple";
       description = ''
         Stateful mode for Apprise:
@@ -106,238 +96,64 @@ in
       '';
     };
 
-    workerCount = mkOption {
-      type = types.int;
+    workerCount = lib.mkOption {
+      type = lib.types.int;
       default = 1;
       description = "Number of worker processes for handling requests";
     };
 
-    enableAdmin = mkOption {
-      type = types.bool;
+    enableAdmin = lib.mkOption {
+      type = lib.types.bool;
       default = true;
       description = "Enable the web-based admin interface for managing notification URLs";
     };
 
-    extraEnvironment = mkOption {
-      type = types.attrsOf types.str;
+    extraEnvironment = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
       default = { };
       description = "Additional environment variables to pass to the container";
     };
 
-    resources = mkOption {
-      type = sharedTypes.containerResourcesSubmodule;
-      default = {
-        memory = "256m";
-        memoryReservation = "128m";
-        cpus = "0.5";
-      };
-      description = "Container resource limits";
-    };
-
-    healthcheck = mkOption {
-      type = sharedTypes.healthcheckSubmodule;
-      default = {
-        enable = true;
-        interval = "30s";
-        timeout = "10s";
-        retries = 3;
-        startPeriod = "10s";
-      };
-      description = "Container healthcheck configuration";
-    };
-
-    reverseProxy = mkOption {
-      type = types.nullOr sharedTypes.reverseProxySubmodule;
+    # Apprise exposes no Prometheus metrics endpoint - keep metrics opt-in
+    # (overrides the factory default of enabled).
+    metrics = lib.mkOption {
+      type = lib.types.nullOr mylib.types.metricsSubmodule;
       default = null;
-      description = "Reverse proxy configuration";
+      description = "Prometheus metrics collection configuration (Apprise has no native metrics)";
     };
 
-    logging = mkOption {
-      type = types.nullOr sharedTypes.loggingSubmodule;
-      default = {
-        enable = true;
-        labels = {
-          service = serviceName;
-          service_type = "notification";
-        };
-        containerDriver = "journald";
-      };
-      description = "Logging configuration for Promtail";
-    };
-
-    backup = mkOption {
-      type = types.nullOr sharedTypes.backupSubmodule;
+    # Failure notifications for the notification gateway itself are opt-in:
+    # if Apprise is down, its own failure notification cannot be delivered
+    # through it anyway.
+    notifications = lib.mkOption {
+      type = lib.types.nullOr mylib.types.notificationSubmodule;
       default = null;
-      description = "Backup configuration";
-    };
-
-    preseed = {
-      enable = mkEnableOption "automatic restore before first start";
-
-      repositoryUrl = mkOption {
-        type = types.str;
-        default = "";
-        description = "URL to Restic repository for preseed restore";
-      };
-
-      passwordFile = mkOption {
-        type = types.nullOr types.path;
-        default = null;
-        description = "Path to file containing Restic repository password";
-      };
-
-      restoreMethods = mkOption {
-        type = types.listOf (types.enum [ "syncoid" "local" "restic" ]);
-        default = [ "syncoid" "local" ];
-        description = "Ordered list of restore methods to try during preseed";
-      };
+      description = "Notification configuration for Apprise service events";
     };
   };
 
-  config = lib.mkMerge [
-    (mkIf cfg.enable {
-      # User and group
-      users.users.${cfg.user} = {
-        isSystemUser = true;
-        group = cfg.group;
-        uid = cfg.uid;
-        home = "/var/empty";
-        createHome = false;
-        description = "Apprise API notification service";
-      };
+  extraConfig = cfg: {
+    # Only bind to localhost - external access goes through the reverse proxy.
+    virtualisation.oci-containers.containers.apprise.ports = lib.mkForce [
+      "127.0.0.1:${toString cfg.port}:8000"
+    ];
 
-      users.groups.${cfg.group} = {
-        gid = cfg.gid;
-      };
+    # Subdirectory permissions inside the dataset
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir}/config 0750 ${cfg.user} ${cfg.group} - -"
+      "d ${cfg.dataDir}/attach 0750 ${cfg.user} ${cfg.group} - -"
+      "d ${cfg.dataDir}/plugin 0750 ${cfg.user} ${cfg.group} - -"
+    ];
 
-      # Storage dataset configuration
-      # Note: OCI containers don't support StateDirectory, so we explicitly set
-      # permissions via tmpfiles and the storage module
-      modules.storage.datasets.services.apprise = {
-        mountpoint = cfg.dataDir;
-        recordsize = "16K"; # Small files for config
-        compression = "lz4";
-        properties = {
-          "com.sun:auto-snapshot" = "true";
-        };
-        owner = cfg.user;
-        group = cfg.group;
-        mode = "0750";
-      };
-
-      # Directory permissions for subdirectories
-      systemd.tmpfiles.rules = [
-        "d ${cfg.dataDir}/config 0750 ${cfg.user} ${cfg.group} - -"
-        "d ${cfg.dataDir}/attach 0750 ${cfg.user} ${cfg.group} - -"
-        "d ${cfg.dataDir}/plugin 0750 ${cfg.user} ${cfg.group} - -"
-      ];
-
-      # Container definition using podmanLib.mkContainer for standard logging
-      virtualisation.oci-containers.containers.${serviceName} = podmanLib.mkContainer serviceName {
-        image = cfg.image;
-        user = "${toString cfg.uid}:${toString cfg.gid}";
-
-        environment = {
-          TZ = cfg.timezone;
-          PUID = toString cfg.uid;
-          PGID = toString cfg.gid;
-          APPRISE_STATEFUL_MODE = cfg.statefulMode;
-          APPRISE_WORKER_COUNT = toString cfg.workerCount;
-          APPRISE_ADMIN = if cfg.enableAdmin then "y" else "n";
-        } // cfg.extraEnvironment;
-
-        volumes = [
-          "${cfg.dataDir}/config:/config:rw"
-          "${cfg.dataDir}/attach:/attach:rw"
-          "${cfg.dataDir}/plugin:/plugin:ro"
-        ];
-
-        # Resource limits (handled by mkContainer)
-        resources = cfg.resources;
-
-        extraOptions =
-          # Healthcheck
-          lib.optionals cfg.healthcheck.enable [
-            ''--health-cmd=curl -sf http://localhost:8000/status || exit 1''
-            "--health-interval=${cfg.healthcheck.interval}"
-            "--health-timeout=${cfg.healthcheck.timeout}"
-            "--health-retries=${toString cfg.healthcheck.retries}"
-            "--health-start-period=${cfg.healthcheck.startPeriod}"
-          ]
-          ++ [
-            "--tmpfs=/tmp:rw,noexec,nosuid,nodev,size=64m"
-            "--cap-drop=ALL"
-            "--security-opt=no-new-privileges:true"
-            "--read-only"
-          ];
-
-        ports = [
-          "127.0.0.1:${toString cfg.port}:8000"
-        ];
-      };
-
-      # Systemd service overrides
-      systemd.services."podman-${serviceName}" = lib.mkMerge [
-        {
-          after = [ "network-online.target" ];
-          wants = [ "network-online.target" ];
-
-          # Create subdirectories before container starts
-          # tmpfiles.rules are processed at boot, but may not run before this service
-          preStart = lib.mkAfter ''
-            install -d -m 0750 -o ${cfg.user} -g ${cfg.group} ${cfg.dataDir}/config
-            install -d -m 0750 -o ${cfg.user} -g ${cfg.group} ${cfg.dataDir}/attach
-            install -d -m 0750 -o ${cfg.user} -g ${cfg.group} ${cfg.dataDir}/plugin
-          '';
-
-          serviceConfig = {
-            Restart = "always";
-            RestartSec = "10s";
-          };
-        }
-        # Add dependency on preseed service if enabled
-        (lib.mkIf cfg.preseed.enable {
-          requires = lib.optional (!allowEmptyBootstrap) "preseed-apprise.service";
-          wants = lib.optional allowEmptyBootstrap "preseed-apprise.service";
-          after = [ "preseed-apprise.service" ];
-        })
-      ];
-
-      # Reverse proxy integration
-      modules.services.caddy.virtualHosts.${serviceName} = mkIf (cfg.reverseProxy != null && cfg.reverseProxy.enable) {
-        enable = true;
-        hostName = cfg.reverseProxy.hostName;
-        backend = {
-          scheme = "http";
-          host = "127.0.0.1";
-          port = cfg.port;
-        };
-        caddySecurity = cfg.reverseProxy.caddySecurity or null;
-        extraConfig = cfg.reverseProxy.extraConfig or "";
-      };
-    })
-
-    # Preseed / disaster recovery service
-    (mkIf (cfg.enable && cfg.preseed.enable) (
-      storageHelpers.mkPreseedService {
-        inherit serviceName;
-        dataset = datasetPath;
-        mountpoint = cfg.dataDir;
-        mainServiceUnit = "podman-${serviceName}.service";
-        replicationCfg = replicationConfig;
-        datasetProperties = {
-          recordsize = "16K";
-          compression = "lz4";
-          "com.sun:auto-snapshot" = "true";
-        };
-        resticRepoUrl = cfg.preseed.repositoryUrl;
-        resticPasswordFile = cfg.preseed.passwordFile;
-        resticPaths = [ cfg.dataDir ];
-        restoreMethods = cfg.preseed.restoreMethods;
-        inherit allowEmptyBootstrap;
-        owner = cfg.user;
-        group = cfg.group;
-      }
-    ))
-  ];
+    systemd.services."${config.virtualisation.oci-containers.backend}-apprise" = {
+      # Create subdirectories before container starts.
+      # tmpfiles.rules are processed at boot, but may not run before this service.
+      preStart = lib.mkAfter ''
+        install -d -m 0750 -o ${cfg.user} -g ${cfg.group} ${cfg.dataDir}/config
+        install -d -m 0750 -o ${cfg.user} -g ${cfg.group} ${cfg.dataDir}/attach
+        install -d -m 0750 -o ${cfg.user} -g ${cfg.group} ${cfg.dataDir}/plugin
+      '';
+      serviceConfig.RestartSec = "10s";
+    };
+  };
 }

--- a/modules/nixos/services/bichon/default.nix
+++ b/modules/nixos/services/bichon/default.nix
@@ -1,3 +1,5 @@
+# modules/nixos/services/bichon/default.nix
+#
 # Bichon - Self-hosted email archiving system
 # https://github.com/rustmailer/bichon
 #
@@ -13,6 +15,7 @@
 # The built-in access token auth is single-user only (root), so we skip it
 # and use PocketID SSO at the reverse proxy layer instead.
 #
+# Factory-based implementation (see lib/service-factory.nix).
 { lib
 , mylib
 , pkgs
@@ -20,62 +23,62 @@
 , podmanLib
 , ...
 }:
+
 let
-  sharedTypes = mylib.types;
-  # Storage helpers via mylib injection (centralized import)
-  storageHelpers = mylib.storageHelpers pkgs;
-
-  cfg = config.modules.services.bichon;
-  notificationsCfg = config.modules.notifications;
-  storageCfg = config.modules.storage;
-  hasCentralizedNotifications = notificationsCfg.enable or false;
-
-  serviceName = "bichon";
-  bichonPort = 15630;
-  mainServiceUnit = "${config.virtualisation.oci-containers.backend}-${serviceName}.service";
-  datasetPath = "${storageCfg.datasets.parentDataset}/${serviceName}";
-
   domain = config.networking.domain or "local";
   defaultHostname = "bichon.${domain}";
-
-  # Build replication config for preseed (walks up dataset tree to find inherited config)
-  replicationConfig = storageHelpers.mkReplicationConfig { inherit config datasetPath; };
-  allowEmptyBootstrap = storageHelpers.allowEmptyBootstrapFor {
-    inherit config;
-    datasetName = serviceName;
-  };
 in
-{
-  options.modules.services.bichon = {
-    enable = lib.mkEnableOption "Bichon email archiving system";
+mylib.mkContainerService {
+  inherit lib mylib pkgs config podmanLib;
 
-    dataDir = lib.mkOption {
-      type = lib.types.path;
-      default = "/var/lib/bichon";
-      description = "Path to Bichon data directory (metadata, indexes, and EML storage)";
+  name = "bichon";
+  description = "Bichon";
+
+  spec = {
+    # Core service configuration
+    port = 15630;
+    # Renovate: datasource=docker depName=rustmailer/bichon
+    image = "rustmailer/bichon:0.1.4@sha256:eb09da0f018ad6b0129e5ff320dab64838e75761bad5a249f5e4191e44ab7697";
+    operationalProfile = "productivity";
+    displayName = "Bichon";
+    function = "email_archiving";
+
+    # Health check using Bichon's status endpoint
+    healthCommand = "curl -fs http://127.0.0.1:15630/api/status || exit 1";
+
+    # ZFS tuning - optimal for SQLite metadata and Tantivy index; zstd
+    # compresses email storage well.
+    zfsRecordSize = "16K";
+
+    resources = {
+      memory = "512M";
+      memoryReservation = "256M";
+      cpus = "1.0";
     };
 
+    # The bichon user was deployed with a dynamic UID/GID; the container runs
+    # as its image-internal user, so no --user flag is passed (see extraConfig
+    # below where the PUID/PGID injection is neutralized).
+    runAsRoot = true;
+
+    # LoadCredential provides the encryption password securely; the preStart
+    # script creates this env file from the credential.
+    environmentFiles = [ "/run/bichon/env" ];
+
+    # Data lives at /data, not /config
+    skipDefaultConfigMount = true;
+    volumes = cfg: [
+      "${cfg.dataDir}:/data:rw"
+    ];
+  };
+
+  extraOptions = {
+    # The bichon system user pre-dates the UID registry and is deployed with
+    # a dynamically allocated UID - keep ownership operations name-based.
     user = lib.mkOption {
       type = lib.types.str;
       default = "bichon";
       description = "User account under which Bichon runs.";
-    };
-
-    group = lib.mkOption {
-      type = lib.types.str;
-      default = "bichon";
-      description = "Group under which Bichon runs.";
-    };
-
-    image = lib.mkOption {
-      type = lib.types.str;
-      # Renovate: datasource=docker depName=rustmailer/bichon
-      default = "rustmailer/bichon:0.1.4@sha256:eb09da0f018ad6b0129e5ff320dab64838e75761bad5a249f5e4191e44ab7697";
-      description = ''
-        Full container image name including tag and digest.
-        Note: GHCR not available, using Docker Hub.
-      '';
-      example = "rustmailer/bichon:0.1.5@sha256:...";
     };
 
     encryptPasswordFile = lib.mkOption {
@@ -105,24 +108,9 @@ in
       description = "Bichon log verbosity level.";
     };
 
-    timezone = lib.mkOption {
-      type = lib.types.str;
-      default = "America/New_York";
-      description = "Timezone for the container";
-    };
-
-    resources = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.containerResourcesSubmodule;
-      default = {
-        memory = "512M";
-        memoryReservation = "256M";
-        cpus = "1.0";
-      };
-      description = "Resource limits for the container";
-    };
-
+    # Bichon's healthcheck uses a tighter timeout than the factory default.
     healthcheck = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.healthcheckSubmodule;
+      type = lib.types.nullOr mylib.types.healthcheckSubmodule;
       default = {
         enable = true;
         interval = "30s";
@@ -133,247 +121,83 @@ in
       description = "Container health check configuration";
     };
 
-    # Standardized reverse proxy integration
-    reverseProxy = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.reverseProxySubmodule;
-      default = null;
-      description = "Reverse proxy configuration for Bichon web interface";
-    };
-
-    # Standardized logging integration
-    logging = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.loggingSubmodule;
-      default = {
-        enable = true;
-        journalUnit = mainServiceUnit;
-        labels = {
-          service = serviceName;
-          service_type = "email";
-        };
-      };
-      description = "Log shipping configuration for Bichon logs";
-    };
-
-    # Standardized backup integration
+    # Backups are configured explicitly by hosts (overrides the factory
+    # default of enabled).
     backup = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.backupSubmodule;
+      type = lib.types.nullOr mylib.types.backupSubmodule;
       default = null;
       description = "Backup configuration for Bichon data";
     };
 
-    # Standardized notifications
-    notifications = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.notificationSubmodule;
-      default = {
-        enable = true;
-        channels = {
-          onFailure = [ "service-alerts" ];
-        };
-        customMessages = {
-          failure = "Bichon email archiving service failed on ${config.networking.hostName}";
-        };
-      };
-      description = "Notification configuration for Bichon service events";
-    };
-
-    preseed = {
-      enable = lib.mkEnableOption "automatic data restore before service start";
-      repositoryUrl = lib.mkOption {
-        type = lib.types.str;
-        default = "";
-        description = "Restic repository URL for restore operations";
-      };
-      passwordFile = lib.mkOption {
-        type = lib.types.path;
-        default = "/dev/null";
-        description = "Path to Restic password file";
-      };
-      environmentFile = lib.mkOption {
-        type = lib.types.nullOr lib.types.path;
-        default = null;
-        description = "Optional environment file for Restic (e.g., for B2 credentials)";
-      };
-      restoreMethods = lib.mkOption {
-        type = lib.types.listOf (lib.types.enum [ "syncoid" "local" "restic" ]);
-        default = [ "syncoid" "local" ];
-        description = ''
-          Order and selection of restore methods to attempt.
-          Note: restic intentionally excluded from defaults - offsite restore
-          is a manual DR decision when syncoid/local sources are unavailable.
-        '';
-      };
+    # Bichon exposes no Prometheus metrics endpoint - keep metrics opt-in.
+    metrics = lib.mkOption {
+      type = lib.types.nullOr mylib.types.metricsSubmodule;
+      default = null;
+      description = "Prometheus metrics collection configuration (Bichon has no native metrics)";
     };
   };
 
-  config = lib.mkMerge [
-    (lib.mkIf cfg.enable {
-      # Assertions
-      assertions = [
-        {
-          assertion = cfg.backup == null || !cfg.backup.enable || cfg.backup.repository != null;
-          message = "Bichon backup.enable requires backup.repository to be set.";
-        }
+  extraConfig = cfg: {
+    # Preserve the dynamically allocated UID/GID of the deployed user - the
+    # factory would otherwise pin them from the UID registry, breaking
+    # ownership of existing data.
+    users.users.bichon.uid = lib.mkForce null;
+    users.groups.bichon.gid = lib.mkForce null;
+
+    # The container runs as its image-internal user; drop the PUID/PGID/UMASK
+    # variables that the factory injects for runAsRoot containers.
+    virtualisation.oci-containers.containers.bichon = {
+      environment = lib.mkForce {
+        TZ = cfg.timezone;
+        # Core configuration
+        BICHON_ROOT_DIR = "/data";
+        BICHON_HTTP_PORT = toString cfg.port;
+        BICHON_BIND_ADDR = "0.0.0.0";
+        BICHON_PUBLIC_URL = cfg.publicUrl;
+        BICHON_LOG_LEVEL = cfg.logLevel;
+        # Disable access token auth - we use caddySecurity SSO instead
+        BICHON_ENABLE_ACCESS_TOKEN = "false";
+        # Disable ANSI logs for cleaner journal output
+        BICHON_ANSI_LOGS = "false";
+      };
+      # Only bind to localhost - external access goes through the reverse proxy.
+      ports = lib.mkForce [
+        "127.0.0.1:${toString cfg.port}:${toString cfg.port}"
       ];
+    };
 
-      # Create system user and group
-      users.users.${cfg.user} = {
-        isSystemUser = true;
-        group = cfg.group;
-        description = "Bichon email archiving service user";
-        home = "/var/empty";
-      };
-
-      users.groups.${cfg.group} = { };
-
-      # Declare dataset requirements for ZFS isolation
-      # OCI containers don't support StateDirectory, so we explicitly set permissions
-      modules.storage.datasets.services.${serviceName} = {
-        mountpoint = cfg.dataDir;
-        recordsize = "16K"; # Optimal for SQLite metadata and Tantivy index
-        compression = "zstd"; # Good compression for email storage
-        properties = {
-          "com.sun:auto-snapshot" = "true";
-        };
-        owner = cfg.user;
-        group = cfg.group;
-        mode = "0750";
-      };
-
-      # Container configuration
-      virtualisation.oci-containers.containers.${serviceName} = podmanLib.mkContainer serviceName {
-        image = cfg.image;
-        environmentFiles = [
-          # LoadCredential provides the encryption password securely
-          # The preStart script creates an env file from the credential
-          "/run/${serviceName}/env"
-        ];
-        environment = {
-          TZ = cfg.timezone;
-          # Core configuration
-          BICHON_ROOT_DIR = "/data";
-          BICHON_HTTP_PORT = toString bichonPort;
-          BICHON_BIND_ADDR = "0.0.0.0";
-          BICHON_PUBLIC_URL = cfg.publicUrl;
-          BICHON_LOG_LEVEL = cfg.logLevel;
-          # Disable access token auth - we use caddySecurity SSO instead
-          BICHON_ENABLE_ACCESS_TOKEN = "false";
-          # Disable ANSI logs for cleaner journal output
-          BICHON_ANSI_LOGS = "false";
-        };
-        volumes = [
-          "${cfg.dataDir}:/data:rw"
-        ];
-        ports = [
-          "127.0.0.1:${toString bichonPort}:${toString bichonPort}"
-        ];
-        resources = cfg.resources;
-        extraOptions = [
-          "--pull=newer"
-          "--umask=0027"
-        ] ++ lib.optionals (cfg.healthcheck != null && cfg.healthcheck.enable) [
-          # Health check using Bichon's status endpoint
-          ''--health-cmd=curl -fs http://127.0.0.1:${toString bichonPort}/api/status || exit 1''
-          "--health-interval=${cfg.healthcheck.interval}"
-          "--health-timeout=${cfg.healthcheck.timeout}"
-          "--health-retries=${toString cfg.healthcheck.retries}"
-          "--health-start-period=${cfg.healthcheck.startPeriod}"
-          "--health-on-failure=${cfg.healthcheck.onFailure}"
-        ];
-      };
-
-      # Systemd service configuration
-      systemd.services."${config.virtualisation.oci-containers.backend}-${serviceName}" = lib.mkMerge [
-        {
-          # Securely load the encryption password and create env file
-          serviceConfig = {
-            LoadCredential = [
-              "encrypt_password:${cfg.encryptPasswordFile}"
-            ];
-          };
-          preStart = ''
-            # Create runtime directory
-            install -d -m 700 /run/${serviceName}
-            # Create env file with encryption password from credential
-            {
-              printf "BICHON_ENCRYPT_PASSWORD=%s\n" "$(cat "$CREDENTIALS_DIRECTORY/encrypt_password")"
-            } > /run/${serviceName}/env
-            chmod 600 /run/${serviceName}/env
-          '';
-        }
-        # Add failure notifications via systemd
-        (lib.mkIf (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
-          unitConfig.OnFailure = [ "notify@${serviceName}-failure:%n.service" ];
-        })
-        # Add dependency on the preseed service
-        (lib.mkIf cfg.preseed.enable {
-          requires = lib.optional (!allowEmptyBootstrap) "preseed-${serviceName}.service";
-          wants = lib.optional allowEmptyBootstrap "preseed-${serviceName}.service";
-          after = [ "preseed-${serviceName}.service" ];
-        })
+    # Securely load the encryption password and create the env file consumed
+    # by the container.
+    systemd.services."${config.virtualisation.oci-containers.backend}-bichon" = {
+      serviceConfig.LoadCredential = [
+        "encrypt_password:${cfg.encryptPasswordFile}"
       ];
+      preStart = ''
+        # Create runtime directory
+        install -d -m 700 /run/bichon
+        # Create env file with encryption password from credential
+        {
+          printf "BICHON_ENCRYPT_PASSWORD=%s\n" "$(cat "$CREDENTIALS_DIRECTORY/encrypt_password")"
+        } > /run/bichon/env
+        chmod 600 /run/bichon/env
+      '';
+    };
 
-      # Automatically register with Caddy reverse proxy if enabled
-      modules.services.caddy.virtualHosts.${serviceName} = lib.mkIf (cfg.reverseProxy != null && cfg.reverseProxy.enable) {
-        enable = true;
-        hostName = cfg.reverseProxy.hostName;
+    # Preserve the pre-factory notification wording
+    modules.notifications.templates."bichon-failure" =
+      lib.mkIf (config.modules.notifications.enable or false && cfg.notifications != null && cfg.notifications.enable) {
+        body = ''
+          <b>Host:</b> ''${hostname}
+          <b>Service:</b> <code>''${serviceName}</code>
 
-        backend = {
-          scheme = "http";
-          host = "127.0.0.1";
-          port = bichonPort;
-        };
+          The Bichon email archiving service has entered a failed state.
 
-        auth = cfg.reverseProxy.auth;
-        caddySecurity = cfg.reverseProxy.caddySecurity;
-        security = cfg.reverseProxy.security;
-        extraConfig = cfg.reverseProxy.extraConfig;
+          <b>Quick Actions:</b>
+          1. Check logs:
+             <code>ssh ''${hostname} 'journalctl -u ''${serviceName} -n 100'</code>
+          2. Restart service:
+             <code>ssh ''${hostname} 'systemctl restart ''${serviceName}'</code>
+        '';
       };
-
-      # Register notification template
-      modules.notifications.templates = lib.mkIf (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
-        "${serviceName}-failure" = {
-          enable = lib.mkDefault true;
-          priority = lib.mkDefault "high";
-          title = lib.mkDefault ''<b><font color="red">✗ Service Failed: Bichon</font></b>'';
-          body = lib.mkDefault ''
-            <b>Host:</b> ''${hostname}
-            <b>Service:</b> <code>''${serviceName}</code>
-
-            The Bichon email archiving service has entered a failed state.
-
-            <b>Quick Actions:</b>
-            1. Check logs:
-               <code>ssh ''${hostname} 'journalctl -u ''${serviceName} -n 100'</code>
-            2. Restart service:
-               <code>ssh ''${hostname} 'systemctl restart ''${serviceName}'</code>
-          '';
-        };
-      };
-    })
-
-    # Preseed service for disaster recovery
-    (lib.mkIf (cfg.enable && cfg.preseed.enable) (
-      storageHelpers.mkPreseedService {
-        inherit serviceName;
-        dataset = datasetPath;
-        mountpoint = cfg.dataDir;
-        inherit mainServiceUnit;
-        replicationCfg = replicationConfig;
-        datasetProperties = {
-          recordsize = "16K";
-          compression = "zstd";
-          "com.sun:auto-snapshot" = "true";
-        };
-        resticRepoUrl = cfg.preseed.repositoryUrl;
-        resticPasswordFile = cfg.preseed.passwordFile;
-        resticEnvironmentFile = cfg.preseed.environmentFile;
-        resticPaths = [ cfg.dataDir ];
-        restoreMethods = cfg.preseed.restoreMethods;
-        inherit hasCentralizedNotifications;
-        inherit allowEmptyBootstrap;
-        owner = cfg.user;
-        group = cfg.group;
-      }
-    ))
-  ];
+  };
 }

--- a/modules/nixos/services/enclosed/default.nix
+++ b/modules/nixos/services/enclosed/default.nix
@@ -1,3 +1,5 @@
+# modules/nixos/services/enclosed/default.nix
+#
 # Enclosed - Self-hostable encrypted note sharing
 # https://enclosed.cc / https://github.com/CorentinTh/enclosed
 #
@@ -10,6 +12,7 @@
 # Data: /app/.data (SQLite database + encrypted attachments)
 # Security: Client-side AES-GCM encryption - server never sees plaintext
 #
+# Factory-based implementation (see lib/service-factory.nix).
 { lib
 , mylib
 , pkgs
@@ -17,60 +20,53 @@
 , podmanLib
 , ...
 }:
-let
-  sharedTypes = mylib.types;
-  # Storage helpers via mylib injection (centralized import)
-  storageHelpers = mylib.storageHelpers pkgs;
 
-  cfg = config.modules.services.enclosed;
-  notificationsCfg = config.modules.notifications;
-  storageCfg = config.modules.storage;
-  hasCentralizedNotifications = notificationsCfg.enable or false;
+mylib.mkContainerService {
+  inherit lib mylib pkgs config podmanLib;
 
-  serviceName = "enclosed";
-  enclosedPort = 8787;
-  mainServiceUnit = "${config.virtualisation.oci-containers.backend}-${serviceName}.service";
-  datasetPath = "${storageCfg.datasets.parentDataset}/${serviceName}";
+  name = "enclosed";
+  description = "Enclosed";
 
-  # Build replication config for preseed (walks up dataset tree to find inherited config)
-  replicationConfig = storageHelpers.mkReplicationConfig { inherit config datasetPath; };
-in
-{
-  options.modules.services.enclosed = {
-    enable = lib.mkEnableOption "Enclosed encrypted note sharing service";
+  spec = {
+    # Core service configuration
+    port = 8787;
+    image = "ghcr.io/corentinth/enclosed:1.9.2@sha256:be7576d6d1074698bb572162eaa5fdefaabfb1b70bcb4a936d1f46ab07051285";
+    operationalProfile = "productivity";
+    displayName = "Enclosed";
+    function = "note_sharing";
 
-    dataDir = lib.mkOption {
-      type = lib.types.path;
-      default = "/var/lib/enclosed";
-      description = "Path to Enclosed data directory (maps to /app/.data in container)";
+    healthCommand = "wget --no-verbose --spider http://127.0.0.1:8787/ || exit 1";
+    startPeriod = "30s";
+
+    # ZFS tuning - optimal for small encrypted files and SQLite
+    zfsRecordSize = "16K";
+
+    # Enclosed is very lightweight
+    resources = {
+      memory = "256M";
+      memoryReservation = "128M";
+      cpus = "0.5";
     };
 
+    # The enclosed user was deployed with a dynamic UID/GID; the container
+    # runs as its image-internal user, so no --user flag is passed (see
+    # extraConfig below where the PUID/PGID injection is neutralized).
+    runAsRoot = true;
+
+    # Data lives at /app/.data, not /config
+    skipDefaultConfigMount = true;
+    volumes = cfg: [
+      "${cfg.dataDir}:/app/.data:rw"
+    ];
+  };
+
+  extraOptions = {
+    # The enclosed system user pre-dates the UID registry and is deployed
+    # with a dynamically allocated UID - keep ownership operations name-based.
     user = lib.mkOption {
       type = lib.types.str;
       default = "enclosed";
       description = "User account under which Enclosed runs.";
-    };
-
-    group = lib.mkOption {
-      type = lib.types.str;
-      default = "enclosed";
-      description = "Group under which Enclosed runs.";
-    };
-
-    image = lib.mkOption {
-      type = lib.types.str;
-      default = "ghcr.io/corentinth/enclosed:1.9.2@sha256:be7576d6d1074698bb572162eaa5fdefaabfb1b70bcb4a936d1f46ab07051285";
-      description = ''
-        Full container image name including tag and digest.
-        Use Renovate bot to automate version updates with digest pinning.
-      '';
-      example = "ghcr.io/corentinth/enclosed:1.9.2@sha256:...";
-    };
-
-    timezone = lib.mkOption {
-      type = lib.types.str;
-      default = "America/New_York";
-      description = "Timezone for the container";
     };
 
     maxPayloadSize = lib.mkOption {
@@ -127,245 +123,69 @@ in
       };
     };
 
-    resources = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.containerResourcesSubmodule;
-      default = {
-        memory = "256M";
-        memoryReservation = "128M";
-        cpus = "0.5";
-      };
-      description = "Resource limits for the container (Enclosed is very lightweight)";
-    };
-
-    healthcheck = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.healthcheckSubmodule;
-      default = {
-        enable = true;
-        interval = "30s";
-        timeout = "10s";
-        retries = 3;
-        startPeriod = "30s";
-      };
-      description = "Container health check configuration";
-    };
-
-    # Standardized reverse proxy integration
-    reverseProxy = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.reverseProxySubmodule;
-      default = null;
-      description = "Reverse proxy configuration for Enclosed web interface";
-    };
-
-    # Standardized logging integration
-    logging = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.loggingSubmodule;
-      default = {
-        enable = true;
-        journalUnit = mainServiceUnit;
-        labels = {
-          service = serviceName;
-          service_type = "notes";
-        };
-      };
-      description = "Log shipping configuration for Enclosed logs";
-    };
-
-    # Standardized backup integration
+    # Encrypted notes are short-lived or self-destructing by design - no
+    # backups (overrides the factory default of enabled).
     backup = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.backupSubmodule;
+      type = lib.types.nullOr mylib.types.backupSubmodule;
       default = null;
       description = "Backup configuration for Enclosed data";
     };
 
-    # Standardized notifications
-    notifications = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.notificationSubmodule;
-      default = {
-        enable = true;
-        channels = {
-          onFailure = [ "service-alerts" ];
-        };
-        customMessages = {
-          failure = "Enclosed note sharing service failed on ${config.networking.hostName}";
-        };
-      };
-      description = "Notification configuration for Enclosed service events";
-    };
-
-    preseed = {
-      enable = lib.mkEnableOption "automatic data restore before service start";
-      repositoryUrl = lib.mkOption {
-        type = lib.types.str;
-        default = "";
-        description = "Restic repository URL for restore operations";
-      };
-      passwordFile = lib.mkOption {
-        type = lib.types.path;
-        default = "/dev/null";
-        description = "Path to Restic password file";
-      };
-      environmentFile = lib.mkOption {
-        type = lib.types.nullOr lib.types.path;
-        default = null;
-        description = "Optional environment file for Restic (e.g., for B2 credentials)";
-      };
-      restoreMethods = lib.mkOption {
-        type = lib.types.listOf (lib.types.enum [ "syncoid" "local" "restic" ]);
-        default = [ "syncoid" "local" ];
-        description = ''
-          Order and selection of restore methods to attempt.
-          Note: restic intentionally excluded from defaults - offsite restore
-          is a manual DR decision when syncoid/local sources are unavailable.
-        '';
-      };
+    # Enclosed exposes no Prometheus metrics endpoint - keep metrics opt-in.
+    metrics = lib.mkOption {
+      type = lib.types.nullOr mylib.types.metricsSubmodule;
+      default = null;
+      description = "Prometheus metrics collection configuration (Enclosed has no native metrics)";
     };
   };
 
-  config = lib.mkMerge [
-    (lib.mkIf cfg.enable {
-      # Assertions
-      assertions = [
-        {
-          assertion = cfg.backup == null || !cfg.backup.enable || cfg.backup.repository != null;
-          message = "Enclosed backup.enable requires backup.repository to be set.";
-        }
+  extraConfig = cfg: {
+    # Preserve the dynamically allocated UID/GID of the deployed user - the
+    # factory would otherwise pin them from the UID registry, breaking
+    # ownership of existing data.
+    users.users.enclosed.uid = lib.mkForce null;
+    users.groups.enclosed.gid = lib.mkForce null;
+
+    # The container runs as its image-internal user; drop the PUID/PGID/UMASK
+    # variables that the factory injects for runAsRoot containers.
+    virtualisation.oci-containers.containers.enclosed = {
+      environment = lib.mkForce {
+        TZ = cfg.timezone;
+        # Size limits
+        NOTES_MAX_ENCRYPTED_PAYLOAD_LENGTH = toString cfg.maxPayloadSize;
+        # UX defaults for note creation
+        PUBLIC_DEFAULT_NOTE_TTL_SECONDS = toString cfg.settings.defaultTtlSeconds;
+        PUBLIC_DEFAULT_DELETE_NOTE_AFTER_READING = lib.boolToString cfg.settings.defaultDeleteAfterReading;
+        PUBLIC_IS_SETTING_NO_EXPIRATION_ALLOWED = lib.boolToString cfg.settings.allowNoExpiration;
+      };
+      # Only bind to localhost - external access goes through the reverse proxy.
+      ports = lib.mkForce [
+        "127.0.0.1:${toString cfg.port}:8787"
       ];
+    };
 
-      # Create system user and group
-      users.users.${cfg.user} = {
-        isSystemUser = true;
-        group = cfg.group;
-        description = "Enclosed service user";
-        home = "/var/empty";
+    # ZFS quota provides hard limit against abuse
+    modules.storage.datasets.services.enclosed.properties = {
+      "com.sun:auto-snapshot" = "true";
+    } // lib.optionalAttrs (cfg.storageQuota != null) {
+      quota = cfg.storageQuota;
+    };
+
+    # Preserve the pre-factory notification wording
+    modules.notifications.templates."enclosed-failure" =
+      lib.mkIf (config.modules.notifications.enable or false && cfg.notifications != null && cfg.notifications.enable) {
+        body = ''
+          <b>Host:</b> ''${hostname}
+          <b>Service:</b> <code>''${serviceName}</code>
+
+          The Enclosed note sharing service has entered a failed state.
+
+          <b>Quick Actions:</b>
+          1. Check logs:
+             <code>ssh ''${hostname} 'journalctl -u ''${serviceName} -n 100'</code>
+          2. Restart service:
+             <code>ssh ''${hostname} 'systemctl restart ''${serviceName}'</code>
+        '';
       };
-
-      users.groups.${cfg.group} = { };
-
-      # Declare dataset requirements for ZFS isolation
-      # OCI containers don't support StateDirectory, so we explicitly set permissions
-      modules.storage.datasets.services.${serviceName} = {
-        mountpoint = cfg.dataDir;
-        recordsize = "16K"; # Optimal for small encrypted files and SQLite
-        compression = "zstd"; # Good compression for encrypted data
-        properties = {
-          "com.sun:auto-snapshot" = "true";
-        } // lib.optionalAttrs (cfg.storageQuota != null) {
-          # ZFS quota provides hard limit against abuse
-          quota = cfg.storageQuota;
-        };
-        owner = cfg.user;
-        group = cfg.group;
-        mode = "0750";
-      };
-
-      # Container configuration
-      virtualisation.oci-containers.containers.${serviceName} = podmanLib.mkContainer serviceName {
-        image = cfg.image;
-        environment = {
-          TZ = cfg.timezone;
-          # Size limits
-          NOTES_MAX_ENCRYPTED_PAYLOAD_LENGTH = toString cfg.maxPayloadSize;
-          # UX defaults for note creation
-          PUBLIC_DEFAULT_NOTE_TTL_SECONDS = toString cfg.settings.defaultTtlSeconds;
-          PUBLIC_DEFAULT_DELETE_NOTE_AFTER_READING = lib.boolToString cfg.settings.defaultDeleteAfterReading;
-          PUBLIC_IS_SETTING_NO_EXPIRATION_ALLOWED = lib.boolToString cfg.settings.allowNoExpiration;
-        };
-        volumes = [
-          "${cfg.dataDir}:/app/.data:rw"
-        ];
-        ports = [
-          "127.0.0.1:${toString enclosedPort}:8787"
-        ];
-        resources = cfg.resources;
-        extraOptions = [
-          "--pull=newer"
-          "--umask=0027"
-        ] ++ lib.optionals (cfg.healthcheck != null && cfg.healthcheck.enable) [
-          # Simple HTTP health check
-          ''--health-cmd=wget --no-verbose --spider http://127.0.0.1:8787/ || exit 1''
-          "--health-interval=${cfg.healthcheck.interval}"
-          "--health-timeout=${cfg.healthcheck.timeout}"
-          "--health-retries=${toString cfg.healthcheck.retries}"
-          "--health-start-period=${cfg.healthcheck.startPeriod}"
-          "--health-on-failure=${cfg.healthcheck.onFailure}"
-        ];
-      };
-
-      # Systemd service configuration
-      systemd.services."${config.virtualisation.oci-containers.backend}-${serviceName}" = lib.mkMerge [
-        # Add failure notifications via systemd
-        (lib.mkIf (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
-          unitConfig.OnFailure = [ "notify@${serviceName}-failure:%n.service" ];
-        })
-        # Add dependency on the preseed service
-        (lib.mkIf cfg.preseed.enable {
-          wants = [ "preseed-${serviceName}.service" ];
-          after = [ "preseed-${serviceName}.service" ];
-        })
-      ];
-
-
-      # Automatically register with Caddy reverse proxy if enabled
-      modules.services.caddy.virtualHosts.${serviceName} = lib.mkIf (cfg.reverseProxy != null && cfg.reverseProxy.enable) {
-        enable = true;
-        hostName = cfg.reverseProxy.hostName;
-
-        backend = {
-          scheme = "http";
-          host = "127.0.0.1";
-          port = enclosedPort;
-        };
-
-        auth = cfg.reverseProxy.auth;
-        caddySecurity = cfg.reverseProxy.caddySecurity;
-        security = cfg.reverseProxy.security;
-        extraConfig = cfg.reverseProxy.extraConfig;
-      };
-
-      # Register notification template
-      modules.notifications.templates = lib.mkIf (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
-        "${serviceName}-failure" = {
-          enable = lib.mkDefault true;
-          priority = lib.mkDefault "high";
-          title = lib.mkDefault ''<b><font color="red">✗ Service Failed: Enclosed</font></b>'';
-          body = lib.mkDefault ''
-            <b>Host:</b> ''${hostname}
-            <b>Service:</b> <code>''${serviceName}</code>
-
-            The Enclosed note sharing service has entered a failed state.
-
-            <b>Quick Actions:</b>
-            1. Check logs:
-               <code>ssh ''${hostname} 'journalctl -u ''${serviceName} -n 100'</code>
-            2. Restart service:
-               <code>ssh ''${hostname} 'systemctl restart ''${serviceName}'</code>
-          '';
-        };
-      };
-    })
-
-    # Preseed service for disaster recovery
-    (lib.mkIf (cfg.enable && cfg.preseed.enable) (
-      storageHelpers.mkPreseedService {
-        inherit serviceName;
-        dataset = datasetPath;
-        mountpoint = cfg.dataDir;
-        inherit mainServiceUnit;
-        replicationCfg = replicationConfig;
-        datasetProperties = {
-          recordsize = "16K";
-          compression = "zstd";
-          "com.sun:auto-snapshot" = "true";
-        };
-        resticRepoUrl = cfg.preseed.repositoryUrl;
-        resticPasswordFile = cfg.preseed.passwordFile;
-        resticEnvironmentFile = cfg.preseed.environmentFile;
-        resticPaths = [ cfg.dataDir ];
-        restoreMethods = cfg.preseed.restoreMethods;
-        inherit hasCentralizedNotifications;
-        owner = cfg.user;
-        group = cfg.group;
-      }
-    ))
-  ];
+  };
 }

--- a/modules/nixos/services/esphome/default.nix
+++ b/modules/nixos/services/esphome/default.nix
@@ -1,42 +1,69 @@
-{ lib, mylib, pkgs, config, podmanLib, ... }:
+# modules/nixos/services/esphome/default.nix
+#
+# ESPHome dashboard - firmware management for ESP devices
+#
+# Runs with host networking by default to enable ICMP-based online status
+# and mDNS discovery of devices.
+#
+# Factory-based implementation (see lib/service-factory.nix).
+{ lib
+, mylib
+, pkgs
+, config
+, podmanLib
+, ...
+}:
 
 let
-  sharedTypes = mylib.types;
-  # Storage helpers via mylib injection (centralized import)
-  storageHelpers = mylib.storageHelpers pkgs;
-  # Import service UIDs from centralized registry
-  serviceIds = mylib.serviceUids.esphome;
-
-  cfg = config.modules.services.esphome;
-  storageCfg = config.modules.storage;
-  notificationsCfg = config.modules.notifications;
-
-  hasCentralizedNotifications = notificationsCfg.enable or false;
-  serviceName = "esphome";
-  backend = config.virtualisation.oci-containers.backend;
-  mainServiceName = "${backend}-${serviceName}";
-  mainServiceUnit = "${mainServiceName}.service";
-  datasetPath = "${storageCfg.datasets.parentDataset}/${serviceName}";
-  esphomePort = cfg.port;
-
-  # Build replication config for preseed (walks up dataset tree to find inherited config)
-  replicationConfig = storageHelpers.mkReplicationConfig { inherit config datasetPath; };
-  allowEmptyBootstrap = storageHelpers.allowEmptyBootstrapFor {
-    inherit config;
-    datasetName = serviceName;
-  };
-
+  # Resolved lazily after option evaluation - safe to reference here.
+  esphomePort = config.modules.services.esphome.port;
+  mainServiceUnit = "${config.virtualisation.oci-containers.backend}-esphome.service";
 in
-{
-  options.modules.services.esphome = {
-    enable = lib.mkEnableOption "ESPHome dashboard container";
+mylib.mkContainerService {
+  inherit lib mylib pkgs config podmanLib;
 
-    dataDir = lib.mkOption {
-      type = lib.types.path;
-      default = "/var/lib/esphome";
-      description = "Persistent configuration directory mounted at /config inside the container.";
+  name = "esphome";
+  description = "ESPHome";
+
+  spec = {
+    # Core service configuration
+    port = 6052;
+    image = "ghcr.io/home-operations/esphome:2025.12.3@sha256:d000147ad5598dbcabe59be0426b0b52b095d7f51b5e2a97addf68072218581f";
+    operationalProfile = "home-automation";
+    displayName = "ESPHome";
+    function = "esp_firmware";
+
+    # Match upstream: curl --fail http://localhost:6052/version -A "HealthCheck"
+    healthCommand = "curl --fail --silent http://127.0.0.1:${toString esphomePort}/version -A HealthCheck || exit 1";
+
+    # Mix of YAML configs and compiled firmware blobs
+    zfsRecordSize = "128K";
+
+    # ESPHome firmware compilation is VERY memory-intensive!
+    # PlatformIO/ESP-IDF compilation can easily consume 4-6GB during builds.
+    # Idle usage is ~50MB but need 4GB+ headroom for compilation spikes.
+    # See: https://github.com/esphome/issues/issues/3488
+    resources = {
+      memory = "6G";
+      memoryReservation = "512M";
+      cpus = "4.0"; # Parallel compilation benefits from multiple cores
     };
 
+    environment = { cfg, ... }: {
+      ESPHOME_DASHBOARD_USE_PING = if cfg.hostNetwork then "true" else "false";
+    };
+
+    # /config comes from the factory's default dataDir mount
+    volumes = cfg: [
+      "${cfg.cacheDir}:/cache:rw"
+      "/etc/localtime:/etc/localtime:ro"
+    ];
+
+    extraOptions = { cfg, ... }:
+      lib.optionals cfg.hostNetwork [ "--network=host" ];
+  };
+
+  extraOptions = {
     cacheDir = lib.mkOption {
       type = lib.types.path;
       default = "/var/cache/esphome";
@@ -58,105 +85,36 @@ in
       description = "Path to a decrypted secrets.yaml file (usually managed by sops) that should be materialized inside the ESPHome data directory.";
     };
 
-    port = lib.mkOption {
-      type = lib.types.port;
-      default = 6052;
-      description = "Local HTTP port used by the ESPHome dashboard.";
-    };
-
-    user = lib.mkOption {
-      type = lib.types.str;
-      default = "esphome";
-      description = "System user to run ESPHome service.";
-    };
-
-    uid = lib.mkOption {
-      type = lib.types.int;
-      default = serviceIds.uid;
-      description = "Static UID for the ESPHome user (from lib/service-uids.nix).";
-    };
-
-    group = lib.mkOption {
-      type = lib.types.str;
-      default = "esphome";
-      description = "System group to run ESPHome service.";
-    };
-
-    gid = lib.mkOption {
-      type = lib.types.int;
-      default = serviceIds.gid;
-      description = "Static GID for the ESPHome group (from lib/service-uids.nix).";
-    };
-
-    image = lib.mkOption {
-      type = lib.types.str;
-      default = "ghcr.io/home-operations/esphome:2025.12.3@sha256:d000147ad5598dbcabe59be0426b0b52b095d7f51b5e2a97addf68072218581f";
-      description = ''
-        Container image for ESPHome (home-operations).
-        Pin to specific version with digest for immutability.
-        Use Renovate bot to automate version updates.
-      '';
-    };
-
-    timezone = lib.mkOption {
-      type = lib.types.str;
-      default = config.time.timeZone or "UTC";
-      description = "Timezone passed through to the container.";
-    };
-
     hostNetwork = lib.mkOption {
       type = lib.types.bool;
       default = true;
       description = "Use host networking to enable ICMP-based online status and mDNS discovery.";
     };
 
-    podmanNetwork = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
-      description = "Optional Podman network name when not using host networking.";
-    };
-
-    resources = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.containerResourcesSubmodule;
-      default = {
-        # ESPHome firmware compilation is VERY memory-intensive!
-        # PlatformIO/ESP-IDF compilation can easily consume 4-6GB during builds.
-        # Idle usage is ~50MB but need 4GB+ headroom for compilation spikes.
-        # See: https://github.com/esphome/issues/issues/3488
-        memory = "6G";
-        memoryReservation = "512M";
-        cpus = "4.0"; # Parallel compilation benefits from multiple cores
-      };
-      description = "Container resource limits. ESPHome compilation requires significant memory (4GB+ recommended).";
-    };
-
-    reverseProxy = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.reverseProxySubmodule;
-      default = null;
-      description = "Reverse proxy configuration for exposing the dashboard via Caddy.";
-    };
-
-    logging = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.loggingSubmodule;
+    # ESPHome healthchecks allow a generous timeout (firmware compiles can
+    # starve the dashboard) - overrides the factory defaults.
+    healthcheck = lib.mkOption {
+      type = lib.types.nullOr mylib.types.healthcheckSubmodule;
       default = {
         enable = true;
-        journalUnit = lib.mkDefault "${backend}-${serviceName}.service";
-        labels = {
-          service = serviceName;
-          service_type = "automation";
-        };
+        interval = "30s";
+        timeout = "30s";
+        retries = 3;
+        startPeriod = "1m";
       };
-      description = "Log shipping configuration for ESPHome.";
+      description = "Container health check configuration (matches upstream).";
     };
 
+    # ESPHome does not expose native metrics by default - keep metrics opt-in.
     metrics = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.metricsSubmodule;
+      type = lib.types.nullOr mylib.types.metricsSubmodule;
       default = null;
       description = "Optional Prometheus metrics scraper definition (ESPHome does not expose native metrics by default).";
     };
 
+    # Preserve the pre-factory backup defaults (firmware cache excluded).
     backup = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.backupSubmodule;
+      type = lib.types.nullOr mylib.types.backupSubmodule;
       default = {
         enable = true;
         repository = "nas-primary";
@@ -172,243 +130,78 @@ in
       };
       description = "Backup configuration using the unified backup system.";
     };
+  };
 
-    notifications = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.notificationSubmodule;
-      default = {
-        enable = true;
-        channels = {
-          onFailure = [ "automation-alerts" ];
+  extraConfig = cfg: {
+    assertions = [
+      {
+        assertion = !(cfg.hostNetwork && cfg.podmanNetwork != null);
+        message = "ESPHome cannot use hostNetwork and a custom Podman network simultaneously.";
+      }
+    ];
+
+    # Firmware builds create files as the container user; keep the dataset
+    # group-writable (the factory default is 0750).
+    modules.storage.datasets.services.esphome.mode = "0770";
+
+    # Ensure Podman-created subdirectories (e.g., .esphome cache) retain the
+    # expected ownership, and provide the build cache directory.
+    systemd.tmpfiles.rules = [
+      "Z ${cfg.dataDir} 0770 ${cfg.user} ${cfg.group} - -"
+      # Cache directory for PlatformIO builds (can grow large, excluded from backups)
+      "d ${cfg.cacheDir} 0770 ${cfg.user} ${cfg.group} - -"
+    ];
+
+    virtualisation.oci-containers.containers.esphome = {
+      # With host networking there is nothing to publish; the dashboard
+      # listens on the host directly.
+      ports = lib.mkForce (lib.optionals (!cfg.hostNetwork) [
+        "${toString cfg.port}:${toString cfg.port}"
+      ]);
+    };
+
+    systemd.services."${config.virtualisation.oci-containers.backend}-esphome" =
+      lib.mkIf (cfg.secretsFile != null) {
+        wants = [ "esphome-sync-secrets.service" ];
+        after = [ "esphome-sync-secrets.service" ];
+      };
+
+    # Preserve the pre-factory notification wording
+    modules.notifications.templates."esphome-failure" =
+      lib.mkIf (config.modules.notifications.enable or false && cfg.notifications != null && cfg.notifications.enable) {
+        title = "ESPHome dashboard failure";
+        body = "ESPHome on ${config.networking.hostName} requires attention.";
+      };
+
+    systemd.services."esphome-sync-secrets" = lib.mkIf (cfg.secretsFile != null) (
+      let
+        syncScript = pkgs.writeShellScript "esphome-sync-secrets" ''
+          set -euo pipefail
+          install -d -m 0750 -o esphome -g esphome ${cfg.dataDir}
+          install -m 0600 -o esphome -g esphome ${cfg.secretsFile} ${cfg.dataDir}/secrets.yaml
+          if ${pkgs.systemd}/bin/systemctl is-active --quiet ${mainServiceUnit}; then
+            ${pkgs.systemd}/bin/systemctl restart --no-block ${mainServiceUnit}
+          fi
+        '';
+      in
+      {
+        description = "Sync ESPHome secrets.yaml from sops";
+        before = [ mainServiceUnit ];
+        requiredBy = [ mainServiceUnit ];
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = syncScript;
         };
-        customMessages.failure = "ESPHome dashboard failed on ${config.networking.hostName}";
-      };
-      description = "Notification preferences for ESPHome failures.";
-    };
+      }
+    );
 
-    healthcheck = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.healthcheckSubmodule;
-      default = {
-        enable = true;
-        interval = "30s";
-        timeout = "30s";
-        retries = 3;
-        startPeriod = "1m";
-      };
-      description = "Container health check configuration (matches upstream).";
-    };
-
-    preseed = {
-      enable = lib.mkEnableOption "Automatic data restore prior to starting the container";
-      repositoryUrl = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = null;
-        description = "Restic repository URL used for preseeding.";
-      };
-      passwordFile = lib.mkOption {
-        type = lib.types.nullOr lib.types.path;
-        default = null;
-        description = "Path to the Restic password file.";
-      };
-      environmentFile = lib.mkOption {
-        type = lib.types.nullOr lib.types.path;
-        default = null;
-        description = "Optional Restic environment file (for B2/S3 credentials).";
-      };
-      restoreMethods = lib.mkOption {
-        type = lib.types.listOf (lib.types.enum [ "syncoid" "local" "restic" ]);
-        default = [ "syncoid" "local" "restic" ];
-        description = "Restore methods evaluated in order when preseeding.";
+    systemd.paths."esphome-sync-secrets" = lib.mkIf (cfg.secretsFile != null) {
+      description = "Watch ESPHome secrets.yaml for changes";
+      wantedBy = [ "multi-user.target" ];
+      pathConfig = {
+        PathChanged = cfg.secretsFile;
+        Unit = "esphome-sync-secrets.service";
       };
     };
   };
-
-  config = lib.mkMerge [
-    (lib.mkIf cfg.enable {
-      assertions = [
-        {
-          assertion = !(cfg.hostNetwork && cfg.podmanNetwork != null);
-          message = "ESPHome cannot use hostNetwork and a custom Podman network simultaneously.";
-        }
-        {
-          assertion = cfg.backup == null || !cfg.backup.enable || cfg.backup.repository != null;
-          message = "ESPHome backup.enable requires backup.repository to be set.";
-        }
-        {
-          assertion = !cfg.preseed.enable || (cfg.preseed.repositoryUrl != null && cfg.preseed.repositoryUrl != "");
-          message = "ESPHome preseed.enable requires repositoryUrl to be set.";
-        }
-        {
-          assertion = !cfg.preseed.enable || cfg.preseed.passwordFile != null;
-          message = "ESPHome preseed.enable requires passwordFile to be set.";
-        }
-      ];
-
-      modules.storage.datasets.services.${serviceName} = {
-        mountpoint = cfg.dataDir;
-        recordsize = "128K"; # mix of YAML configs and compiled firmware blobs
-        compression = "zstd";
-        properties = {
-          "com.sun:auto-snapshot" = "true";
-        };
-        owner = cfg.user;
-        group = cfg.group;
-        mode = "0770";
-      };
-
-      # Create local user/group for file ownership on host volumes
-      # Container runs with --user to match these UIDs
-      users.groups.${cfg.group} = {
-        gid = cfg.gid;
-      };
-
-      users.users.${cfg.user} = {
-        uid = cfg.uid;
-        isSystemUser = true;
-        group = cfg.group;
-        description = "ESPHome service account";
-      };
-
-      # Ensure Podman-created subdirectories (e.g., .esphome cache) retain the
-      # expected ownership. Other containerized services achieve this via their
-      # tmpfiles entries, so mirror that behavior here with a recursive rule.
-      systemd.tmpfiles.rules = [
-        "Z ${cfg.dataDir} 0770 ${cfg.user} ${cfg.group} - -"
-        # Cache directory for PlatformIO builds (can grow large, excluded from backups)
-        "d ${cfg.cacheDir} 0770 ${cfg.user} ${cfg.group} - -"
-      ];
-
-      modules.services.caddy.virtualHosts.${serviceName} = lib.mkIf (cfg.reverseProxy != null && cfg.reverseProxy.enable) {
-        enable = true;
-        hostName = cfg.reverseProxy.hostName;
-        backend = {
-          scheme = "http";
-          host = "127.0.0.1";
-          port = esphomePort;
-        };
-        auth = cfg.reverseProxy.auth;
-        caddySecurity = cfg.reverseProxy.caddySecurity;
-        security = cfg.reverseProxy.security;
-        extraConfig = cfg.reverseProxy.extraConfig;
-      };
-
-      virtualisation.oci-containers.containers.${serviceName} = podmanLib.mkContainer serviceName {
-        image = cfg.image;
-        environment = {
-          TZ = cfg.timezone;
-          ESPHOME_DASHBOARD_USE_PING = if cfg.hostNetwork then "true" else "false";
-        };
-        volumes = [
-          "${cfg.dataDir}:/config:rw"
-          "${cfg.cacheDir}:/cache:rw"
-          "/etc/localtime:/etc/localtime:ro"
-        ];
-        ports = lib.optionals (!cfg.hostNetwork) [
-          "${toString esphomePort}:${toString esphomePort}"
-        ];
-        resources = cfg.resources;
-        extraOptions = [
-          "--pull=newer"
-          # Run container as the host esphome user for proper file ownership
-          "--user=${toString cfg.uid}:${toString cfg.gid}"
-        ]
-        ++ (lib.optionals cfg.hostNetwork [ "--network=host" ])
-        ++ (lib.optionals (!cfg.hostNetwork && cfg.podmanNetwork != null) [ "--network=${cfg.podmanNetwork}" ])
-        ++ lib.optionals (cfg.healthcheck != null && cfg.healthcheck.enable) [
-          # Match upstream: curl --fail http://localhost:6052/version -A "HealthCheck"
-          "--health-cmd=curl --fail --silent http://127.0.0.1:${toString esphomePort}/version -A HealthCheck || exit 1"
-          "--health-interval=${cfg.healthcheck.interval}"
-          "--health-timeout=${cfg.healthcheck.timeout}"
-          "--health-retries=${toString cfg.healthcheck.retries}"
-          "--health-start-period=${cfg.healthcheck.startPeriod}"
-          "--health-on-failure=${cfg.healthcheck.onFailure}"
-        ];
-      };
-
-      systemd.services.${mainServiceName} = lib.mkMerge [
-        (lib.mkIf (cfg.podmanNetwork != null && !cfg.hostNetwork) {
-          requires = [ "podman-network-${cfg.podmanNetwork}.service" ];
-          after = [ "podman-network-${cfg.podmanNetwork}.service" ];
-        })
-        (lib.mkIf (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
-          unitConfig.OnFailure = [ "notify@esphome-failure:%n.service" ];
-        })
-        (lib.mkIf cfg.preseed.enable {
-          requires = lib.optional (!allowEmptyBootstrap) "preseed-esphome.service";
-          wants = lib.optional allowEmptyBootstrap "preseed-esphome.service";
-          after = [ "preseed-esphome.service" ];
-        })
-        (lib.mkIf (cfg.secretsFile != null) {
-          wants = [ "esphome-sync-secrets.service" ];
-          after = [ "esphome-sync-secrets.service" ];
-        })
-      ];
-
-      # Health check is handled natively by Podman container (see extraOptions above)
-      # No separate systemd timer needed - Prometheus scrapes container health status
-
-      modules.notifications.templates = lib.mkIf (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
-        "esphome-failure" = {
-          enable = lib.mkDefault true;
-          priority = lib.mkDefault "high";
-          title = lib.mkDefault "ESPHome dashboard failure";
-          body = lib.mkDefault ''ESPHome on ${config.networking.hostName} requires attention.'';
-        };
-      };
-
-      systemd.services."esphome-sync-secrets" = lib.mkIf (cfg.secretsFile != null) (
-        let
-          syncScript = pkgs.writeShellScript "esphome-sync-secrets" ''
-            set -euo pipefail
-            install -d -m 0750 -o esphome -g esphome ${cfg.dataDir}
-            install -m 0600 -o esphome -g esphome ${cfg.secretsFile} ${cfg.dataDir}/secrets.yaml
-            if ${pkgs.systemd}/bin/systemctl is-active --quiet ${mainServiceUnit}; then
-              ${pkgs.systemd}/bin/systemctl restart --no-block ${mainServiceUnit}
-            fi
-          '';
-        in
-        {
-          description = "Sync ESPHome secrets.yaml from sops";
-          before = [ mainServiceUnit ];
-          requiredBy = [ mainServiceUnit ];
-          serviceConfig = {
-            Type = "oneshot";
-            ExecStart = syncScript;
-          };
-        }
-      );
-
-      systemd.paths."esphome-sync-secrets" = lib.mkIf (cfg.secretsFile != null) {
-        description = "Watch ESPHome secrets.yaml for changes";
-        wantedBy = [ "multi-user.target" ];
-        pathConfig = {
-          PathChanged = cfg.secretsFile;
-          Unit = "esphome-sync-secrets.service";
-        };
-      };
-    })
-
-    (lib.mkIf (cfg.enable && cfg.preseed.enable) (
-      storageHelpers.mkPreseedService {
-        serviceName = serviceName;
-        dataset = datasetPath;
-        mountpoint = cfg.dataDir;
-        mainServiceUnit = mainServiceUnit;
-        replicationCfg = replicationConfig;
-        datasetProperties = {
-          recordsize = "128K";
-          compression = "zstd";
-          "com.sun:auto-snapshot" = "true";
-        };
-        resticRepoUrl = cfg.preseed.repositoryUrl;
-        resticPasswordFile = cfg.preseed.passwordFile;
-        resticEnvironmentFile = cfg.preseed.environmentFile;
-        resticPaths = [ cfg.dataDir ];
-        restoreMethods = cfg.preseed.restoreMethods;
-        hasCentralizedNotifications = hasCentralizedNotifications;
-        inherit allowEmptyBootstrap;
-        owner = "esphome";
-        group = "esphome";
-      }
-    ))
-  ];
 }

--- a/modules/nixos/services/mealie/default.nix
+++ b/modules/nixos/services/mealie/default.nix
@@ -1,141 +1,96 @@
+# modules/nixos/services/mealie/default.nix
+#
+# Mealie - self-hosted recipe manager
+#
+# Factory-based implementation (see lib/service-factory.nix).
 { lib, mylib, pkgs, config, podmanLib, ... }:
 with lib;
 let
-  sharedTypes = mylib.types;
-  # Storage helpers via mylib injection (centralized import)
-  storageHelpers = mylib.storageHelpers pkgs;
-
-  cfg = config.modules.services.mealie or { };
-  notificationsCfg = config.modules.notifications or { };
-  hasCentralizedNotifications = notificationsCfg.enable or false;
-
-  storageCfg = config.modules.storage or { };
-  datasetsCfg = storageCfg.datasets or { };
-  defaultDatasetPath =
-    if datasetsCfg ? parentDataset then
-      "${datasetsCfg.parentDataset}/mealie"
-    else
-      null;
-
-  datasetPath = cfg.datasetPath or defaultDatasetPath;
-
   serviceName = "mealie";
   backend = config.virtualisation.oci-containers.backend;
-  serviceAttrName = "${backend}-${serviceName}";
-  mainServiceUnit = "${serviceAttrName}.service";
+  mainServiceUnit = "${backend}-${serviceName}.service";
 
   envDir = "/run/${serviceName}";
   envFile = "${envDir}/env";
 
   boolStr = value: if value then "true" else "false";
 
-  # Build replication config for preseed (walks up dataset tree to find inherited config)
-  replicationConfig = storageHelpers.mkReplicationConfig { inherit config datasetPath; };
-
-  effectiveBaseUrl =
-    if cfg.baseUrl != null then cfg.baseUrl
-    else if cfg.reverseProxy != null && cfg.reverseProxy.enable then
-      "https://${cfg.reverseProxy.hostName}"
+  datasetsCfg = config.modules.storage.datasets or { };
+  defaultDatasetPath =
+    if datasetsCfg ? parentDataset then
+      "${datasetsCfg.parentDataset}/mealie"
     else
-      "http://${cfg.listenAddress}:${toString cfg.listenPort}";
+      null;
 
-  databaseEnv =
-    if cfg.database.engine == "postgres" then {
-      DB_ENGINE = "postgres";
-      POSTGRES_USER = cfg.database.user;
-      POSTGRES_DB = cfg.database.name;
-      POSTGRES_SERVER = cfg.database.host;
-      POSTGRES_PORT = toString cfg.database.port;
-    } else {
-      DB_ENGINE = "sqlite";
-    };
-
-  smtpEnv =
-    if cfg.smtp.enable then {
-      SMTP_HOST = cfg.smtp.host;
-      SMTP_PORT = toString cfg.smtp.port;
-      SMTP_FROM_NAME = cfg.smtp.fromName;
-      SMTP_FROM_EMAIL = cfg.smtp.fromEmail;
-      SMTP_AUTH_STRATEGY = cfg.smtp.strategy;
-      SMTP_USER = cfg.smtp.username;
-    } else { };
-
-  oidcEnv =
-    if cfg.oidc.enable then
-      {
-        OIDC_AUTH_ENABLED = "true";
-        OIDC_CONFIGURATION_URL = cfg.oidc.configurationUrl;
-        OIDC_CLIENT_ID = cfg.oidc.clientId;
-        OIDC_PROVIDER_NAME = cfg.oidc.providerName;
-        OIDC_SIGNUP_ENABLED = boolStr cfg.oidc.signupEnabled;
-        OIDC_AUTO_REDIRECT = boolStr cfg.oidc.autoRedirect;
-        OIDC_REMEMBER_ME = boolStr cfg.oidc.rememberMe;
-        OIDC_USER_CLAIM = cfg.oidc.userClaim;
-        OIDC_NAME_CLAIM = cfg.oidc.nameClaim;
-        OIDC_GROUPS_CLAIM = cfg.oidc.groupsClaim;
-      }
-      // (lib.optionalAttrs (cfg.oidc.userGroup != null) { OIDC_USER_GROUP = cfg.oidc.userGroup; })
-      // (lib.optionalAttrs (cfg.oidc.adminGroup != null) { OIDC_ADMIN_GROUP = cfg.oidc.adminGroup; })
-      // (lib.optionalAttrs (cfg.oidc.scopes != [ ]) { OIDC_SCOPES_OVERRIDE = lib.concatStringsSep " " cfg.oidc.scopes; })
-    else
-      { OIDC_AUTH_ENABLED = "false"; };
-
-  openaiEnv =
-    if cfg.openai.enable then
-      {
-        OPENAI_MODEL = cfg.openai.model;
-        OPENAI_WORKERS = toString cfg.openai.workers;
-        OPENAI_SEND_DATABASE_DATA = boolStr cfg.openai.sendDatabaseData;
-        OPENAI_ENABLE_IMAGE_SERVICES = boolStr cfg.openai.enableImageServices;
-        OPENAI_REQUEST_TIMEOUT = toString cfg.openai.requestTimeout;
-      }
-      // (lib.optionalAttrs (cfg.openai.baseUrl != null) { OPENAI_BASE_URL = cfg.openai.baseUrl; })
-      // (lib.optionalAttrs (cfg.openai.customHeaders != null) { OPENAI_CUSTOM_HEADERS = cfg.openai.customHeaders; })
-      // (lib.optionalAttrs (cfg.openai.customParams != null) { OPENAI_CUSTOM_PARAMS = cfg.openai.customParams; })
-    else
-      { };
-
-  credentials =
-    (lib.optional (cfg.database.engine == "postgres") "db_password:${cfg.database.passwordFile}")
-    ++ (lib.optional (cfg.smtp.enable && cfg.smtp.passwordFile != null) "smtp_password:${cfg.smtp.passwordFile}")
-    ++ (lib.optional (cfg.oidc.enable && cfg.oidc.clientSecretFile != null) "oidc_client_secret:${cfg.oidc.clientSecretFile}")
-    ++ (lib.optional (cfg.openai.enable && cfg.openai.apiKeyFile != null) "openai_api_key:${cfg.openai.apiKeyFile}");
+  # Resolved lazily after option evaluation - safe to reference here.
+  mealieCfg = config.modules.services.mealie;
 in
-{
-  options.modules.services.mealie = {
-    enable = mkEnableOption "Mealie self-hosted recipe manager";
+mylib.mkContainerService {
+  inherit lib mylib pkgs config podmanLib;
 
-    image = mkOption {
-      type = types.str;
-      default = "ghcr.io/mealie-recipes/mealie:v3.5.0";
-      description = ''
-        Container image reference for Mealie. Pin to a specific version tag or digest
-        to guarantee repeatable deployments.
-      '';
+  name = "mealie";
+  description = "Mealie";
+
+  spec = {
+    # Core service configuration. The web port option is aliased to
+    # listenPort (see extraOptions below); the container listens on 9000.
+    port = 9925;
+    image = "ghcr.io/mealie-recipes/mealie:v3.5.0";
+    operationalProfile = "productivity";
+    displayName = "Mealie";
+    function = "recipes";
+
+    healthCommand = ''python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9000/api/app/about', timeout=5)" || exit 1'';
+
+    # ZFS tuning - SQLite/uploads mix, small records
+    zfsRecordSize = "16K";
+
+    resources = {
+      memory = "1024M";
+      memoryReservation = "512M";
+      cpus = "1.0";
     };
 
-    dataDir = mkOption {
-      type = types.path;
-      default = "/var/lib/mealie";
-      description = "Directory where Mealie stores persistent state.";
-    };
+    # The mealie user was deployed with a dynamic UID/GID; the container's
+    # environment (including its PUID/PGID passthrough) is fully defined in
+    # extraConfig below.
+    runAsRoot = true;
 
-    datasetPath = mkOption {
-      type = types.nullOr types.str;
-      default = defaultDatasetPath;
-      description = "Backing ZFS dataset for Mealie data; defaults to parentDataset/mealie.";
-    };
+    # Secrets (DB/SMTP/OIDC/OpenAI) are materialized into this env file by
+    # the preStart script from systemd credentials.
+    environmentFiles = [ envFile ];
 
+    # Data lives at /app/data, not /config
+    skipDefaultConfigMount = true;
+    volumes = cfg: [
+      "${cfg.dataDir}:/app/data:rw"
+    ];
+
+    # Extra /etc/hosts entries (hairpin NAT workaround)
+    extraOptions = { cfg, ... }:
+      lib.mapAttrsToList (host: ip: "--add-host=${host}:${ip}") cfg.extraHosts;
+  };
+
+  extraOptions = {
+    # The mealie system user pre-dates the UID registry and is deployed with
+    # a dynamically allocated UID - keep ownership operations name-based.
     user = mkOption {
       type = types.str;
       default = "mealie";
       description = "System user that owns Mealie data.";
     };
 
-    group = mkOption {
-      type = types.str;
-      default = "mealie";
-      description = "System group that owns Mealie data.";
+    # Alias: the canonical web port option for this module is listenPort.
+    port = mkOption {
+      type = types.port;
+      default = mealieCfg.listenPort;
+      description = "Host port for the Mealie web interface (tracks listenPort).";
+    };
+
+    datasetPath = mkOption {
+      type = types.nullOr types.str;
+      default = defaultDatasetPath;
+      description = "Backing ZFS dataset for Mealie data; defaults to parentDataset/mealie.";
     };
 
     listenAddress = mkOption {
@@ -158,12 +113,6 @@ in
         from the configured reverse proxy host (https://<host>). If no reverse proxy is configured,
         fall back to http://<listenAddress>:<listenPort>.
       '';
-    };
-
-    timezone = mkOption {
-      type = types.str;
-      default = config.time.timeZone or "UTC";
-      description = "Timezone passed to the container.";
     };
 
     allowSignup = mkOption {
@@ -208,12 +157,6 @@ in
       description = "Initial admin metadata passed via environment variables.";
     };
 
-    podmanNetwork = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      description = "Optional Podman network to attach to.";
-    };
-
     extraHosts = mkOption {
       type = types.attrsOf types.str;
       default = { };
@@ -229,87 +172,6 @@ in
       '';
       example = {
         "id.holthome.net" = "10.89.0.1";
-      };
-    };
-
-    resources = mkOption {
-      type = types.nullOr sharedTypes.containerResourcesSubmodule;
-      default = {
-        memory = "1024M";
-        memoryReservation = "512M";
-        cpus = "1.0";
-      };
-      description = "Container resource limits (translated to Podman run options).";
-    };
-
-    healthcheck = mkOption {
-      type = types.nullOr sharedTypes.healthcheckSubmodule;
-      default = {
-        enable = true;
-        interval = "30s";
-        timeout = "10s";
-        retries = 3;
-        startPeriod = "120s";
-      };
-      description = "Container healthcheck configuration.";
-    };
-
-    reverseProxy = mkOption {
-      type = types.nullOr sharedTypes.reverseProxySubmodule;
-      default = null;
-      description = "Reverse proxy definition for automatic Caddy + Authelia wiring.";
-    };
-
-    logging = mkOption {
-      type = types.nullOr sharedTypes.loggingSubmodule;
-      default = {
-        enable = true;
-        journalUnit = mainServiceUnit;
-        labels = {
-          service = serviceName;
-          service_type = "recipes";
-        };
-      };
-      description = "Log shipping metadata consumed by the observability stack.";
-    };
-
-    backup = mkOption {
-      type = types.nullOr sharedTypes.backupSubmodule;
-      default = null;
-      description = "Restic backup configuration for Mealie state.";
-    };
-
-    notifications = mkOption {
-      type = types.nullOr sharedTypes.notificationSubmodule;
-      default = {
-        enable = true;
-        channels.onFailure = [ "system-alerts" ];
-        customMessages.failure = "Mealie failed on ${config.networking.hostName}";
-      };
-      description = "Notification policy for service failures.";
-    };
-
-    preseed = {
-      enable = mkEnableOption "automatic restore before service start";
-      repositoryUrl = mkOption {
-        type = types.str;
-        default = "";
-        description = "Restic repository URL.";
-      };
-      passwordFile = mkOption {
-        type = types.nullOr types.path;
-        default = null;
-        description = "Restic password file.";
-      };
-      environmentFile = mkOption {
-        type = types.nullOr types.path;
-        default = null;
-        description = "Optional environment file for cloud credentials.";
-      };
-      restoreMethods = mkOption {
-        type = types.listOf (types.enum [ "syncoid" "local" "restic" ]);
-        default = [ "syncoid" "local" "restic" ];
-        description = "Ordered list of restore strategies.";
       };
     };
 
@@ -555,10 +417,95 @@ in
       default = { enable = false; };
       description = "OpenAI integration settings for Mealie.";
     };
+
+    # Backups are configured explicitly by hosts (overrides the factory
+    # default of enabled).
+    backup = mkOption {
+      type = types.nullOr mylib.types.backupSubmodule;
+      default = null;
+      description = "Restic backup configuration for Mealie state.";
+    };
+
+    # Mealie exposes no Prometheus metrics endpoint - keep metrics opt-in.
+    metrics = mkOption {
+      type = types.nullOr mylib.types.metricsSubmodule;
+      default = null;
+      description = "Prometheus metrics collection configuration (Mealie has no native metrics)";
+    };
   };
 
-  config = mkMerge [
-    (mkIf cfg.enable {
+  extraConfig = cfg:
+    let
+      effectiveBaseUrl =
+        if cfg.baseUrl != null then cfg.baseUrl
+        else if cfg.reverseProxy != null && cfg.reverseProxy.enable then
+          "https://${cfg.reverseProxy.hostName}"
+        else
+          "http://${cfg.listenAddress}:${toString cfg.listenPort}";
+
+      databaseEnv =
+        if cfg.database.engine == "postgres" then {
+          DB_ENGINE = "postgres";
+          POSTGRES_USER = cfg.database.user;
+          POSTGRES_DB = cfg.database.name;
+          POSTGRES_SERVER = cfg.database.host;
+          POSTGRES_PORT = toString cfg.database.port;
+        } else {
+          DB_ENGINE = "sqlite";
+        };
+
+      smtpEnv =
+        if cfg.smtp.enable then {
+          SMTP_HOST = cfg.smtp.host;
+          SMTP_PORT = toString cfg.smtp.port;
+          SMTP_FROM_NAME = cfg.smtp.fromName;
+          SMTP_FROM_EMAIL = cfg.smtp.fromEmail;
+          SMTP_AUTH_STRATEGY = cfg.smtp.strategy;
+          SMTP_USER = cfg.smtp.username;
+        } else { };
+
+      oidcEnv =
+        if cfg.oidc.enable then
+          {
+            OIDC_AUTH_ENABLED = "true";
+            OIDC_CONFIGURATION_URL = cfg.oidc.configurationUrl;
+            OIDC_CLIENT_ID = cfg.oidc.clientId;
+            OIDC_PROVIDER_NAME = cfg.oidc.providerName;
+            OIDC_SIGNUP_ENABLED = boolStr cfg.oidc.signupEnabled;
+            OIDC_AUTO_REDIRECT = boolStr cfg.oidc.autoRedirect;
+            OIDC_REMEMBER_ME = boolStr cfg.oidc.rememberMe;
+            OIDC_USER_CLAIM = cfg.oidc.userClaim;
+            OIDC_NAME_CLAIM = cfg.oidc.nameClaim;
+            OIDC_GROUPS_CLAIM = cfg.oidc.groupsClaim;
+          }
+          // (lib.optionalAttrs (cfg.oidc.userGroup != null) { OIDC_USER_GROUP = cfg.oidc.userGroup; })
+          // (lib.optionalAttrs (cfg.oidc.adminGroup != null) { OIDC_ADMIN_GROUP = cfg.oidc.adminGroup; })
+          // (lib.optionalAttrs (cfg.oidc.scopes != [ ]) { OIDC_SCOPES_OVERRIDE = lib.concatStringsSep " " cfg.oidc.scopes; })
+        else
+          { OIDC_AUTH_ENABLED = "false"; };
+
+      openaiEnv =
+        if cfg.openai.enable then
+          {
+            OPENAI_MODEL = cfg.openai.model;
+            OPENAI_WORKERS = toString cfg.openai.workers;
+            OPENAI_SEND_DATABASE_DATA = boolStr cfg.openai.sendDatabaseData;
+            OPENAI_ENABLE_IMAGE_SERVICES = boolStr cfg.openai.enableImageServices;
+            OPENAI_REQUEST_TIMEOUT = toString cfg.openai.requestTimeout;
+          }
+          // (lib.optionalAttrs (cfg.openai.baseUrl != null) { OPENAI_BASE_URL = cfg.openai.baseUrl; })
+          // (lib.optionalAttrs (cfg.openai.customHeaders != null) { OPENAI_CUSTOM_HEADERS = cfg.openai.customHeaders; })
+          // (lib.optionalAttrs (cfg.openai.customParams != null) { OPENAI_CUSTOM_PARAMS = cfg.openai.customParams; })
+        else
+          { };
+
+      credentials =
+        (lib.optional (cfg.database.engine == "postgres") "db_password:${cfg.database.passwordFile}")
+        ++ (lib.optional (cfg.smtp.enable && cfg.smtp.passwordFile != null) "smtp_password:${cfg.smtp.passwordFile}")
+        ++ (lib.optional (cfg.oidc.enable && cfg.oidc.clientSecretFile != null) "oidc_client_secret:${cfg.oidc.clientSecretFile}")
+        ++ (lib.optional (cfg.openai.enable && cfg.openai.apiKeyFile != null) "openai_api_key:${cfg.openai.apiKeyFile}");
+    in
+    {
       assertions = [
         {
           assertion = cfg.database.engine != "postgres" || cfg.database.passwordFile != null;
@@ -578,28 +525,23 @@ in
         }
       ];
 
-      users.users.${cfg.user} = {
-        isSystemUser = true;
-        group = cfg.group;
+      # Preserve the dynamically allocated UID/GID of the deployed user - the
+      # factory would otherwise pin them from the UID registry, breaking
+      # ownership of existing data.
+      users.users.mealie = {
+        uid = lib.mkForce null;
         home = cfg.dataDir;
-        description = "Mealie service account";
       };
-
-      users.groups.${cfg.group} = { };
+      users.groups.mealie.gid = lib.mkForce null;
 
       systemd.tmpfiles.rules = [
         "d ${cfg.dataDir} 0750 ${cfg.user} ${cfg.group} -"
         "d ${envDir} 0700 root root -"
       ];
 
-      modules.storage.datasets.services.${serviceName} = {
-        mountpoint = cfg.dataDir;
-        recordsize = "16K";
-        compression = "zstd";
-        owner = cfg.user;
-        group = cfg.group;
-        mode = "0750";
-      };
+      # The pre-factory module set no extra ZFS properties on the dataset
+      # (snapshots are managed by sanoid at the host level).
+      modules.storage.datasets.services.mealie.properties = { };
 
       modules.services.postgresql.databases.${cfg.database.name} = mkIf (cfg.database.engine == "postgres" && cfg.database.manageDatabase) {
         owner = cfg.database.user;
@@ -609,10 +551,11 @@ in
         schemaMigrations = cfg.database.schemaMigrations;
       };
 
-      virtualisation.oci-containers.containers.${serviceName} = podmanLib.mkContainer serviceName {
-        image = cfg.image;
-        environmentFiles = [ envFile ];
-        environment = {
+      virtualisation.oci-containers.containers.mealie = {
+        # Full environment definition (the factory's PUID/PGID injection for
+        # runAsRoot containers is replaced by the pre-factory passthrough of
+        # the host user's uid/gid, which stays empty for dynamic IDs).
+        environment = lib.mkForce ({
           PUID = toString config.users.users.${cfg.user}.uid;
           PGID = toString config.users.groups.${cfg.group}.gid;
           TZ = cfg.timezone;
@@ -627,95 +570,61 @@ in
         // databaseEnv
         // smtpEnv
         // oidcEnv
-        // openaiEnv;
-        volumes = [
-          "${cfg.dataDir}:/app/data:rw"
-        ];
-        ports = [
+        // openaiEnv);
+        # Bind on listenAddress only - Caddy proxies external requests.
+        ports = lib.mkForce [
           "${cfg.listenAddress}:${toString cfg.listenPort}:9000/tcp"
-        ];
-        resources = cfg.resources;
-        extraOptions = [ "--pull=newer" ]
-          ++ lib.optionals (cfg.podmanNetwork != null) [ "--network=${cfg.podmanNetwork}" ]
-          ++ lib.optionals (cfg.extraHosts != { }) (
-          lib.mapAttrsToList (host: ip: "--add-host=${host}:${ip}") cfg.extraHosts
-        )
-          ++ lib.optionals (cfg.healthcheck != null && cfg.healthcheck.enable) [
-          ''--health-cmd=python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9000/api/app/about', timeout=5)" || exit 1''
-          "--health-interval=${cfg.healthcheck.interval}"
-          "--health-timeout=${cfg.healthcheck.timeout}"
-          "--health-retries=${toString cfg.healthcheck.retries}"
-          "--health-start-period=${cfg.healthcheck.startPeriod}"
         ];
       };
 
-      systemd.services.${serviceAttrName} = mkMerge [
-        {
-          after = [ "network-online.target" ]
-            ++ lib.optional (cfg.database.engine == "postgres" && cfg.database.localInstance) "postgresql.service"
-            ++ lib.optionals cfg.preseed.enable [ "mealie-preseed.service" ];
-          wants = [ "network-online.target" ]
-            ++ lib.optionals cfg.preseed.enable [ "mealie-preseed.service" ];
-          requires =
-            lib.optional (cfg.database.engine == "postgres" && cfg.database.manageDatabase && cfg.database.localInstance)
-              "postgresql-provision-databases.service";
-          serviceConfig = {
-            LoadCredential = credentials;
-            Restart = lib.mkForce "on-failure";
-            RestartSec = "10s";
-          };
-          preStart = ''
-            set -euo pipefail
-            install -d -m 750 -o ${cfg.user} -g ${cfg.group} ${cfg.dataDir}
-            install -d -m 700 ${envDir}
-            tmp="${envFile}.tmp"
-            trap 'rm -f "$tmp"' EXIT
-            {
-            ${lib.optionalString (cfg.database.engine == "postgres") ''
-              printf "POSTGRES_PASSWORD=%s\n" "$(cat "$CREDENTIALS_DIRECTORY/db_password")"
-            ''}
-            ${lib.optionalString (cfg.smtp.enable && cfg.smtp.passwordFile != null) ''
-              printf "SMTP_PASSWORD=%s\n" "$(cat "$CREDENTIALS_DIRECTORY/smtp_password")"
-            ''}
-            ${lib.optionalString (cfg.oidc.enable && cfg.oidc.clientSecretFile != null) ''
-              printf "OIDC_CLIENT_SECRET=%s\n" "$(cat "$CREDENTIALS_DIRECTORY/oidc_client_secret")"
-            ''}
-            ${lib.optionalString (cfg.openai.enable && cfg.openai.apiKeyFile != null) ''
-              printf "OPENAI_API_KEY=%s\n" "$(cat "$CREDENTIALS_DIRECTORY/openai_api_key")"
-            ''}
-            } > "$tmp"
-            install -m 600 "$tmp" ${envFile}
-          '';
-        }
-        (mkIf (cfg.podmanNetwork != null) {
-          requires = [ "podman-network-${cfg.podmanNetwork}.service" ];
-          after = [ "podman-network-${cfg.podmanNetwork}.service" ];
-        })
-        (mkIf (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
-          unitConfig.OnFailure = [ "notify@${serviceName}-failure:%n.service" ];
-        })
-      ];
+      systemd.services."${backend}-mealie" = {
+        after = lib.optional (cfg.database.engine == "postgres" && cfg.database.localInstance) "postgresql.service";
+        requires =
+          lib.optional (cfg.database.engine == "postgres" && cfg.database.manageDatabase && cfg.database.localInstance)
+            "postgresql-provision-databases.service";
+        serviceConfig = {
+          LoadCredential = credentials;
+          Restart = lib.mkForce "on-failure";
+          RestartSec = "10s";
+        };
+        preStart = ''
+          set -euo pipefail
+          install -d -m 750 -o ${cfg.user} -g ${cfg.group} ${cfg.dataDir}
+          install -d -m 700 ${envDir}
+          tmp="${envFile}.tmp"
+          trap 'rm -f "$tmp"' EXIT
+          {
+          ${lib.optionalString (cfg.database.engine == "postgres") ''
+            printf "POSTGRES_PASSWORD=%s\n" "$(cat "$CREDENTIALS_DIRECTORY/db_password")"
+          ''}
+          ${lib.optionalString (cfg.smtp.enable && cfg.smtp.passwordFile != null) ''
+            printf "SMTP_PASSWORD=%s\n" "$(cat "$CREDENTIALS_DIRECTORY/smtp_password")"
+          ''}
+          ${lib.optionalString (cfg.oidc.enable && cfg.oidc.clientSecretFile != null) ''
+            printf "OIDC_CLIENT_SECRET=%s\n" "$(cat "$CREDENTIALS_DIRECTORY/oidc_client_secret")"
+          ''}
+          ${lib.optionalString (cfg.openai.enable && cfg.openai.apiKeyFile != null) ''
+            printf "OPENAI_API_KEY=%s\n" "$(cat "$CREDENTIALS_DIRECTORY/openai_api_key")"
+          ''}
+          } > "$tmp"
+          install -m 600 "$tmp" ${envFile}
+        '';
+      };
 
-      modules.services.caddy.virtualHosts.${serviceName} = mkIf (cfg.reverseProxy != null && cfg.reverseProxy.enable) (
-        let
-          defaultBackend = {
+      # The reverse proxy backend follows listenAddress/listenPort and honors
+      # host-level backend overrides (pre-factory behavior).
+      modules.services.caddy.virtualHosts.mealie = mkIf (cfg.reverseProxy != null && cfg.reverseProxy.enable) {
+        backend = lib.mkForce (recursiveUpdate
+          {
             scheme = "http";
             host = cfg.listenAddress;
             port = cfg.listenPort;
-          };
-          configuredBackend = cfg.reverseProxy.backend or { };
-        in
-        {
-          enable = true;
-          hostName = cfg.reverseProxy.hostName;
-          backend = recursiveUpdate defaultBackend configuredBackend;
-          auth = cfg.reverseProxy.auth;
-          security = cfg.reverseProxy.security;
-          extraConfig = cfg.reverseProxy.extraConfig;
-        }
-      );
+          }
+          (cfg.reverseProxy.backend or { }));
+      };
 
-      modules.backup.restic.jobs.${serviceName} = mkIf (cfg.backup != null && cfg.backup.enable) {
+      # Backup integration using the standardized restic job pattern
+      modules.backup.restic.jobs.mealie = mkIf (cfg.backup != null && cfg.backup.enable) {
         enable = true;
         repository = cfg.backup.repository;
         frequency = cfg.backup.frequency;
@@ -724,46 +633,21 @@ in
         excludePatterns = cfg.backup.excludePatterns;
         tags = cfg.backup.tags;
         useSnapshots = cfg.backup.useSnapshots or true;
-        zfsDataset = cfg.backup.zfsDataset or datasetPath;
+        zfsDataset = cfg.backup.zfsDataset or cfg.datasetPath;
       };
 
-      modules.notifications.templates."${serviceName}-failure" = mkIf (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
-        enable = true;
-        priority = "high";
-        title = "❌ Mealie service failed";
-        body = ''
-          <b>Host:</b> ${config.networking.hostName}
-          <b>Service:</b> ${mainServiceUnit}
+      # Preserve the pre-factory notification wording
+      modules.notifications.templates."mealie-failure" =
+        mkIf (config.modules.notifications.enable or false && cfg.notifications != null && cfg.notifications.enable) {
+          enable = true;
+          priority = "high";
+          title = "❌ Mealie service failed";
+          body = ''
+            <b>Host:</b> ${config.networking.hostName}
+            <b>Service:</b> ${mainServiceUnit}
 
-          Check logs: <code>journalctl -u ${mainServiceUnit} -n 200</code>
-        '';
-      };
-
-      # NOTE: Service alerts are defined at host level (e.g., hosts/forge/services/mealie.nix)
-      # to keep modules portable and not assume Prometheus availability
-    })
-
-    (mkIf (cfg.enable && cfg.preseed.enable) (
-      storageHelpers.mkPreseedService {
-        serviceName = serviceName;
-        dataset = datasetPath;
-        mountpoint = cfg.dataDir;
-        mainServiceUnit = mainServiceUnit;
-        replicationCfg = replicationConfig;
-        datasetProperties = {
-          recordsize = "16K";
-          compression = "zstd";
-          "com.sun:auto-snapshot" = "true";
+            Check logs: <code>journalctl -u ${mainServiceUnit} -n 200</code>
+          '';
         };
-        resticRepoUrl = cfg.preseed.repositoryUrl;
-        resticPasswordFile = cfg.preseed.passwordFile;
-        resticEnvironmentFile = cfg.preseed.environmentFile;
-        resticPaths = [ cfg.dataDir ];
-        restoreMethods = cfg.preseed.restoreMethods;
-        hasCentralizedNotifications = hasCentralizedNotifications;
-        owner = cfg.user;
-        group = cfg.group;
-      }
-    ))
-  ];
+    };
 }

--- a/modules/nixos/services/paperless-ai/default.nix
+++ b/modules/nixos/services/paperless-ai/default.nix
@@ -1,3 +1,5 @@
+# modules/nixos/services/paperless-ai/default.nix
+#
 # Paperless-AI - AI-powered document tagging for Paperless-ngx
 # https://github.com/clusterzx/paperless-ai
 #
@@ -10,6 +12,7 @@
 # Data: /app/data (SQLite database for state tracking)
 # Auth: No native OIDC - use caddySecurity for SSO
 #
+# Factory-based implementation (see lib/service-factory.nix).
 { lib
 , mylib
 , pkgs
@@ -17,40 +20,63 @@
 , podmanLib
 , ...
 }:
-let
-  sharedTypes = mylib.types;
-  # Storage helpers via mylib injection (centralized import)
-  storageHelpers = mylib.storageHelpers pkgs;
 
-  cfg = config.modules.services.paperless-ai;
-  notificationsCfg = config.modules.notifications;
-  storageCfg = config.modules.storage;
-  hasCentralizedNotifications = notificationsCfg.enable or false;
+mylib.mkContainerService {
+  inherit lib mylib pkgs config podmanLib;
 
-  serviceName = "paperless-ai";
-  paperlessAiPort = cfg.port;
-  mainServiceUnit = "${config.virtualisation.oci-containers.backend}-${serviceName}.service";
-  datasetPath = "${storageCfg.datasets.parentDataset}/${serviceName}";
+  name = "paperless-ai";
+  description = "Paperless-AI";
 
-  # Build replication config for preseed (walks up dataset tree to find inherited config)
-  replicationConfig = storageHelpers.mkReplicationConfig { inherit config datasetPath; };
-in
-{
-  options.modules.services.paperless-ai = {
-    enable = lib.mkEnableOption "Paperless-AI document tagging service";
+  spec = {
+    # Core service configuration. The container internally always runs on
+    # port 3000; cfg.port is the external mapping.
+    port = 3000;
+    image = "clusterzx/paperless-ai:3.0.9";
+    operationalProfile = "productivity";
+    displayName = "Paperless-AI";
+    function = "document_tagging";
 
-    dataDir = lib.mkOption {
-      type = lib.types.path;
-      default = "/var/lib/paperless-ai";
-      description = "Path to Paperless-AI data directory (maps to /app/data in container)";
+    # Health check: verify web UI is responding (uses upstream /health endpoint)
+    healthCommand = "curl -f http://127.0.0.1:3000/health || exit 1";
+    startPeriod = "60s";
+
+    # ZFS tuning - optimal for SQLite database
+    zfsRecordSize = "16K";
+
+    resources = {
+      memory = "256M";
+      memoryReservation = "128M";
+      cpus = "0.5";
     };
 
-    port = lib.mkOption {
-      type = lib.types.port;
-      default = 3000;
-      description = "Port for Paperless-AI web interface";
-    };
+    # Runs as the (shared) paperless user via a numeric --user flag added
+    # below - the username does not exist inside the image, so the factory's
+    # name-based --user flag cannot be used. The PUID/PGID injection is
+    # neutralized in extraConfig.
+    runAsRoot = true;
 
+    # Data lives at /app/data plus several writable subdirectory mounts.
+    skipDefaultConfigMount = true;
+    volumes = cfg: [
+      "${cfg.dataDir}:/app/data:rw"
+      # Mount SOPS-rendered .env file directly (symlinks don't work in containers)
+      "${config.sops.templates."paperless-ai-env".path}:/app/data/.env:ro"
+      # Additional writable paths (container expects to write here)
+      "${cfg.dataDir}/logs:/app/logs:rw"
+      "${cfg.dataDir}/.pm2:/app/.pm2:rw"
+      "${cfg.dataDir}/nltk_data:/app/nltk_data:rw"
+      "${cfg.dataDir}/openapi:/app/OPENAPI:rw"
+      # Only mount images subdir - /app/public contains static CSS/JS assets
+      "${cfg.dataDir}/public-images:/app/public/images:rw"
+    ];
+
+    extraOptions = { cfg, config, ... }: [
+      # Use UID:GID (writable paths redirected to /app/data via env vars)
+      "--user=${toString config.users.users.${cfg.user}.uid}:${toString config.users.groups.${cfg.group}.gid}"
+    ];
+  };
+
+  extraOptions = {
     user = lib.mkOption {
       type = lib.types.str;
       default = "paperless";
@@ -67,22 +93,6 @@ in
         Group under which Paperless-AI runs.
         Defaults to 'paperless' to share permissions with paperless-ngx.
       '';
-    };
-
-    image = lib.mkOption {
-      type = lib.types.str;
-      default = "clusterzx/paperless-ai:3.0.9";
-      description = ''
-        Full container image name including tag.
-        Use Renovate bot to automate version updates.
-      '';
-      example = "clusterzx/paperless-ai:3.0.9@sha256:...";
-    };
-
-    timezone = lib.mkOption {
-      type = lib.types.str;
-      default = "America/New_York";
-      description = "Timezone for the container";
     };
 
     # =========================================================================
@@ -355,43 +365,10 @@ in
       '';
     };
 
-    # =========================================================================
-    # Container Configuration
-    # =========================================================================
-    resources = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.containerResourcesSubmodule;
-      default = {
-        memory = "256M";
-        memoryReservation = "128M";
-        cpus = "0.5";
-      };
-      description = "Resource limits for the container";
-    };
-
-    healthcheck = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.healthcheckSubmodule;
-      default = {
-        enable = true;
-        interval = "30s";
-        timeout = "10s";
-        retries = 3;
-        startPeriod = "60s";
-      };
-      description = "Container health check configuration";
-    };
-
-    # =========================================================================
-    # Standardized Submodules
-    # =========================================================================
-    reverseProxy = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.reverseProxySubmodule;
-      default = null;
-      description = "Reverse proxy configuration for Paperless-AI web interface";
-    };
-
+    # Preserve the pre-factory backup defaults.
     backup = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.backupSubmodule;
-      default = lib.mkIf cfg.enable {
+      type = lib.types.nullOr mylib.types.backupSubmodule;
+      default = {
         enable = lib.mkDefault true;
         repository = lib.mkDefault "nas-primary";
         frequency = lib.mkDefault "daily";
@@ -405,310 +382,148 @@ in
       description = "Backup configuration for Paperless-AI";
     };
 
-    notifications = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.notificationSubmodule;
-      default = {
-        enable = true;
-        channels = {
-          onFailure = [ "service-alerts" ];
-        };
-        customMessages = {
-          failure = "Paperless-AI service failed on ${config.networking.hostName}";
-        };
-      };
-      description = "Notification configuration for Paperless-AI service events";
-    };
-
-    preseed = {
-      enable = lib.mkEnableOption "automatic data restore before service start";
-      repositoryUrl = lib.mkOption {
-        type = lib.types.str;
-        description = "Restic repository URL for restore operations";
-      };
-      passwordFile = lib.mkOption {
-        type = lib.types.path;
-        description = "Path to Restic password file";
-      };
-      environmentFile = lib.mkOption {
-        type = lib.types.nullOr lib.types.path;
-        default = null;
-        description = "Optional environment file for Restic (e.g., for B2 credentials)";
-      };
-      restoreMethods = lib.mkOption {
-        type = lib.types.listOf (lib.types.enum [ "syncoid" "local" "restic" ]);
-        default = [ "syncoid" "local" "restic" ];
-        description = ''
-          Order and selection of restore methods to attempt.
-        '';
-      };
+    # Paperless-AI exposes no Prometheus metrics endpoint - keep metrics opt-in.
+    metrics = lib.mkOption {
+      type = lib.types.nullOr mylib.types.metricsSubmodule;
+      default = null;
+      description = "Prometheus metrics collection configuration (Paperless-AI has no native metrics)";
     };
   };
 
-  config = lib.mkMerge [
-    (lib.mkIf cfg.enable {
-      # =========================================================================
-      # Assertions
-      # =========================================================================
-      assertions = [
-        {
-          assertion = cfg.paperless.apiUrl != "";
-          message = "Paperless-AI requires paperless.apiUrl to be set.";
-        }
-        {
-          assertion = cfg.llm.provider != "custom" || cfg.llm.baseUrl != null;
-          message = "Paperless-AI with 'custom' LLM provider requires llm.baseUrl to be set.";
-        }
-        {
-          assertion = cfg.backup == null || !cfg.backup.enable || cfg.backup.repository != null;
-          message = "Paperless-AI backup.enable requires backup.repository to be set.";
-        }
-        {
-          assertion = !cfg.preseed.enable || cfg.preseed.repositoryUrl != "";
-          message = "Paperless-AI preseed.enable requires preseed.repositoryUrl to be set.";
-        }
+  extraConfig = cfg: {
+    assertions = [
+      {
+        assertion = cfg.paperless.apiUrl != "";
+        message = "Paperless-AI requires paperless.apiUrl to be set.";
+      }
+      {
+        assertion = cfg.llm.provider != "custom" || cfg.llm.baseUrl != null;
+        message = "Paperless-AI with 'custom' LLM provider requires llm.baseUrl to be set.";
+      }
+    ];
+
+    # The service runs as the existing paperless user (created by
+    # paperless-ngx); the factory still declares a paperless-ai user entry,
+    # which must not pin the registry-less fallback UID.
+    users.users.paperless-ai.uid = lib.mkForce null;
+
+    # Pre-factory dataset properties (atime off for the SQLite workload)
+    modules.storage.datasets.services.paperless-ai.properties = {
+      "com.sun:auto-snapshot" = "true";
+      atime = "off";
+    };
+
+    # Create subdirectories that are volume-mounted into the container.
+    # These must exist before the container starts.
+    systemd.tmpfiles.rules = [
+      "d ${cfg.dataDir}/logs 0750 ${cfg.user} ${cfg.group} -"
+      "d ${cfg.dataDir}/.pm2 0750 ${cfg.user} ${cfg.group} -"
+      "d ${cfg.dataDir}/nltk_data 0750 ${cfg.user} ${cfg.group} -"
+      "d ${cfg.dataDir}/openapi 0750 ${cfg.user} ${cfg.group} -"
+      # Only mount images subdir - /app/public contains static assets we must not overwrite
+      "d ${cfg.dataDir}/public-images 0750 ${cfg.user} ${cfg.group} -"
+    ];
+
+    # =========================================================================
+    # SOPS Template for .env Configuration File
+    # =========================================================================
+    # paperless-ai reads configuration from /app/data/.env file, not from
+    # environment variables. We mount this file directly into the container.
+    sops.templates."paperless-ai-env" = {
+      owner = "root";
+      group = "root";
+      mode = "0444"; # Readable by container user
+      content = ''
+        # Initial Setup - always 'no' since .env is read-only (managed by NixOS/SOPS)
+        # All configuration must be done via NixOS module options
+        PAPERLESS_AI_INITIAL_SETUP=no
+
+        # Paperless-ngx Integration
+        PAPERLESS_API_URL=${cfg.paperless.apiUrl}
+        PAPERLESS_API_TOKEN=${config.sops.placeholder."paperless-ai/paperless_token"}
+        PAPERLESS_USERNAME=${cfg.paperless.username}
+        # Python RAG service uses different env var names
+        PAPERLESS_URL=${cfg.paperless.apiUrl}
+
+        # LLM Configuration
+        AI_PROVIDER=${cfg.llm.provider}
+        ${lib.optionalString (cfg.llm.baseUrl != null) "CUSTOM_BASE_URL=${cfg.llm.baseUrl}"}
+        CUSTOM_MODEL=${cfg.llm.model}
+        ${lib.optionalString (cfg.llm.apiKeyFile != null) "CUSTOM_API_KEY=${config.sops.placeholder."paperless-ai/llm_api_key"}"}
+        # Some backends also check these env vars
+        OPENAI_API_KEY=
+        OPENAI_MODEL=
+
+        # Scanning Configuration
+        SCAN_INTERVAL=${cfg.scan.interval}
+        ADD_AI_PROCESSED_TAG=${if cfg.scan.addAiProcessedTag then "yes" else "no"}
+        AI_PROCESSED_TAG_NAME=${cfg.scan.aiProcessedTagName}
+        USE_EXISTING_DATA=${if cfg.scan.useExistingData then "yes" else "no"}
+        PROCESS_PREDEFINED_DOCUMENTS=${if cfg.scan.processPredefinedDocuments then "yes" else "no"}
+
+        # Tag Configuration
+        TAGS=${lib.concatStringsSep "," cfg.tags.trigger}
+        USE_PROMPT_TAGS=${if cfg.tags.usePromptTags then "yes" else "no"}
+        PROMPT_TAGS=${lib.concatStringsSep "," cfg.tags.promptTags}
+
+        # AI Function Limits
+        ACTIVATE_TAGGING=${if cfg.aiFunctions.tagging then "yes" else "no"}
+        ACTIVATE_CORRESPONDENTS=${if cfg.aiFunctions.correspondents then "yes" else "no"}
+        ACTIVATE_DOCUMENT_TYPE=${if cfg.aiFunctions.documentType then "yes" else "no"}
+        ACTIVATE_TITLE=${if cfg.aiFunctions.title then "yes" else "no"}
+        ACTIVATE_CUSTOM_FIELDS=${if cfg.aiFunctions.customFields then "yes" else "no"}
+
+        # System Prompt (newlines escaped for .env format)
+        SYSTEM_PROMPT=${lib.replaceStrings ["\n"] ["\\n"] cfg.systemPrompt}
+
+        # API Authentication (for paperless-ai's own API endpoints)
+        ${lib.optionalString (cfg.apiKeyFile != null) ''API_KEY=${config.sops.placeholder."paperless-ai/api_key"}''}
+
+        # System Configuration
+        TZ=${cfg.timezone}
+      '';
+    };
+
+    virtualisation.oci-containers.containers.paperless-ai = {
+      # Configuration is read from /app/data/.env file; only system-level env
+      # vars needed here for path redirects. Replaces the factory's
+      # PUID/PGID injection for runAsRoot containers.
+      environment = lib.mkForce {
+        TZ = cfg.timezone;
+
+        # Writable paths are mounted from dataDir (allows running as non-root)
+        # These env vars ensure apps write to mounted locations
+        HOME = "/app/data";
+        PM2_HOME = "/app/.pm2"; # Mounted from dataDir/.pm2
+        NLTK_DATA = "/app/nltk_data"; # Mounted from dataDir/nltk_data
+      };
+      # Only bind to localhost - external access goes through the reverse proxy.
+      ports = lib.mkForce [
+        "127.0.0.1:${toString cfg.port}:3000"
       ];
+    };
 
-      # =========================================================================
-      # Caddy Reverse Proxy Registration
-      # =========================================================================
-      modules.services.caddy.virtualHosts.${serviceName} = lib.mkIf (cfg.reverseProxy != null && cfg.reverseProxy.enable) {
-        enable = true;
-        hostName = cfg.reverseProxy.hostName;
-        backend = {
-          scheme = "http";
-          host = "127.0.0.1";
-          port = paperlessAiPort;
-        };
-        auth = cfg.reverseProxy.auth;
-        caddySecurity = cfg.reverseProxy.caddySecurity;
-        security = cfg.reverseProxy.security;
-        reverseProxyBlock = cfg.reverseProxy.reverseProxyBlock or "";
-        extraConfig = cfg.reverseProxy.extraConfig;
-      };
+    # Wait for SOPS to create the .env file
+    systemd.services."${config.virtualisation.oci-containers.backend}-paperless-ai" = {
+      wants = [ "sops-nix.service" ];
+      after = [ "sops-nix.service" ];
+    };
 
-      # =========================================================================
-      # ZFS Dataset
-      # =========================================================================
-      modules.storage.datasets.services.${serviceName} = {
-        mountpoint = cfg.dataDir;
-        recordsize = "16K"; # Optimal for SQLite database
-        compression = "zstd";
-        properties = {
-          "com.sun:auto-snapshot" = "true";
-          atime = "off";
-        };
-        owner = cfg.user;
-        group = cfg.group;
-        mode = "0750";
-      };
+    # Preserve the pre-factory notification wording
+    modules.notifications.templates."paperless-ai-failure" =
+      lib.mkIf (config.modules.notifications.enable or false && cfg.notifications != null && cfg.notifications.enable) {
+        body = ''
+          <b>Host:</b> ''${hostname}
+          <b>Service:</b> <code>''${serviceName}</code>
 
-      # =========================================================================
-      # User (uses existing paperless user by default)
-      # =========================================================================
-      # Note: User/group typically already exist from paperless-ngx
-      # Only create if using a different user
-      users.users.${cfg.user} = lib.mkIf (cfg.user != "paperless") {
-        isSystemUser = true;
-        group = cfg.group;
-        description = "Paperless-AI service user";
-      };
+          The Paperless-AI document tagging service has entered a failed state.
 
-      users.groups.${cfg.group} = lib.mkIf (cfg.group != "paperless") { };
-
-      # =========================================================================
-      # Tmpfiles Rules for Writable Subdirectories
-      # =========================================================================
-      # Create subdirectories that are volume-mounted into the container
-      # These must exist before the container starts
-      systemd.tmpfiles.rules = [
-        "d ${cfg.dataDir}/logs 0750 ${cfg.user} ${cfg.group} -"
-        "d ${cfg.dataDir}/.pm2 0750 ${cfg.user} ${cfg.group} -"
-        "d ${cfg.dataDir}/nltk_data 0750 ${cfg.user} ${cfg.group} -"
-        "d ${cfg.dataDir}/openapi 0750 ${cfg.user} ${cfg.group} -"
-        # Only mount images subdir - /app/public contains static assets we must not overwrite
-        "d ${cfg.dataDir}/public-images 0750 ${cfg.user} ${cfg.group} -"
-      ];
-
-      # =========================================================================
-      # SOPS Template for .env Configuration File
-      # =========================================================================
-      # paperless-ai reads configuration from /app/data/.env file, not from
-      # environment variables. We mount this file directly into the container.
-      sops.templates."${serviceName}-env" = {
-        owner = "root";
-        group = "root";
-        mode = "0444"; # Readable by container user
-        content = ''
-          # Initial Setup - always 'no' since .env is read-only (managed by NixOS/SOPS)
-          # All configuration must be done via NixOS module options
-          PAPERLESS_AI_INITIAL_SETUP=no
-
-          # Paperless-ngx Integration
-          PAPERLESS_API_URL=${cfg.paperless.apiUrl}
-          PAPERLESS_API_TOKEN=${config.sops.placeholder."paperless-ai/paperless_token"}
-          PAPERLESS_USERNAME=${cfg.paperless.username}
-          # Python RAG service uses different env var names
-          PAPERLESS_URL=${cfg.paperless.apiUrl}
-
-          # LLM Configuration
-          AI_PROVIDER=${cfg.llm.provider}
-          ${lib.optionalString (cfg.llm.baseUrl != null) "CUSTOM_BASE_URL=${cfg.llm.baseUrl}"}
-          CUSTOM_MODEL=${cfg.llm.model}
-          ${lib.optionalString (cfg.llm.apiKeyFile != null) "CUSTOM_API_KEY=${config.sops.placeholder."paperless-ai/llm_api_key"}"}
-          # Some backends also check these env vars
-          OPENAI_API_KEY=
-          OPENAI_MODEL=
-
-          # Scanning Configuration
-          SCAN_INTERVAL=${cfg.scan.interval}
-          ADD_AI_PROCESSED_TAG=${if cfg.scan.addAiProcessedTag then "yes" else "no"}
-          AI_PROCESSED_TAG_NAME=${cfg.scan.aiProcessedTagName}
-          USE_EXISTING_DATA=${if cfg.scan.useExistingData then "yes" else "no"}
-          PROCESS_PREDEFINED_DOCUMENTS=${if cfg.scan.processPredefinedDocuments then "yes" else "no"}
-
-          # Tag Configuration
-          TAGS=${lib.concatStringsSep "," cfg.tags.trigger}
-          USE_PROMPT_TAGS=${if cfg.tags.usePromptTags then "yes" else "no"}
-          PROMPT_TAGS=${lib.concatStringsSep "," cfg.tags.promptTags}
-
-          # AI Function Limits
-          ACTIVATE_TAGGING=${if cfg.aiFunctions.tagging then "yes" else "no"}
-          ACTIVATE_CORRESPONDENTS=${if cfg.aiFunctions.correspondents then "yes" else "no"}
-          ACTIVATE_DOCUMENT_TYPE=${if cfg.aiFunctions.documentType then "yes" else "no"}
-          ACTIVATE_TITLE=${if cfg.aiFunctions.title then "yes" else "no"}
-          ACTIVATE_CUSTOM_FIELDS=${if cfg.aiFunctions.customFields then "yes" else "no"}
-
-          # System Prompt (newlines escaped for .env format)
-          SYSTEM_PROMPT=${lib.replaceStrings ["\n"] ["\\n"] cfg.systemPrompt}
-
-          # API Authentication (for paperless-ai's own API endpoints)
-          ${lib.optionalString (cfg.apiKeyFile != null) ''API_KEY=${config.sops.placeholder."paperless-ai/api_key"}''}
-
-          # System Configuration
-          TZ=${cfg.timezone}
+          <b>Quick Actions:</b>
+          1. Check logs:
+             <code>ssh ''${hostname} 'journalctl -u ''${serviceName} -n 100'</code>
+          2. Restart service:
+             <code>ssh ''${hostname} 'systemctl restart ''${serviceName}'</code>
         '';
       };
-
-      # =========================================================================
-      # Container Configuration
-      # =========================================================================
-      virtualisation.oci-containers.containers.${serviceName} = podmanLib.mkContainer serviceName {
-        image = cfg.image;
-        # Configuration is read from /app/data/.env file
-        # Only system-level env vars needed here for path redirects
-        environment = {
-          TZ = cfg.timezone;
-
-          # Writable paths are mounted from dataDir (allows running as non-root)
-          # These env vars ensure apps write to mounted locations
-          HOME = "/app/data";
-          PM2_HOME = "/app/.pm2"; # Mounted from ${dataDir}/.pm2
-          NLTK_DATA = "/app/nltk_data"; # Mounted from ${dataDir}/nltk_data
-        };
-
-        volumes = [
-          "${cfg.dataDir}:/app/data:rw"
-          # Mount SOPS-rendered .env file directly (symlinks don't work in containers)
-          "${config.sops.templates."${serviceName}-env".path}:/app/data/.env:ro"
-          # Additional writable paths (container expects to write here)
-          "${cfg.dataDir}/logs:/app/logs:rw"
-          "${cfg.dataDir}/.pm2:/app/.pm2:rw"
-          "${cfg.dataDir}/nltk_data:/app/nltk_data:rw"
-          "${cfg.dataDir}/openapi:/app/OPENAPI:rw"
-          # Only mount images subdir - /app/public contains static CSS/JS assets
-          "${cfg.dataDir}/public-images:/app/public/images:rw"
-        ];
-
-        ports = [
-          "127.0.0.1:${toString paperlessAiPort}:3000"
-        ];
-
-        resources = cfg.resources;
-
-        extraOptions = [
-          "--pull=newer"
-          # Use UID:GID (writable paths redirected to /app/data via env vars)
-          "--user=${toString config.users.users.${cfg.user}.uid}:${toString config.users.groups.${cfg.group}.gid}"
-        ] ++ lib.optionals (cfg.healthcheck != null && cfg.healthcheck.enable) [
-          # Health check: verify web UI is responding (uses upstream /health endpoint)
-          # Note: Container internally always runs on port 3000, cfg.port is external mapping
-          ''--health-cmd=curl -f http://127.0.0.1:3000/health || exit 1''
-          "--health-interval=${cfg.healthcheck.interval}"
-          "--health-timeout=${cfg.healthcheck.timeout}"
-          "--health-retries=${toString cfg.healthcheck.retries}"
-          "--health-start-period=${cfg.healthcheck.startPeriod}"
-          "--health-on-failure=${cfg.healthcheck.onFailure}"
-        ];
-      };
-
-      # =========================================================================
-      # Systemd Service Configuration
-      # =========================================================================
-      systemd.services."${config.virtualisation.oci-containers.backend}-${serviceName}" = lib.mkMerge [
-        # Core dependencies - wait for SOPS to create .env file
-        {
-          wants = [ "sops-nix.service" ];
-          after = [ "sops-nix.service" ];
-        }
-        # Failure notifications
-        (lib.mkIf (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
-          unitConfig.OnFailure = [ "notify@${serviceName}-failure:%n.service" ];
-        })
-        # Preseed dependency
-        (lib.mkIf cfg.preseed.enable {
-          wants = [ "preseed-${serviceName}.service" ];
-          after = [ "preseed-${serviceName}.service" ];
-        })
-      ];
-
-      # =========================================================================
-      # Notification Template
-      # =========================================================================
-      modules.notifications.templates = lib.mkIf (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
-        "${serviceName}-failure" = {
-          enable = lib.mkDefault true;
-          priority = lib.mkDefault "high";
-          title = lib.mkDefault ''<b><font color="red">✗ Service Failed: Paperless-AI</font></b>'';
-          body = lib.mkDefault ''
-            <b>Host:</b> ''${hostname}
-            <b>Service:</b> <code>''${serviceName}</code>
-
-            The Paperless-AI document tagging service has entered a failed state.
-
-            <b>Quick Actions:</b>
-            1. Check logs:
-               <code>ssh ''${hostname} 'journalctl -u ''${serviceName} -n 100'</code>
-            2. Restart service:
-               <code>ssh ''${hostname} 'systemctl restart ''${serviceName}'</code>
-          '';
-        };
-      };
-    })
-
-    # =========================================================================
-    # Preseed Service
-    # =========================================================================
-    (lib.mkIf (cfg.enable && cfg.preseed.enable) (
-      storageHelpers.mkPreseedService {
-        inherit serviceName;
-        dataset = datasetPath;
-        mountpoint = cfg.dataDir;
-        mainServiceUnit = mainServiceUnit;
-        replicationCfg = replicationConfig;
-        datasetProperties = {
-          recordsize = "16K";
-          compression = "zstd";
-          "com.sun:auto-snapshot" = "true";
-        };
-        resticRepoUrl = cfg.preseed.repositoryUrl;
-        resticPasswordFile = cfg.preseed.passwordFile;
-        resticEnvironmentFile = cfg.preseed.environmentFile;
-        resticPaths = [ cfg.dataDir ];
-        restoreMethods = cfg.preseed.restoreMethods;
-        hasCentralizedNotifications = hasCentralizedNotifications;
-        owner = cfg.user;
-        group = cfg.group;
-      }
-    ))
-  ];
+  };
 }

--- a/modules/nixos/services/qui/default.nix
+++ b/modules/nixos/services/qui/default.nix
@@ -1,3 +1,8 @@
+# modules/nixos/services/qui/default.nix
+#
+# qui - Modern web interface for qBittorrent
+#
+# Factory-based implementation (see lib/service-factory.nix).
 { lib
 , mylib
 , pkgs
@@ -5,85 +10,72 @@
 , podmanLib
 , ...
 }:
+
 let
-  # Storage helpers via mylib injection (centralized import)
-  storageHelpers = mylib.storageHelpers pkgs;
-  # Import shared type definitions
-  sharedTypes = mylib.types;
-
-  cfg = config.modules.services.qui;
-  storageCfg = config.modules.storage;
-  mainServiceName = "${config.virtualisation.oci-containers.backend}-qui";
-  mainServiceUnit = "${mainServiceName}.service";
-  datasetPath = "${storageCfg.datasets.parentDataset}/qui";
-
-  # Build replication config for preseed (walks up dataset tree to find inherited config)
-  replicationConfig = storageHelpers.mkReplicationConfig { inherit config datasetPath; };
-  allowEmptyBootstrap = storageHelpers.allowEmptyBootstrapFor {
-    inherit config;
-    datasetName = "qui";
-  };
+  # Resolved lazily after option evaluation - safe to reference here.
+  quiPort = config.modules.services.qui.port;
 in
-{
-  options.modules.services.qui = {
-    enable = lib.mkEnableOption "qui - Modern web interface for qBittorrent";
+mylib.mkContainerService {
+  inherit lib mylib pkgs config podmanLib;
 
-    dataDir = lib.mkOption {
-      type = lib.types.path;
-      default = "/var/lib/qui";
-      description = ''
-        Path to qui data directory.
+  name = "qui";
+  description = "qui";
 
-        This directory stores:
-        - config.toml (auto-generated on first run)
-        - qui.db (SQLite database for state)
-        - tracker-icons/ (cached tracker favicons)
-        - logs (if logPath is configured)
-      '';
+  spec = {
+    # Core service configuration
+    port = 7476;
+    image = "ghcr.io/autobrr/qui:latest";
+    operationalProfile = "media";
+    displayName = "qui";
+    function = "qbittorrent_ui";
+
+    healthCommand = "wget --no-verbose --tries=1 --spider http://localhost:${toString quiPort}/health || exit 1";
+    startPeriod = "30s";
+
+    # ZFS tuning - 16K recordsize optimal for the SQLite database (qui.db),
+    # lz4 for fast compression of database and config files.
+    zfsRecordSize = "16K";
+    zfsCompression = "lz4";
+
+    # qui is lightweight but may consume more resources with multiple
+    # qBittorrent instances or large torrent collections (>1000 torrents).
+    resources = {
+      memory = "512M";
+      memoryReservation = "256M";
+      cpus = "1.0";
     };
 
-    user = lib.mkOption {
-      type = lib.types.str;
-      default = "980";
-      description = "User account under which qui runs (numeric UID as string).";
+    environment = { cfg, ... }: {
+      QUI__HOST = cfg.hostAddress;
+      QUI__PORT = toString cfg.port;
+      QUI__BASE_URL = cfg.baseUrl;
+      QUI__LOG_LEVEL = cfg.logLevel;
+      QUI__CHECK_FOR_UPDATES = if cfg.checkForUpdates then "true" else "false";
+    } // lib.optionalAttrs cfg.metricsEnabled {
+      QUI__METRICS_ENABLED = "true";
+      QUI__METRICS_HOST = cfg.metricsHost;
+      QUI__METRICS_PORT = toString cfg.metricsPort;
+    } // lib.optionalAttrs (cfg.oidc != null && cfg.oidc.enabled) {
+      QUI__OIDC_ENABLED = "true";
+      QUI__OIDC_ISSUER = cfg.oidc.issuer;
+      QUI__OIDC_CLIENT_ID = cfg.oidc.clientId;
+      QUI__OIDC_REDIRECT_URL = cfg.oidc.redirectUrl;
+      QUI__OIDC_DISABLE_BUILT_IN_LOGIN = if cfg.oidc.disableBuiltInLogin then "true" else "false";
     };
 
-    group = lib.mkOption {
-      type = lib.types.str;
-      default = "media";
-      description = "Group under which qui runs.";
-    };
+    # Own volume list (dataDir without explicit :rw, plus host-provided
+    # extra volumes for cross-seed hardlink mode).
+    skipDefaultConfigMount = true;
+    volumes = cfg: [
+      "${cfg.dataDir}:/config"
+    ] ++ cfg.extraVolumes;
 
-    image = lib.mkOption {
-      type = lib.types.str;
-      default = "ghcr.io/autobrr/qui:latest";
-      description = ''
-        Full container image name including tag or digest.
+    # Extra /etc/hosts entries (hairpin NAT workaround)
+    extraOptions = { cfg, ... }:
+      lib.mapAttrsToList (host: ip: "--add-host=${host}:${ip}") cfg.extraHosts;
+  };
 
-        Best practices:
-        - Pin to specific version tags
-        - Use digest pinning for immutability
-        - Avoid 'latest' tag for production systems
-
-        Use Renovate bot to automate version updates with digest pinning.
-
-        Multi-architecture support: linux/amd64, linux/arm64
-      '';
-      example = "ghcr.io/autobrr/qui:v1.7.0@sha256:abc...";
-    };
-
-    podmanNetwork = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
-      description = ''
-        Podman network to attach the container to.
-
-        Use "media-services" to enable DNS resolution to qBittorrent and other media services.
-        Required for qui to act as a client proxy for Sonarr/Radarr/autobrr.
-      '';
-      example = "media-services";
-    };
-
+  extraOptions = {
     extraHosts = lib.mkOption {
       type = lib.types.attrsOf lib.types.str;
       default = { };
@@ -97,12 +89,6 @@ in
         "id.holthome.net" = "10.89.0.1";
         "auth.example.com" = "10.89.0.1";
       };
-    };
-
-    port = lib.mkOption {
-      type = lib.types.port;
-      default = 7476;
-      description = "Port for qui web interface";
     };
 
     hostAddress = lib.mkOption {
@@ -128,12 +114,6 @@ in
         Must include trailing slash when using subdirectory.
       '';
       example = "/qui/";
-    };
-
-    timezone = lib.mkOption {
-      type = lib.types.str;
-      default = "America/New_York";
-      description = "Timezone for the container";
     };
 
     logLevel = lib.mkOption {
@@ -267,54 +247,19 @@ in
       '';
     };
 
-    resources = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.containerResourcesSubmodule;
-      default = {
-        memory = "512M";
-        memoryReservation = "256M";
-        cpus = "1.0";
-      };
-      description = ''
-        Resource limits for the container.
-
-        qui is lightweight but may consume more resources with:
-        - Multiple qBittorrent instances
-        - Large torrent collections (>1000 torrents)
-        - Frequent backup operations
-      '';
-    };
-
-    healthcheck = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.healthcheckSubmodule;
-      default = {
-        enable = true;
-        interval = "30s";
-        timeout = "10s";
-        retries = 3;
-        startPeriod = "30s";
-      };
-      description = "Container health check configuration";
-    };
-
-    # Standardized reverse proxy integration
-    reverseProxy = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.reverseProxySubmodule;
+    # Backups are configured explicitly by hosts (overrides the factory
+    # default of enabled). qui has a built-in qBittorrent backup/restore
+    # feature; this option is for qui's own state only.
+    backup = lib.mkOption {
+      type = lib.types.nullOr mylib.types.backupSubmodule;
       default = null;
-      description = ''
-        Reverse proxy configuration for qui web interface.
-
-        qui includes built-in client proxy feature that can:
-        - Proxy qBittorrent API for Sonarr/Radarr/autobrr
-        - Manage authentication automatically
-        - Reduce qBittorrent login thrashing
-
-        Configure proxy keys in qui UI after deployment.
-      '';
+      description = "Backup configuration for qui data (config.toml, qui.db, tracker-icons)";
     };
 
-    # Standardized metrics collection pattern
+    # Scrape registration is opt-in and separate from qui's own
+    # metricsEnabled toggle (overrides the factory default of enabled).
     metrics = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.metricsSubmodule;
+      type = lib.types.nullOr mylib.types.metricsSubmodule;
       default = null;
       description = ''
         Prometheus metrics collection configuration for qui.
@@ -323,323 +268,76 @@ in
         This option controls whether to register qui with Prometheus scraping.
       '';
     };
-
-    # Standardized logging integration
-    logging = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.loggingSubmodule;
-      default = {
-        enable = true;
-        driver = "journald";
-      };
-      description = "Logging configuration for qui container";
-    };
-
-    notifications = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.notificationSubmodule;
-      default = lib.mkIf cfg.enable {
-        enable = lib.mkDefault true;
-        channels = {
-          onFailure = [ "media-alerts" ];
-        };
-        customMessages = {
-          failure = "qui qBittorrent web interface failed on ${config.networking.hostName}";
-        };
-      };
-      description = "Notification configuration for qui service events";
-    };
-
-    # Standardized backup configuration
-    backup = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.backupSubmodule;
-      default = null;
-      description = ''
-        Backup configuration for qui data.
-
-        qui stores:
-        - config.toml (configuration file)
-        - qui.db (SQLite database with users, instances, proxy keys, API keys)
-        - tracker-icons/ (cached favicon PNGs)
-
-        Recommended recordsize: 16K (optimal for SQLite database)
-
-        Note: qui has built-in qBittorrent backup/restore feature.
-        This backup config is for qui's own state, not qBittorrent backups.
-      '';
-    };
-
-    # NOTE: Dataset is managed via modules.storage.datasets.services.qui (declarative pattern).
-    # This option is removed as it was unused - the module only checked for null/non-null.
-    # Dataset configuration happens automatically when the service is enabled.
-
-    preseed = {
-      enable = lib.mkEnableOption "automatic data restore before service start";
-      repositoryUrl = lib.mkOption {
-        type = lib.types.str;
-        description = "Restic repository URL for restore operations";
-      };
-      passwordFile = lib.mkOption {
-        type = lib.types.path;
-        description = "Path to Restic password file";
-      };
-      environmentFile = lib.mkOption {
-        type = lib.types.nullOr lib.types.path;
-        default = null;
-        description = "Optional environment file for Restic (e.g., for B2 credentials)";
-      };
-      restoreMethods = lib.mkOption {
-        type = lib.types.listOf (lib.types.enum [ "syncoid" "local" "restic" ]);
-        default = [ "syncoid" "local" "restic" ];
-        description = ''
-          Order and selection of restore methods to attempt. Methods are tried
-          sequentially until one succeeds.
-        '';
-      };
-    };
   };
 
-  config =
-    let
-      # Build environment variables
-      environmentVars = {
-        TZ = cfg.timezone;
-        QUI__HOST = cfg.hostAddress;
-        QUI__PORT = toString cfg.port;
-        QUI__BASE_URL = cfg.baseUrl;
-        QUI__LOG_LEVEL = cfg.logLevel;
-        QUI__CHECK_FOR_UPDATES = if cfg.checkForUpdates then "true" else "false";
-      } // lib.optionalAttrs cfg.metricsEnabled {
-        QUI__METRICS_ENABLED = "true";
-        QUI__METRICS_HOST = cfg.metricsHost;
-        QUI__METRICS_PORT = toString cfg.metricsPort;
-      } // lib.optionalAttrs (cfg.oidc != null && cfg.oidc.enabled) {
-        QUI__OIDC_ENABLED = "true";
-        QUI__OIDC_ISSUER = cfg.oidc.issuer;
-        QUI__OIDC_CLIENT_ID = cfg.oidc.clientId;
-        QUI__OIDC_REDIRECT_URL = cfg.oidc.redirectUrl;
-        QUI__OIDC_DISABLE_BUILT_IN_LOGIN = if cfg.oidc.disableBuiltInLogin then "true" else "false";
-      };
-
-    in
-    lib.mkMerge [
-      (lib.mkIf cfg.enable {
-        # Validate configuration
-        assertions = [
-          {
-            assertion = cfg.backup == null || !cfg.backup.enable || cfg.backup.repository != null;
-            message = "qui backup.enable requires backup.repository to be set (use primaryRepo.name from host config).";
-          }
-          {
-            assertion = !cfg.preseed.enable || cfg.preseed.repositoryUrl != "";
-            message = "qui preseed.enable requires preseed.repositoryUrl to be set.";
-          }
-          {
-            assertion = !cfg.preseed.enable || (builtins.isPath cfg.preseed.passwordFile || builtins.isString cfg.preseed.passwordFile);
-            message = "qui preseed.enable requires preseed.passwordFile to be set.";
-          }
-          {
-            assertion = lib.hasPrefix "/" cfg.baseUrl;
-            message = "qui baseUrl must be an absolute path starting with '/' (e.g., '/' or '/qui/').";
-          }
-          {
-            assertion = cfg.baseUrl == "/" || lib.hasSuffix "/" cfg.baseUrl;
-            message = "qui baseUrl must end with a trailing slash ('/') when using subdirectory paths (e.g., '/qui/').";
-          }
-          {
-            assertion = let path = lib.removeSuffix "/" cfg.baseUrl; in path == "" || !lib.hasSuffix "/" path;
-            message = "qui baseUrl contains redundant trailing slashes (e.g., '//' or '/qui//').";
-          }
-          {
-            assertion = cfg.oidc == null || !cfg.oidc.enabled || (builtins.isPath cfg.oidc.clientSecretFile || builtins.isString cfg.oidc.clientSecretFile);
-            message = "qui OIDC authentication requires oidc.clientSecretFile to be set.";
-          }
-          {
-            assertion = cfg.oidc == null || !cfg.oidc.enabled || (cfg.oidc.issuer != "" && lib.hasPrefix "http" cfg.oidc.issuer);
-            message = "qui OIDC authentication requires oidc.issuer to be a valid URL starting with 'http' (e.g., 'https://auth.example.com/realms/main').";
-          }
-          {
-            assertion = cfg.oidc == null || !cfg.oidc.enabled || cfg.oidc.clientId != "";
-            message = "qui OIDC authentication requires oidc.clientId to be set.";
-          }
-          {
-            assertion = cfg.oidc == null || !cfg.oidc.enabled || (cfg.oidc.redirectUrl != "" && lib.hasPrefix "http" cfg.oidc.redirectUrl);
-            message = "qui OIDC authentication requires oidc.redirectUrl to be a valid URL starting with 'http' (e.g., 'https://qui.example.com/api/auth/oidc/callback').";
-          }
-        ];
-
-        # User configuration
-        users.users.qui = {
-          uid = lib.mkDefault (lib.toInt cfg.user);
-          group = cfg.group;
-          isSystemUser = true;
-          description = "qui service user";
-          home = cfg.dataDir;
-          createHome = true;
-        };
-
-        users.groups.${cfg.group} = { };
-
-        # Declare dataset requirements for per-service ZFS isolation
-        # This integrates with the storage.datasets module to automatically
-        # create tank/services/qui with appropriate ZFS properties
-        # Note: OCI containers don't support StateDirectory, so we explicitly set permissions
-        # via tmpfiles by keeping owner/group/mode here
-        modules.storage.datasets.services.qui = {
-          mountpoint = cfg.dataDir;
-          recordsize = lib.mkDefault "16K"; # Optimal for SQLite databases (qui.db)
-          compression = lib.mkDefault "lz4"; # Fast compression for database and config files
-          properties = {
-            "com.sun:auto-snapshot" = "true"; # Enable automatic snapshots
-            # snapdir managed by sanoid module - no longer needed with clone-based backups
-          };
-          # Ownership matches the container user/group
-          owner = cfg.user;
-          group = cfg.group;
-          mode = "0750"; # Allow group read access for backup systems
-        };
-
-        # NOTE: ZFS snapshots and replication for qui dataset should be configured
-        # in the host-level config (e.g., hosts/forge/default.nix), not here.
-        # Reason: Replication targets are host-specific (forge → nas-1, luna → nas-2, etc.)
-        # Defining them in a shared module would hardcode "forge" in the target path,
-        # breaking reusability across different hosts.
-
-        # Note: Backup integration now handled by backup-integration module
-        # The backup submodule configuration will be auto-discovered and converted
-        # to a Restic job named "service-qui" with the specified settings
-
-        # Container configuration
-        virtualisation.oci-containers.containers.qui = podmanLib.mkContainer "qui" {
-          image = cfg.image;
-          autoStart = true;
-
-          environment = environmentVars;
-
-          # Use environmentFiles for OIDC client secret
-          environmentFiles = lib.optionals (cfg.oidc != null && cfg.oidc.enabled) [
-            config.sops.templates."qui-env".path
-          ];
-
-          volumes = [
-            "${cfg.dataDir}:/config"
-          ] ++ cfg.extraVolumes;
-
-          ports = [
-            "${toString cfg.port}:${toString cfg.port}"
-          ] ++ lib.optionals cfg.metricsEnabled [
-            "${cfg.metricsHost}:${toString cfg.metricsPort}:${toString cfg.metricsPort}"
-          ];
-
-          resources = cfg.resources;
-
-          extraOptions = [
-            "--pull=newer" # Automatically pull newer images
-            "--user=${cfg.user}:${toString config.users.groups.${cfg.group}.gid}"
-          ] ++ lib.optionals (cfg.podmanNetwork != null) [
-            "--network=${cfg.podmanNetwork}"
-          ] ++ lib.optionals (cfg.extraHosts != { }) (
-            lib.mapAttrsToList (host: ip: "--add-host=${host}:${ip}") cfg.extraHosts
-          ) ++ lib.optionals (cfg.healthcheck != null && cfg.healthcheck.enable) [
-            "--health-cmd=wget --no-verbose --tries=1 --spider http://localhost:${toString cfg.port}/health || exit 1"
-            "--health-interval=${cfg.healthcheck.interval}"
-            "--health-timeout=${cfg.healthcheck.timeout}"
-            "--health-retries=${toString cfg.healthcheck.retries}"
-            "--health-start-period=${cfg.healthcheck.startPeriod}"
-            "--health-on-failure=${cfg.healthcheck.onFailure}"
-          ];
-        };
-
-        # Apply additional service configuration
-        systemd.services.${mainServiceName} = lib.mkMerge [
-          {
-            serviceConfig = {
-              Restart = "always";
-              RestartSec = "10s";
-            };
-          }
-          (lib.mkIf (cfg.podmanNetwork != null) {
-            requires = [ "podman-network-${cfg.podmanNetwork}.service" ];
-            after = [ "podman-network-${cfg.podmanNetwork}.service" ];
-          })
-          (lib.mkIf cfg.preseed.enable {
-            requires = lib.optional (!allowEmptyBootstrap) "preseed-qui.service";
-            wants = lib.optional allowEmptyBootstrap "preseed-qui.service";
-            after = [ "preseed-qui.service" ];
-          })
-        ];
-
-        # Automatically register with Caddy reverse proxy if enabled
-        modules.services.caddy.virtualHosts.qui = lib.mkIf (cfg.reverseProxy != null && cfg.reverseProxy.enable) {
-          enable = true;
-          hostName = cfg.reverseProxy.hostName;
-
-          # Use structured backend configuration from shared types
-          backend = {
-            scheme = "http"; # qui uses HTTP locally
-            host = "127.0.0.1";
-            port = cfg.port;
-          };
-
-          # Authentication configuration from shared types
-          auth = cfg.reverseProxy.auth;
-
-          # Security configuration from shared types
-          security = cfg.reverseProxy.security;
-
-          extraConfig = cfg.reverseProxy.extraConfig;
-        };
-
-        # Note: Prometheus scrape config should be added manually in host configuration
-        # Example:
-        #   services.prometheus.scrapeConfigs = [{
-        #     job_name = "qui";
-        #     static_configs = [{ targets = [ "127.0.0.1:9074" ]; }];
-        #   }];
-
-        # Notifications integration
-        modules.notifications.templates = lib.mkIf ((config.modules.notifications.enable or false) && cfg.notifications != null && cfg.notifications.enable) {
-          "qui-failure" = {
-            enable = lib.mkDefault true;
-            priority = lib.mkDefault "high";
-            title = lib.mkDefault ''<b><font color="red">✗ Service Failed: qui</font></b>'';
-            body = lib.mkDefault ''
-              <b>Host:</b> ''${hostname}
-              <b>Service:</b> <code>''${serviceName}</code>
-
-              The qui qBittorrent interface service has entered a failed state.
-
-              <b>Quick Actions:</b>
-              1. Check logs:
-                 <code>ssh ''${hostname} 'journalctl -u ''${serviceName} -n 100'</code>
-              2. Restart service:
-                 <code>ssh ''${hostname} 'systemctl restart ''${serviceName}'</code>
-            '';
-          };
-        };
-      })
-
-      # Add the preseed service itself
-      (lib.mkIf (cfg.enable && cfg.preseed.enable) (
-        storageHelpers.mkPreseedService {
-          serviceName = "qui";
-          dataset = datasetPath;
-          mountpoint = cfg.dataDir;
-          mainServiceUnit = mainServiceUnit;
-          replicationCfg = replicationConfig; # Pass the auto-discovered replication config
-          datasetProperties = {
-            recordsize = "16K"; # Optimal for SQLite databases
-            compression = "zstd"; # Better compression for text/config files
-            "com.sun:auto-snapshot" = "true"; # Enable sanoid snapshots for this dataset
-          };
-          resticRepoUrl = cfg.preseed.repositoryUrl;
-          resticPasswordFile = cfg.preseed.passwordFile;
-          resticEnvironmentFile = cfg.preseed.environmentFile;
-          resticPaths = [ cfg.dataDir ];
-          restoreMethods = cfg.preseed.restoreMethods;
-          inherit allowEmptyBootstrap;
-          hasCentralizedNotifications = config.modules.notifications.enable or false;
-          owner = cfg.user;
-          group = cfg.group;
-        }
-      ))
+  extraConfig = cfg: {
+    assertions = [
+      {
+        assertion = lib.hasPrefix "/" cfg.baseUrl;
+        message = "qui baseUrl must be an absolute path starting with '/' (e.g., '/' or '/qui/').";
+      }
+      {
+        assertion = cfg.baseUrl == "/" || lib.hasSuffix "/" cfg.baseUrl;
+        message = "qui baseUrl must end with a trailing slash ('/') when using subdirectory paths (e.g., '/qui/').";
+      }
+      {
+        assertion = let path = lib.removeSuffix "/" cfg.baseUrl; in path == "" || !lib.hasSuffix "/" path;
+        message = "qui baseUrl contains redundant trailing slashes (e.g., '//' or '/qui//').";
+      }
+      {
+        assertion = cfg.oidc == null || !cfg.oidc.enabled || (builtins.isPath cfg.oidc.clientSecretFile || builtins.isString cfg.oidc.clientSecretFile);
+        message = "qui OIDC authentication requires oidc.clientSecretFile to be set.";
+      }
+      {
+        assertion = cfg.oidc == null || !cfg.oidc.enabled || (cfg.oidc.issuer != "" && lib.hasPrefix "http" cfg.oidc.issuer);
+        message = "qui OIDC authentication requires oidc.issuer to be a valid URL starting with 'http' (e.g., 'https://auth.example.com/realms/main').";
+      }
+      {
+        assertion = cfg.oidc == null || !cfg.oidc.enabled || cfg.oidc.clientId != "";
+        message = "qui OIDC authentication requires oidc.clientId to be set.";
+      }
+      {
+        assertion = cfg.oidc == null || !cfg.oidc.enabled || (cfg.oidc.redirectUrl != "" && lib.hasPrefix "http" cfg.oidc.redirectUrl);
+        message = "qui OIDC authentication requires oidc.redirectUrl to be a valid URL starting with 'http' (e.g., 'https://qui.example.com/api/auth/oidc/callback').";
+      }
     ];
+
+    # qui's home is its data directory (pre-factory behavior)
+    users.users.qui = {
+      home = cfg.dataDir;
+      createHome = true;
+    };
+
+    virtualisation.oci-containers.containers.qui = {
+      # OIDC client secret via SOPS template
+      environmentFiles = lib.optionals (cfg.oidc != null && cfg.oidc.enabled) [
+        config.sops.templates."qui-env".path
+      ];
+      # Prometheus metrics endpoint on a separate port
+      ports = lib.optionals cfg.metricsEnabled [
+        "${cfg.metricsHost}:${toString cfg.metricsPort}:${toString cfg.metricsPort}"
+      ];
+    };
+
+    systemd.services."${config.virtualisation.oci-containers.backend}-qui" = {
+      serviceConfig.RestartSec = "10s";
+    };
+
+    # Preserve the pre-factory notification wording
+    modules.notifications.templates."qui-failure" =
+      lib.mkIf (config.modules.notifications.enable or false && cfg.notifications != null && cfg.notifications.enable) {
+        body = ''
+          <b>Host:</b> ''${hostname}
+          <b>Service:</b> <code>''${serviceName}</code>
+
+          The qui qBittorrent interface service has entered a failed state.
+
+          <b>Quick Actions:</b>
+          1. Check logs:
+             <code>ssh ''${hostname} 'journalctl -u ''${serviceName} -n 100'</code>
+          2. Restart service:
+             <code>ssh ''${hostname} 'systemctl restart ''${serviceName}'</code>
+        '';
+      };
+  };
 }

--- a/modules/nixos/services/seerr/default.nix
+++ b/modules/nixos/services/seerr/default.nix
@@ -1,3 +1,9 @@
+# modules/nixos/services/seerr/default.nix
+#
+# Seerr - request management for Plex/Jellyfin/Emby
+# (rebranded/merged successor to Overseerr and Jellyseerr)
+#
+# Factory-based implementation (see lib/service-factory.nix).
 { lib
 , mylib
 , pkgs
@@ -5,89 +11,58 @@
 , podmanLib
 , ...
 }:
-let
-  # Storage helpers via mylib injection (centralized import)
-  storageHelpers = mylib.storageHelpers pkgs;
-  # Import shared type definitions
-  sharedTypes = mylib.types;
 
-  # Only cfg is needed at top level for mkIf condition
-  cfg = config.modules.services.seerr;
-in
-{
-  options.modules.services.seerr = {
-    enable = lib.mkEnableOption "Seerr";
+mylib.mkContainerService {
+  inherit lib mylib pkgs config podmanLib;
 
-    dataDir = lib.mkOption {
-      type = lib.types.path;
-      default = "/var/lib/seerr";
-      description = "Path to Seerr data directory";
+  name = "seerr";
+  description = "Seerr";
+
+  spec = {
+    # Core service configuration
+    port = 5055;
+    image = "ghcr.io/seerr-team/seerr:sha-adbcf80@sha256:2bfd7605fe24e3edbf704e893ac4b56a40a068facd30d2d0a524b915277a10f6";
+    operationalProfile = "media";
+    displayName = "Seerr";
+    function = "request_management";
+
+    # Health check - use /login instead of /api/v1/status; the status API tries
+    # to reach external services (Plex, Sonarr, etc.) and times out if they're
+    # unreachable.
+    healthCommand = "wget --no-verbose --tries=1 --spider http://localhost:5055/login || exit 1";
+    startPeriod = "60s";
+
+    # ZFS tuning - 16K recordsize is optimal for Seerr's SQLite database
+    zfsRecordSize = "16K";
+
+    # Resource limits. Note: 512MB may be insufficient for large libraries
+    # (50K+ items) - monitor and scale to 1-2GB if OOM kills are observed.
+    resources = {
+      memory = "512M";
+      memoryReservation = "256M";
+      cpus = "1.0";
     };
 
-    user = lib.mkOption {
-      type = lib.types.str;
-      default = "923";
-      description = "User account under which Seerr runs.";
-    };
+    # Official seerr image expects config at /app/config (not /config) and
+    # ships no init process (--init required).
+    skipDefaultConfigMount = true;
+    volumes = cfg: [
+      "${cfg.dataDir}:/app/config:rw"
+    ];
+    extraOptions = _: [ "--init" ];
 
-    group = lib.mkOption {
-      type = lib.types.str;
-      default = "media";
-      description = "Group under which Seerr runs.";
+    environment = _: {
+      LOG_LEVEL = "info";
     };
+  };
 
-    podmanNetwork = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
+  extraOptions = {
+    # Seerr has no native Prometheus metrics endpoint - keep metrics opt-in
+    # (overrides the factory default of enabled).
+    metrics = lib.mkOption {
+      type = lib.types.nullOr mylib.types.metricsSubmodule;
       default = null;
-      description = ''
-        Name of the Podman network to attach this container to.
-        Enables DNS resolution to other containers on the same network.
-        Network must be defined in `modules.virtualization.podman.networks`.
-      '';
-      example = "media-services";
-    };
-
-    image = lib.mkOption {
-      type = lib.types.str;
-      default = "ghcr.io/seerr-team/seerr:sha-adbcf80@sha256:2bfd7605fe24e3edbf704e893ac4b56a40a068facd30d2d0a524b915277a10f6";
-      description = ''
-        Full container image name including tag or digest.
-
-        This uses the official Seerr image from ghcr.io/seerr-team/seerr.
-
-        Seerr is the rebranded/merged successor to Overseerr and Jellyseerr.
-        Migration from Overseerr/Jellyseerr is automatic on first start.
-
-        Best practices:
-        - Pin to specific version tags (e.g., "v2.7.4")
-        - Use digest pinning for immutability (e.g., "v2.7.4@sha256:...")
-        - Avoid 'latest' tag for production systems
-
-        Use Renovate bot to automate version updates with digest pinning.
-      '';
-      example = "ghcr.io/seerr-team/seerr:v2.7.4@sha256:f3ad4f59e6e5e4a...";
-    };
-
-    timezone = lib.mkOption {
-      type = lib.types.str;
-      default = "America/New_York";
-      description = "Timezone for the container";
-    };
-
-    resources = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.containerResourcesSubmodule;
-      default = {
-        memory = "512M";
-        memoryReservation = "256M";
-        cpus = "1.0";
-      };
-      description = ''
-        Resource limits for the container.
-
-        Note: Default 512MB memory may be insufficient for large libraries (50K+ items).
-        Monitor memory usage and increase limits if you observe OOM kills or performance degradation.
-        Consider scaling to 1-2GB for production environments with extensive media collections.
-      '';
+      description = "Prometheus metrics collection configuration for Seerr (no native metrics support)";
     };
 
     dependsOn = lib.mkOption {
@@ -99,302 +74,39 @@ in
         This ensures Seerr starts after its dependencies are ready, preventing
         connection errors and log spam during startup. Service names should match
         the base service name without the "podman-" prefix or ".service" suffix.
-
-        Example: `dependsOn = [ "sonarr" "radarr" ];`
       '';
       example = [ "sonarr" "radarr" ];
     };
+  };
 
-    healthcheck = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.healthcheckSubmodule;
-      default = {
+  extraConfig = cfg: {
+    # Legacy seerr group (pre-factory module always created it; the factory
+    # only creates a group when cfg.group == service name, and Seerr runs
+    # under the shared "media" group).
+    users.groups.seerr = {
+      gid = lib.mkDefault (lib.toInt cfg.user);
+    };
+
+    # Start after declared dependencies (sonarr/radarr) to avoid connection
+    # errors during startup.
+    systemd.services."${config.virtualisation.oci-containers.backend}-seerr" = {
+      requires = map (s: "${config.virtualisation.oci-containers.backend}-${s}.service") cfg.dependsOn;
+      after = map (s: "${config.virtualisation.oci-containers.backend}-${s}.service") cfg.dependsOn;
+      serviceConfig.RestartSec = "10s";
+    };
+
+    # Backup integration using the standardized restic job pattern
+    modules.backup.restic.jobs = lib.mkIf (cfg.backup != null && cfg.backup.enable) {
+      seerr = {
         enable = true;
-        interval = "30s";
-        timeout = "10s";
-        retries = 3;
-        startPeriod = "60s";
-        onFailure = "kill";
-      };
-      description = "Container healthcheck configuration. Uses Podman native health checks with automatic restart on failure.";
-    };
-
-    # Standardized reverse proxy integration
-    reverseProxy = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.reverseProxySubmodule;
-      default = null;
-      description = "Reverse proxy configuration for Seerr web interface";
-    };
-
-    # Standardized metrics collection pattern
-    metrics = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.metricsSubmodule;
-      default = null;
-      description = "Prometheus metrics collection configuration for Seerr (no native metrics support)";
-    };
-
-    # Standardized logging integration
-    logging = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.loggingSubmodule;
-      default = {
-        enable = true;
-        driver = "journald";
-      };
-      description = "Logging configuration for Seerr";
-    };
-
-    notifications = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.notificationSubmodule;
-      default = {
-        enable = true;
-        channels = {
-          onFailure = [ "media-alerts" ];
-        };
-        customMessages = {
-          failure = "Seerr request management failed on ${config.networking.hostName}";
-        };
-      };
-      description = "Notification configuration for Seerr service events";
-    };
-
-    # Standardized backup configuration
-    backup = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.backupSubmodule;
-      default = null;
-      description = ''
-        Backup configuration for Seerr data.
-
-        Seerr stores all configuration and user data in a SQLite database at /var/lib/seerr.
-        This includes request history, user settings, and integration configurations.
-
-        Recommended recordsize: 16K (optimal for SQLite databases)
-      '';
-    };
-
-    # Dataset configuration with storage helper integration
-    dataset = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.datasetSubmodule;
-      default = null;
-      description = "ZFS dataset configuration for Seerr data directory";
-    };
-
-    preseed = {
-      enable = lib.mkEnableOption "automatic data restore before service start";
-      repositoryUrl = lib.mkOption {
-        type = lib.types.str;
-        description = "Restic repository URL for restore operations";
-      };
-      passwordFile = lib.mkOption {
-        type = lib.types.path;
-        description = "Path to Restic password file";
-      };
-      environmentFile = lib.mkOption {
-        type = lib.types.nullOr lib.types.path;
-        default = null;
-        description = "Optional environment file for Restic (e.g., for B2 credentials)";
-      };
-      restoreMethods = lib.mkOption {
-        type = lib.types.listOf (lib.types.enum [ "syncoid" "local" "restic" ]);
-        default = [ "syncoid" "local" "restic" ];
-        description = ''
-          Order and selection of restore methods to attempt. Methods are tried
-          sequentially until one succeeds. Examples:
-          - [ "syncoid" "local" "restic" ] - Default, try replication first
-          - [ "local" "restic" ] - Skip replication, try local snapshots first
-          - [ "restic" ] - Restic-only (for air-gapped systems)
-          - [ "local" "restic" "syncoid" ] - Local-first for quick recovery
-        '';
+        paths = [ cfg.dataDir ];
+        repository = cfg.backup.repository;
+        frequency = cfg.backup.frequency;
+        tags = cfg.backup.tags;
+        excludePatterns = cfg.backup.excludePatterns;
+        useSnapshots = cfg.backup.useSnapshots;
+        zfsDataset = cfg.backup.zfsDataset;
       };
     };
   };
-
-  config =
-    let
-      # Move config-dependent variables here to avoid infinite recursion
-      storageCfg = config.modules.storage;
-      seerrPort = 5055;
-      mainServiceName = "${config.virtualisation.oci-containers.backend}-seerr";
-      mainServiceUnit = "${mainServiceName}.service";
-      datasetPath = "${storageCfg.datasets.parentDataset}/seerr";
-
-      # Build replication config for preseed (walks up dataset tree to find inherited config)
-      replicationConfig = storageHelpers.mkReplicationConfig { inherit config datasetPath; };
-      allowEmptyBootstrap = storageHelpers.allowEmptyBootstrapFor {
-        inherit config;
-        datasetName = "seerr";
-      };
-
-      hasCentralizedNotifications = config.modules.notifications.alertmanager.enable or false;
-    in
-    lib.mkMerge [
-      (lib.mkIf cfg.enable {
-        assertions = [
-          {
-            assertion = cfg.reverseProxy != null -> cfg.reverseProxy.enable;
-            message = "Seerr reverse proxy must be explicitly enabled when configured";
-          }
-          {
-            assertion = cfg.preseed.enable -> (cfg.preseed.repositoryUrl != "");
-            message = "Seerr preseed.enable requires preseed.repositoryUrl to be set.";
-          }
-          {
-            assertion = cfg.preseed.enable -> (builtins.isPath cfg.preseed.passwordFile || builtins.isString cfg.preseed.passwordFile);
-            message = "Seerr preseed.enable requires preseed.passwordFile to be set.";
-          }
-          {
-            assertion = cfg.backup != null -> cfg.backup.enable;
-            message = "Seerr backup must be explicitly enabled when configured";
-          }
-        ];
-
-        # Warnings for missing critical configuration
-        warnings =
-          (lib.optional (cfg.reverseProxy == null) "Seerr has no reverse proxy configured. Service will only be accessible locally.")
-          ++ (lib.optional (cfg.backup == null) "Seerr has no backup configured. User data and settings will not be protected.");
-
-        # Create ZFS dataset for Seerr data
-        modules.storage.datasets.services.seerr = {
-          mountpoint = cfg.dataDir;
-          # 16K recordsize is optimal for SQLite databases (Seerr uses SQLite for all data storage)
-          # Rationale: SQLite's default page size is 4KB, but modern SSDs benefit from larger block sizes.
-          # 16K provides a balance between:
-          # - Reduced write amplification (fewer ZFS metadata updates per SQLite transaction)
-          # - Efficient SSD alignment (matches common NAND page sizes)
-          # - Minimal read overhead (SQLite rarely needs sub-16K reads)
-          # This is a well-established best practice for SQLite on ZFS.
-          recordsize = "16K";
-          compression = "zstd";
-          properties = {
-            "com.sun:auto-snapshot" = "true";
-          };
-          owner = cfg.user;
-          group = cfg.group;
-          mode = "0750";
-        };
-
-        # Create system user for Seerr
-        users.users.seerr = {
-          uid = lib.mkDefault (lib.toInt cfg.user);
-          group = cfg.group;
-          isSystemUser = true;
-          description = "Seerr service user";
-        };
-
-        # Create system group for Seerr
-        users.groups.seerr = {
-          gid = lib.mkDefault (lib.toInt cfg.user);
-        };
-
-        # Seerr container configuration
-        # Uses official ghcr.io/seerr-team/seerr image which expects:
-        # - Config at /app/config
-        # - Container runs as node user (UID 1000) by default
-        # - TZ and LOG_LEVEL environment variables
-        # - --init flag is required (container does not provide init process)
-        virtualisation.oci-containers.containers.seerr = podmanLib.mkContainer "seerr" {
-          image = cfg.image;
-          environment = {
-            TZ = cfg.timezone;
-            LOG_LEVEL = "info";
-          };
-          volumes = [
-            "${cfg.dataDir}:/app/config:rw"
-          ];
-          ports = [ "${toString seerrPort}:5055" ];
-          log-driver = "journald";
-          extraOptions =
-            # The --init flag is required as the container doesn't provide an init process
-            [ "--init" ]
-            ++ [ "--user=${cfg.user}:${toString config.users.groups.${cfg.group}.gid}" ]
-            ++ (lib.optionals (cfg.resources != null) [
-              "--memory=${cfg.resources.memory}"
-              "--memory-reservation=${cfg.resources.memoryReservation}"
-              "--cpus=${cfg.resources.cpus}"
-            ])
-            ++ (lib.optionals (cfg.healthcheck != null && cfg.healthcheck.enable) [
-              # Use /login endpoint instead of /api/v1/status - the status API tries to reach
-              # external services (Plex, Sonarr, etc.) and times out if they're unreachable
-              "--health-cmd=wget --no-verbose --tries=1 --spider http://localhost:5055/login || exit 1"
-              "--health-interval=${cfg.healthcheck.interval}"
-              "--health-timeout=${cfg.healthcheck.timeout}"
-              "--health-retries=${toString cfg.healthcheck.retries}"
-              "--health-start-period=${cfg.healthcheck.startPeriod}"
-              "--health-on-failure=${cfg.healthcheck.onFailure}"
-            ] ++ lib.optionals (cfg.podmanNetwork != null) [
-              "--network=${cfg.podmanNetwork}"
-            ]);
-        };
-
-        # Systemd service dependencies and security
-        systemd.services."${mainServiceName}" = lib.mkMerge [
-          {
-            requires = [ "network-online.target" ]
-              ++ lib.optionals (cfg.podmanNetwork != null) [ "podman-network-${cfg.podmanNetwork}.service" ]
-              ++ (map (s: "${config.virtualisation.oci-containers.backend}-${s}.service") cfg.dependsOn)
-              ++ lib.optional (cfg.preseed.enable && !allowEmptyBootstrap) "preseed-seerr.service";
-            after = [ "network-online.target" ]
-              ++ lib.optionals (cfg.podmanNetwork != null) [ "podman-network-${cfg.podmanNetwork}.service" ]
-              ++ (map (s: "${config.virtualisation.oci-containers.backend}-${s}.service") cfg.dependsOn)
-              ++ lib.optional cfg.preseed.enable "preseed-seerr.service";
-            wants = lib.optional (cfg.preseed.enable && allowEmptyBootstrap) "preseed-seerr.service";
-            serviceConfig = {
-              Restart = lib.mkForce "always";
-              RestartSec = "10s";
-            };
-          }
-        ];
-
-        # Integrate with centralized Caddy reverse proxy if configured
-        modules.services.caddy.virtualHosts.seerr = lib.mkIf (cfg.reverseProxy != null && cfg.reverseProxy.enable) {
-          enable = true;
-          hostName = cfg.reverseProxy.hostName;
-          backend = {
-            scheme = "http";
-            host = "127.0.0.1";
-            port = seerrPort;
-          };
-          auth = cfg.reverseProxy.auth;
-          security = cfg.reverseProxy.security;
-          extraConfig = cfg.reverseProxy.extraConfig;
-        };
-
-        # Backup integration using standardized restic pattern
-        modules.backup.restic.jobs = lib.mkIf (cfg.backup != null && cfg.backup.enable) {
-          seerr = {
-            enable = true;
-            paths = [ cfg.dataDir ];
-            repository = cfg.backup.repository;
-            frequency = cfg.backup.frequency;
-            tags = cfg.backup.tags;
-            excludePatterns = cfg.backup.excludePatterns;
-            useSnapshots = cfg.backup.useSnapshots;
-            zfsDataset = cfg.backup.zfsDataset;
-          };
-        };
-      })
-
-      # Preseed service
-      (lib.mkIf (cfg.enable && cfg.preseed.enable) (
-        storageHelpers.mkPreseedService {
-          serviceName = "seerr";
-          dataset = datasetPath;
-          mountpoint = cfg.dataDir;
-          mainServiceUnit = mainServiceUnit;
-          replicationCfg = replicationConfig;
-          datasetProperties = {
-            recordsize = "16K";
-            compression = "zstd";
-            "com.sun:auto-snapshot" = "true";
-          };
-          resticRepoUrl = cfg.preseed.repositoryUrl;
-          resticPasswordFile = cfg.preseed.passwordFile;
-          resticEnvironmentFile = cfg.preseed.environmentFile;
-          resticPaths = [ cfg.dataDir ];
-          restoreMethods = cfg.preseed.restoreMethods;
-          hasCentralizedNotifications = hasCentralizedNotifications;
-          inherit allowEmptyBootstrap;
-          owner = cfg.user;
-          group = cfg.group;
-        }
-      ))
-    ];
 }

--- a/modules/nixos/services/termix/default.nix
+++ b/modules/nixos/services/termix/default.nix
@@ -1,3 +1,5 @@
+# modules/nixos/services/termix/default.nix
+#
 # Termix - Self-hosted SSH web terminal and server management platform
 #
 # Termix provides SSH terminal access, tunnel management, remote file manager,
@@ -5,7 +7,8 @@
 #
 # Reference: https://github.com/Termix-SSH/Termix
 # Docs: https://docs.termix.site/
-
+#
+# Factory-based implementation (see lib/service-factory.nix).
 { lib
 , mylib
 , pkgs
@@ -13,52 +16,55 @@
 , podmanLib
 , ...
 }:
+
 let
-  # Storage helpers via mylib injection (centralized import)
-  storageHelpers = mylib.storageHelpers pkgs;
-  # Import service UIDs from centralized registry
   serviceIds = mylib.serviceUids.termix;
-
-  # Import shared type definitions
-  sharedTypes = mylib.types;
-
-  cfg = config.modules.services.termix;
-  notificationsCfg = config.modules.notifications;
-  storageCfg = config.modules.storage;
-
-  hasCentralizedNotifications = notificationsCfg.enable or false;
-
-  # Default port changed from 8080 (conflicts with qbittorrent) to 8095
-  termixPort = cfg.port;
-
-  mainServiceUnit = "${config.virtualisation.oci-containers.backend}-termix.service";
-  datasetPath = "${storageCfg.datasets.parentDataset}/termix";
-
-  # Build replication config for preseed
-  replicationConfig = storageHelpers.mkReplicationConfig { inherit config datasetPath; };
+  # Resolved lazily after option evaluation - safe to reference here.
+  termixPort = config.modules.services.termix.port;
 in
-{
-  options.modules.services.termix = {
-    enable = lib.mkEnableOption "termix SSH web terminal";
+mylib.mkContainerService {
+  inherit lib mylib pkgs config podmanLib;
 
-    dataDir = lib.mkOption {
-      type = lib.types.path;
-      default = "/var/lib/termix";
-      description = "Path to Termix data directory (SQLite database, uploads, config)";
+  name = "termix";
+  description = "Termix";
+
+  spec = {
+    # Core service configuration.
+    # Default port changed from upstream 8080 to avoid conflicts with qbittorrent.
+    port = 8095;
+    image = "ghcr.io/lukegus/termix:release-1.9.0@sha256:42649d815da4ee2cb71560b04a22641e54d993e05279908711d9056504487feb";
+    operationalProfile = "infrastructure";
+    displayName = "Termix";
+    function = "ssh_management";
+
+    startPeriod = "60s";
+
+    # Use Node.js for the health check since the container lacks wget/curl
+    healthCommand = ''node -e "fetch('http://127.0.0.1:${toString termixPort}/').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"'';
+
+    # ZFS tuning - optimal for SQLite database
+    zfsRecordSize = "16K";
+
+    resources = {
+      memory = "512M";
+      memoryReservation = "256M";
+      cpus = "2.0";
     };
 
-    user = lib.mkOption {
-      type = lib.types.str;
-      default = "termix";
-      description = "User account under which Termix runs.";
-    };
+    # Container runs as root internally because the entrypoint script needs
+    # to modify nginx config. Security is maintained via:
+    # 1. Container isolation
+    # 2. Localhost-only port binding (127.0.0.1)
+    # 3. OIDC authentication
+    # The PUID/PGID injection is neutralized in extraConfig below; file
+    # ownership is handled by the idmapped volume mount instead.
+    runAsRoot = true;
 
-    group = lib.mkOption {
-      type = lib.types.str;
-      default = "termix";
-      description = "Group under which Termix runs.";
-    };
+    # Data lives at /app/data via an idmapped mount, not /config
+    skipDefaultConfigMount = true;
+  };
 
+  extraOptions = {
     uid = lib.mkOption {
       type = lib.types.int;
       default = serviceIds.uid;
@@ -69,31 +75,6 @@ in
       type = lib.types.int;
       default = serviceIds.gid;
       description = "GID for the Termix service group (from lib/service-uids.nix).";
-    };
-
-    port = lib.mkOption {
-      type = lib.types.port;
-      default = 8095;
-      description = ''
-        Port for the Termix web interface.
-        Default changed from upstream 8080 to avoid conflicts with qbittorrent.
-      '';
-    };
-
-    image = lib.mkOption {
-      type = lib.types.str;
-      default = "ghcr.io/lukegus/termix:release-1.9.0@sha256:42649d815da4ee2cb71560b04a22641e54d993e05279908711d9056504487feb";
-      description = ''
-        Full container image name including tag and digest.
-        Use Renovate bot to automate version updates with digest pinning.
-      '';
-      example = "ghcr.io/lukegus/termix:release-1.9.0@sha256:42649d815da4ee2cb71560b04a22641e54d993e05279908711d9056504487feb";
-    };
-
-    timezone = lib.mkOption {
-      type = lib.types.str;
-      default = "America/New_York";
-      description = "Timezone for the container";
     };
 
     # OIDC configuration for PocketID integration
@@ -126,279 +107,87 @@ in
       };
     };
 
-    resources = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.containerResourcesSubmodule;
-      default = {
-        memory = "512M";
-        memoryReservation = "256M";
-        cpus = "2.0";
-      };
-      description = "Resource limits for the container";
-    };
-
-    healthcheck = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.healthcheckSubmodule;
-      default = {
-        enable = true;
-        interval = "30s";
-        timeout = "10s";
-        retries = 3;
-        startPeriod = "60s";
-        onFailure = "kill";
-      };
-      description = "Container healthcheck configuration.";
-    };
-
-    # Standardized reverse proxy integration
-    reverseProxy = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.reverseProxySubmodule;
+    # Termix exposes no Prometheus metrics endpoint - keep metrics opt-in.
+    metrics = lib.mkOption {
+      type = lib.types.nullOr mylib.types.metricsSubmodule;
       default = null;
-      description = "Reverse proxy configuration for Termix web interface";
-    };
-
-    # Standardized backup integration
-    backup = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.backupSubmodule;
-      default = lib.mkIf cfg.enable {
-        enable = lib.mkDefault true;
-        repository = lib.mkDefault "nas-primary";
-        frequency = lib.mkDefault "daily";
-        tags = lib.mkDefault [ "infrastructure" "termix" "ssh-management" ];
-        useSnapshots = lib.mkDefault true;
-        zfsDataset = lib.mkDefault "tank/services/termix";
-        excludePatterns = lib.mkDefault [
-          "**/*.log"
-          "**/logs/**"
-        ];
-      };
-      description = "Backup configuration for Termix";
-    };
-
-    # Standardized notifications
-    notifications = lib.mkOption {
-      type = lib.types.nullOr sharedTypes.notificationSubmodule;
-      default = {
-        enable = true;
-        channels = {
-          onFailure = [ "infrastructure-alerts" ];
-        };
-        customMessages = {
-          failure = "Termix SSH terminal service failed on ${config.networking.hostName}";
-        };
-      };
-      description = "Notification configuration for Termix service events";
-    };
-
-    preseed = {
-      enable = lib.mkEnableOption "automatic data restore before service start";
-      repositoryUrl = lib.mkOption {
-        type = lib.types.str;
-        description = "Restic repository URL for restore operations";
-      };
-      passwordFile = lib.mkOption {
-        type = lib.types.path;
-        description = "Path to Restic password file";
-      };
-      environmentFile = lib.mkOption {
-        type = lib.types.nullOr lib.types.path;
-        default = null;
-        description = "Optional environment file for Restic";
-      };
-      restoreMethods = lib.mkOption {
-        type = lib.types.listOf (lib.types.enum [ "syncoid" "local" "restic" ]);
-        default = [ "syncoid" "local" "restic" ];
-        description = "Order of restore methods to attempt.";
-      };
+      description = "Prometheus metrics collection configuration (Termix has no native metrics)";
     };
   };
 
-  config = lib.mkMerge [
-    (lib.mkIf cfg.enable {
-      # Assertions for configuration validation
-      assertions =
-        (lib.optional (cfg.backup != null && cfg.backup.enable) {
-          assertion = cfg.backup.repository != null;
-          message = "Termix backup.enable requires backup.repository to be set.";
-        })
-        ++ (lib.optional cfg.preseed.enable {
-          assertion = cfg.preseed.repositoryUrl != "";
-          message = "Termix preseed.enable requires preseed.repositoryUrl to be set.";
-        })
-        ++ (lib.optional cfg.preseed.enable {
-          assertion = builtins.isPath cfg.preseed.passwordFile || builtins.isString cfg.preseed.passwordFile;
-          message = "Termix preseed.enable requires preseed.passwordFile to be set.";
-        })
-        ++ (lib.optional cfg.oidc.enable {
-          assertion = cfg.oidc.serverUrl != "";
-          message = "Termix oidc.enable requires oidc.serverUrl to be set.";
-        })
-        ++ (lib.optional cfg.oidc.enable {
-          assertion = cfg.oidc.clientSecretFile != null;
-          message = "Termix oidc.enable requires oidc.clientSecretFile to be set.";
-        });
+  extraConfig = cfg: {
+    assertions =
+      (lib.optional cfg.oidc.enable {
+        assertion = cfg.oidc.serverUrl != "";
+        message = "Termix oidc.enable requires oidc.serverUrl to be set.";
+      })
+      ++ (lib.optional cfg.oidc.enable {
+        assertion = cfg.oidc.clientSecretFile != null;
+        message = "Termix oidc.enable requires oidc.clientSecretFile to be set.";
+      });
 
-      # Automatically register with Caddy reverse proxy if enabled
-      modules.services.caddy.virtualHosts.termix = lib.mkIf (cfg.reverseProxy != null && cfg.reverseProxy.enable) {
-        enable = true;
-        hostName = cfg.reverseProxy.hostName;
-
-        backend = {
-          scheme = "http";
-          host = "127.0.0.1";
-          port = termixPort;
-        };
-
-        auth = cfg.reverseProxy.auth;
-        caddySecurity = cfg.reverseProxy.caddySecurity;
-        security = cfg.reverseProxy.security;
-        extraConfig = cfg.reverseProxy.extraConfig;
+    virtualisation.oci-containers.containers.termix = {
+      # The container runs as root internally; drop the PUID/PGID/UMASK
+      # variables that the factory injects for runAsRoot containers.
+      environment = lib.mkForce {
+        PORT = toString cfg.port;
+        TZ = cfg.timezone;
+        # Disable SSL - handled by Caddy reverse proxy
+        ENABLE_SSL = "false";
       };
-
-      # ZFS dataset for persistent storage
-      modules.storage.datasets.services.termix = {
-        mountpoint = cfg.dataDir;
-        recordsize = "16K"; # Optimal for SQLite database
-        compression = "zstd";
-        properties = {
-          "com.sun:auto-snapshot" = "true";
-        };
-        owner = cfg.user;
-        group = cfg.group;
-        mode = "0750";
-      };
-
-      # Create local user and group
-      users.users.${cfg.user} = {
-        uid = cfg.uid;
-        group = cfg.group;
-        isSystemUser = true;
-        description = "Termix service user";
-        home = "/var/empty";
-        createHome = false;
-      };
-
-      users.groups.${cfg.group} = {
-        gid = cfg.gid;
-      };
-
-      # Termix container configuration
-      virtualisation.oci-containers.containers.termix = podmanLib.mkContainer "termix" {
-        image = cfg.image;
-        environment = {
-          PORT = toString termixPort;
-          TZ = cfg.timezone;
-          # Disable SSL - handled by Caddy reverse proxy
-          ENABLE_SSL = "false";
-        };
-        environmentFiles = lib.optional cfg.oidc.enable "/run/termix/oidc.env";
-        volumes = [
-          "${cfg.dataDir}:/app/data:rw,idmap=uids=0-0-1#${toString cfg.uid}-1000-1;gids=0-0-1#${toString cfg.gid}-1000-1"
-        ];
-        ports = [
-          "127.0.0.1:${toString termixPort}:${toString termixPort}"
-        ];
-        resources = cfg.resources;
-        extraOptions =
-          [
-            "--pull=newer"
-            # Note: Container runs as root internally because the entrypoint script
-            # needs to modify nginx config. Security is maintained via:
-            # 1. Container isolation
-            # 2. Localhost-only port binding (127.0.0.1)
-            # 3. OIDC authentication via Caddy reverse proxy
-          ]
-          ++ lib.optionals (cfg.healthcheck != null && cfg.healthcheck.enable) [
-            # Use Node.js for healthcheck since container lacks wget/curl
-            ''--health-cmd=node -e "fetch('http://127.0.0.1:${toString termixPort}/').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"''
-            "--health-interval=${cfg.healthcheck.interval}"
-            "--health-timeout=${cfg.healthcheck.timeout}"
-            "--health-retries=${toString cfg.healthcheck.retries}"
-            "--health-start-period=${cfg.healthcheck.startPeriod}"
-            "--health-on-failure=${cfg.healthcheck.onFailure}"
-          ];
-      };
-
-      # Pre-start service to set up OIDC environment
-      systemd.services."${config.virtualisation.oci-containers.backend}-termix" = lib.mkMerge [
-        {
-          serviceConfig = {
-            # Create runtime directory for OIDC env file
-            RuntimeDirectory = "termix";
-            RuntimeDirectoryMode = "0700";
-          };
-          preStart = ''
-            # Migrate files created by the image's UID 1000 before the idmapped mount.
-            ${pkgs.coreutils}/bin/chown -R ${toString cfg.uid}:${toString cfg.gid} ${cfg.dataDir}
-
-            ${lib.optionalString cfg.oidc.enable ''
-            # Generate OIDC environment file with secret
-            cat > /run/termix/oidc.env << 'EOF'
-            OIDC_ENABLED=true
-            OIDC_ISSUER_URL=${cfg.oidc.serverUrl}
-            OIDC_CLIENT_ID=${cfg.oidc.clientId}
-            OIDC_REDIRECT_URI=https://${cfg.reverseProxy.hostName or "termix.local"}/auth/callback
-            OIDC_AUTO_REDIRECT=${if cfg.oidc.autoRedirect then "true" else "false"}
-            EOF
-            echo "OIDC_CLIENT_SECRET=$(cat ${cfg.oidc.clientSecretFile})" >> /run/termix/oidc.env
-            chmod 600 /run/termix/oidc.env
-            ''}
-          '';
-        }
-        # Add failure notifications via systemd
-        (lib.mkIf (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
-          unitConfig.OnFailure = [ "notify@termix-failure:%n.service" ];
-        })
-        # Add dependency on the preseed service
-        (lib.mkIf cfg.preseed.enable {
-          wants = [ "preseed-termix.service" ];
-          after = [ "preseed-termix.service" ];
-        })
+      environmentFiles = lib.optional cfg.oidc.enable "/run/termix/oidc.env";
+      # Idmapped mount: the image writes as UID 1000; map it to the termix
+      # service user on the host.
+      volumes = [
+        "${cfg.dataDir}:/app/data:rw,idmap=uids=0-0-1#${toString cfg.uid}-1000-1;gids=0-0-1#${toString cfg.gid}-1000-1"
       ];
+      # Only bind to localhost - external access goes through the reverse proxy.
+      ports = lib.mkForce [
+        "127.0.0.1:${toString cfg.port}:${toString cfg.port}"
+      ];
+    };
 
-      # Register notification template
-      modules.notifications.templates = lib.mkIf (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
-        "termix-failure" = {
-          enable = lib.mkDefault true;
-          priority = lib.mkDefault "high";
-          title = lib.mkDefault ''<b><font color="red">✗ Service Failed: Termix</font></b>'';
-          body = lib.mkDefault ''
-            <b>Host:</b> ''${hostname}
-            <b>Service:</b> <code>''${serviceName}</code>
-
-            The Termix SSH web terminal service has entered a failed state.
-
-            <b>Quick Actions:</b>
-            1. Check logs:
-               <code>ssh ''${hostname} 'journalctl -u ''${serviceName} -n 100'</code>
-            2. Restart service:
-               <code>ssh ''${hostname} 'systemctl restart ''${serviceName}'</code>
-          '';
-        };
+    # Pre-start setup: data ownership migration and OIDC environment
+    systemd.services."${config.virtualisation.oci-containers.backend}-termix" = {
+      serviceConfig = {
+        # Create runtime directory for OIDC env file
+        RuntimeDirectory = "termix";
+        RuntimeDirectoryMode = "0700";
       };
-    })
+      preStart = ''
+        # Migrate files created by the image's UID 1000 before the idmapped mount.
+        ${pkgs.coreutils}/bin/chown -R ${toString cfg.uid}:${toString cfg.gid} ${cfg.dataDir}
 
-    # Add the preseed service
-    (lib.mkIf (cfg.enable && cfg.preseed.enable) (
-      storageHelpers.mkPreseedService {
-        serviceName = "termix";
-        dataset = datasetPath;
-        mountpoint = cfg.dataDir;
-        mainServiceUnit = mainServiceUnit;
-        replicationCfg = replicationConfig;
-        datasetProperties = {
-          recordsize = "16K";
-          compression = "zstd";
-          "com.sun:auto-snapshot" = "true";
-        };
-        resticRepoUrl = cfg.preseed.repositoryUrl;
-        resticPasswordFile = cfg.preseed.passwordFile;
-        resticEnvironmentFile = cfg.preseed.environmentFile;
-        resticPaths = [ cfg.dataDir ];
-        restoreMethods = cfg.preseed.restoreMethods;
-        hasCentralizedNotifications = hasCentralizedNotifications;
-        owner = cfg.user;
-        group = cfg.group;
-      }
-    ))
-  ];
+        ${lib.optionalString cfg.oidc.enable ''
+        # Generate OIDC environment file with secret
+        cat > /run/termix/oidc.env << 'EOF'
+        OIDC_ENABLED=true
+        OIDC_ISSUER_URL=${cfg.oidc.serverUrl}
+        OIDC_CLIENT_ID=${cfg.oidc.clientId}
+        OIDC_REDIRECT_URI=https://${cfg.reverseProxy.hostName or "termix.local"}/auth/callback
+        OIDC_AUTO_REDIRECT=${if cfg.oidc.autoRedirect then "true" else "false"}
+        EOF
+        echo "OIDC_CLIENT_SECRET=$(cat ${cfg.oidc.clientSecretFile})" >> /run/termix/oidc.env
+        chmod 600 /run/termix/oidc.env
+        ''}
+      '';
+    };
+
+    # Preserve the pre-factory notification wording
+    modules.notifications.templates."termix-failure" =
+      lib.mkIf (config.modules.notifications.enable or false && cfg.notifications != null && cfg.notifications.enable) {
+        body = ''
+          <b>Host:</b> ''${hostname}
+          <b>Service:</b> <code>''${serviceName}</code>
+
+          The Termix SSH web terminal service has entered a failed state.
+
+          <b>Quick Actions:</b>
+          1. Check logs:
+             <code>ssh ''${hostname} 'journalctl -u ''${serviceName} -n 100'</code>
+          2. Restart service:
+             <code>ssh ''${hostname} 'systemctl restart ''${serviceName}'</code>
+        '';
+      };
+  };
 }


### PR DESCRIPTION
## Summary

Migrates 9 of the 11 factory-eligible container service modules under `modules/nixos/services/` to `lib/service-factory.nix`'s `mkContainerService`, one commit per service, using `modules/nixos/services/sonarr/default.nix` as the reference pattern (factory spec + `extraOptions` for module-specific options + `extraConfig` for wiring):

seerr · apprise · enclosed · bichon · termix · qui · esphome · mealie · paperless-ai

All host-side files in `hosts/forge/services/` work unchanged — every option they set keeps its name, type, and default.

## Verification

Each migration was verified individually against a full before/after snapshot of `nixosConfigurations.forge` (`nix eval --json` capturing rendered oci-container configs, all systemd unit hashes + podman unit texts, users/groups, ZFS dataset entries, tmpfiles rules, restic jobs, Caddy vhosts, and Prometheus scrape configs). No users, groups, datasets, restic jobs, Caddy vhosts, or scrape targets were added or removed. paperless-ai (disabled on forge) renders a byte-identical system. The final toplevel drvPath evaluates cleanly; statix, deadnix, and nixpkgs-fmt pass.

The only rendered deltas are the standard factory hardening, consistent across all services:
- `--umask=0027`, `--pull=newer` (no-op on digest-pinned images)
- `--health-on-failure=kill` + startup-phase healthcheck flags (`--health-startup-*`)
- numeric-UID (same identity) dataset/tmpfiles ownership

## Deliberately preserved quirks

- **Dynamic UIDs**: enclosed, bichon, and mealie are deployed with dynamically allocated UIDs (registry entries were never deployed) — their modules `mkForce null` the uid/gid and keep name-based ownership so existing data ownership is untouched.
- enclosed's no-backup stance (ephemeral notes), mealie's no-auto-snapshot dataset, apprise/enclosed/bichon/mealie/paperless-ai localhost-only port bindings, esphome host networking + 0770 dataset, qui idmap-free `/config` mount + metrics port binding, termix idmapped mount, and all pre-factory notification wording.

## Bug fixes gained

- seerr and qui declared `notifications` options that were never wired — `OnFailure=notify@…` hooks now actually fire.
- mealie's unit referenced nonexistent `mealie-preseed.service`; it now depends on the real `preseed-mealie.service`.

## Not migrated (needs a factory extension first)

- **unpackerr** and **it-tools** are deliberately stateless: no dataset, no system user, no published ports (unpackerr). `mkContainerService` unconditionally creates a ZFS dataset (real `zfs create` at activation), a system user, and stateful backup options — migrating them today would create new infrastructure on forge. They need a small `spec.stateless` factory feature first, same category as the multi-container exclusions.

Composes cleanly with #631 (no file overlap; all migrated modules set `spec.resources`/`displayName`/`function` explicitly, so merge order doesn't matter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)