### PR TITLE
feat(signal-api): add Signal delivery transport for household advisor

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -577,6 +577,7 @@
                 onCallMigration = forge.systemd.services.podman-grafana-oncall-migration;
                 postgresql = manifest.datasets."tank/services/postgresql";
                 prometheus = manifest.datasets."tank/services/prometheus";
+                signalApi = manifest.datasets."tank/services/signal-api";
                 failClosedUnits = {
                   actual = "actual";
                   apprise = "podman-apprise";
@@ -661,9 +662,9 @@
               in
               assert manifest.schemaVersion == 1;
               assert manifest.summary.total >= 60;
-              assert manifest.summary.classified == 45;
+              assert manifest.summary.classified == 46;
               assert manifest.summary.byClass == {
-                critical = 9;
+                critical = 10;
                 ephemeral = 20;
                 standard = 14;
                 system = 2;
@@ -716,6 +717,18 @@
               assert postgresql.missingRequiredTiers == [ "independent-restore" ];
               assert prometheus.classification == "ephemeral";
               assert prometheus.missingRequiredTiers == [ ];
+              # signal-api holds the Signal bot's registration keys, which are
+              # not reproducible from any other source, so it carries a second
+              # Restic job to r2-offsite and is the only critical service with
+              # every tier satisfied - hence its absence from
+              # criticalServicePaths below, which asserts a missing offsite
+              # tier. allowEmptyBootstrap is true so a fresh deployment can
+              # come up account-less for the registration runbook; the
+              # /v1/accounts Gatus check covers what that concedes.
+              assert signalApi.classification == "critical";
+              assert signalApi.missingRequiredTiers == [ ];
+              assert signalApi.policy.allowEmptyBootstrap;
+              assert !(builtins.hasAttr "signal-api" failClosedUnits);
               assert builtins.all
                 (path:
                   manifest.datasets.${path}.classification == "ephemeral"
@@ -765,16 +778,16 @@
                   "zfs-snapshot-never-created"
                 ];
               in
-              assert builtins.length expectedTimers == 111;
+              assert builtins.length expectedTimers == 117;
               assert builtins.elem "pgbackrest-incr-backup.timer" expectedTimers;
               assert builtins.elem "restic-backup-service-plex.timer" expectedTimers;
               assert builtins.elem "sanoid.timer" expectedTimers;
               assert builtins.elem "syncoid-tank-services-plex.timer" expectedTimers;
               assert forge.systemd.timers.nixos-deploy-backup-guard-metrics.wantedBy == [ "timers.target" ];
               assert builtins.all (name: builtins.hasAttr name forge.modules.alerting.rules) requiredAlerts;
-              assert builtins.length (builtins.attrNames snapshotDatasets) == 54;
+              assert builtins.length (builtins.attrNames snapshotDatasets) == 55;
               assert !(builtins.hasAttr "tank/services" snapshotDatasets);
-              assert builtins.length (builtins.attrNames enabledResticJobs) == 50;
+              assert builtins.length (builtins.attrNames enabledResticJobs) == 52;
               assert builtins.all (name: builtins.hasAttr name forge.modules.alerting.rules) requiredFreshnessAlerts;
               assert pkgs.lib.hasInfix "zfs_snapshot_dataset_info" snapshotMetricsScript;
               assert pkgs.lib.hasInfix "zfs_snapshot_latest_timestamp" snapshotMetricsScript;

--- a/hosts/forge/default.nix
+++ b/hosts/forge/default.nix
@@ -108,6 +108,7 @@ in
     ./services/grafana-oncall.nix # Grafana OnCall incident response platform
     ./services/scrypted.nix # Scrypted NVR/automation hub
     ./services/searxng.nix # SearXNG meta search engine
+    ./services/signal-api.nix # Signal bot transport for the household advisor pulse
     ./services/home-assistant.nix # Home Assistant automation platform
     ./services/music-assistant.nix # Music Assistant media library + player server
     ./services/homepage.nix # Homepage dashboard (LAN only)

--- a/hosts/forge/services/signal-api.nix
+++ b/hosts/forge/services/signal-api.nix
@@ -1,0 +1,226 @@
+# hosts/forge/services/signal-api.nix
+#
+# Signal delivery transport for the household-advisor system.
+#
+# signal-cli-rest-api runs a dedicated Signal bot account ("Household
+# Advisor"). Its only intended consumer is homelab-mcp on this host, which
+# will grow a `signal_send` tool that posts the weekly financial pulse to the
+# family Signal group.
+#
+#   hermes-agent (weekly pulse job)  ->  homelab-mcp `signal_send`
+#                                          |  HTTP, 127.0.0.1:8484
+#                                          v
+#                                    signal-api container
+#                                          |  Signal protocol (outbound)
+#                                          v
+#                                    family Signal group
+#
+# The account registration is a ONE-TIME MANUAL PROCEDURE performed by a
+# human - see modules/nixos/services/signal-api/RUNBOOK.md. Until that runs,
+# the container comes up healthy but has no account and every send returns an
+# error. Nothing here depends on registration having happened.
+#
+# NETWORK EXPOSURE: internal only, and deliberately so. The REST API has no
+# authentication of any kind. Do NOT add a Caddy vhost, a Cloudflare Tunnel
+# ingress rule, or a LAN port opening for this service. See the security
+# model in modules/nixos/services/signal-api/default.nix.
+{ config, lib, ... }:
+
+let
+  forgeDefaults = import ../lib/defaults.nix { inherit config lib; };
+  serviceName = "signal-api";
+  dataDir = "/var/lib/signal-api";
+  dataset = "tank/services/${serviceName}";
+  serviceEnabled = config.modules.services.signal-api.enable or false;
+
+  # Dedicated, isolated Podman network. Isolation is what stops every *other*
+  # container on forge from reaching the unauthenticated API on its container
+  # IP; the iptables guard below covers host processes.
+  podmanNetwork = "signal-api";
+  podmanSubnet = "10.90.0.0/24";
+  podmanGateway = "10.90.0.1";
+in
+{
+  config = lib.mkMerge [
+    {
+      modules.services.signal-api = {
+        enable = true;
+        inherit dataDir;
+
+        # Native json-rpc mode: one resident signal-cli daemon, sub-second
+        # sends. Required for a responsive MCP tool.
+        mode = "json-rpc";
+
+        inherit podmanNetwork;
+
+        # Who may talk to the unauthenticated API on this host:
+        #   homelab-mcp - the approved caller (`signal_send`)
+        #   gatus       - the liveness check below
+        #   root        - operators following the registration runbook
+        localAccess = {
+          enable = true;
+          subnet = podmanSubnet;
+          allowedUsers = [ "root" "homelab-mcp" "gatus" ];
+        };
+
+        # Crown-jewel state: the account registration keys ARE the bot's
+        # Signal identity. Losing them means re-registering the number (new
+        # safety numbers for every member, re-joining the group); leaking them
+        # means someone else can impersonate the bot.
+        backup = forgeDefaults.mkBackupWithTags serviceName [ "signal" "messaging" "forge" ];
+
+        preseed = forgeDefaults.mkPreseed [ "syncoid" "local" ];
+
+        notifications = {
+          enable = true;
+          channels.onFailure = [ "system-alerts" ];
+          customMessages.failure = ''
+            Signal API failed on ${config.networking.hostName}. The weekly
+            household pulse cannot be delivered until it recovers.
+            Check: journalctl -u podman-signal-api -n 200
+          '';
+        };
+      };
+
+      # Isolated bridge for this container only.
+      modules.virtualization.podman.networks.${podmanNetwork} = {
+        driver = "bridge";
+        subnet = podmanSubnet;
+        gateway = podmanGateway;
+        # netavark drops traffic between this bridge and every other Podman
+        # network. Host <-> container and outbound NAT to Signal's servers are
+        # unaffected.
+        isolate = true;
+      };
+    }
+
+    (lib.mkIf serviceEnabled {
+      # ZFS dataset. 0700 (rather than the factory's 0750) because nothing
+      # else has any business reading the account keys - the Restic job reads
+      # them from a snapshot clone with CAP_DAC_READ_SEARCH.
+      modules.storage.datasets.services.${serviceName} = {
+        mountpoint = dataDir;
+        mode = "0700";
+        properties = {
+          atime = "off";
+          "com.sun:auto-snapshot" = "true";
+        };
+
+        protection = {
+          class = "critical";
+          objectives = {
+            onsiteRpoSeconds = 900;
+            offsiteRpoSeconds = 86400;
+            rtoSeconds = 7200;
+          };
+          requiredTiers = [
+            "local-snapshot"
+            "replication"
+            "nas-backup"
+            "offsite-backup"
+            "automated-restore"
+          ];
+          consistency = "crash-consistent";
+          validator = "signal-api-registration";
+
+          # true, despite this being critical data. The service ships with no
+          # account at all - the first deployment MUST be able to come up on an
+          # empty dataset so a human can run the registration runbook against
+          # it. With `false`, preseed finds nothing to restore, refuses to let
+          # the container start, and (on the syncoid path) leaves the freshly
+          # created dataset renamed to a `-graveyard-<ts>` sibling.
+          #
+          # The cost is that a disaster recovery which loses every copy starts
+          # the container empty and healthy rather than refusing to start:
+          # /v1/health answers 204 with or without an account. Sends fail loudly
+          # ("User <number> is not registered"), and the runbook's post-restore
+          # check is `GET /v1/accounts` - do not treat a green Gatus check as
+          # proof the bot still has its identity.
+          allowEmptyBootstrap = true;
+
+          notes = ''
+            Registration state is not reproducible from any other source: a
+            lost dataset means re-registering the VoIP number with Signal and
+            having the family group re-add the bot (see the runbook). Hence
+            offsite coverage on top of the standard onsite tiers.
+          '';
+        };
+      };
+
+      modules.backup.sanoid.datasets.${dataset} =
+        forgeDefaults.mkSanoidDataset serviceName;
+
+      # Offsite copy to R2. Most forge services stop at the NAS repository;
+      # this one is small (a few MB) and unrecoverable, so it also goes
+      # offsite - which is what satisfies the "offsite-backup" tier declared
+      # above.
+      modules.services.backup.restic.jobs."${serviceName}-offsite" = {
+        enable = true;
+        repository = "r2-offsite";
+        paths = [ dataDir ];
+        tags = [ serviceName "signal" "offsite" "forge" ];
+        frequency = "daily";
+        useSnapshots = true;
+        zfsDataset = dataset;
+      };
+
+      modules.alerting.rules."${serviceName}-service-down" =
+        forgeDefaults.mkServiceDownAlert serviceName "SignalApi" "Signal message transport";
+
+      # Liveness check. Gatus runs as the `gatus` user, which is why it is in
+      # localAccess.allowedUsers above.
+      #
+      # /v1/health is a bare `return 204` in the upstream handler - it proves
+      # the HTTP server is serving and nothing more. That is exactly what a
+      # liveness probe should be, but do not read more into a green check: the
+      # account check below is what says the bot still has an identity.
+      modules.services.gatus.contributions.${serviceName} = {
+        name = "Signal API";
+        group = "Infrastructure";
+        url = "http://127.0.0.1:${toString config.modules.services.signal-api.port}/v1/health";
+        interval = "60s";
+        conditions = [
+          "[STATUS] == 204"
+          "[RESPONSE_TIME] < 2000"
+        ];
+        alerts = [{
+          type = "pushover";
+          sendOnResolved = true;
+          failureThreshold = 3;
+          successThreshold = 1;
+        }];
+      };
+
+      # Registration check. In json-rpc mode this call goes through the
+      # resident signal-cli daemon (`listAccounts`), so a 200 with a non-empty
+      # body proves both that the daemon is answering and that the bot account
+      # still exists. It is the check that catches the failure mode
+      # allowEmptyBootstrap accepts above: a container restored onto an empty
+      # dataset, serving 204s, with no identity.
+      #
+      # EXPECTED TO BE RED until the registration runbook has been run on a new
+      # deployment. The body is a JSON array of registered numbers, so the
+      # condition compares against the empty array rather than naming the
+      # number here (which would put it in the Nix store).
+      modules.services.gatus.contributions."${serviceName}-account" = {
+        name = "Signal Account";
+        group = "Infrastructure";
+        url = "http://127.0.0.1:${toString config.modules.services.signal-api.port}/v1/accounts";
+        interval = "300s";
+        conditions = [
+          "[STATUS] == 200"
+          "[BODY] != []"
+        ];
+        alerts = [{
+          type = "pushover";
+          sendOnResolved = true;
+          # Deliberately slack: an unregistered bot is a "fix this today"
+          # problem, not a wake-someone-up problem, and this must not page
+          # during a container restart.
+          failureThreshold = 5;
+          successThreshold = 1;
+        }];
+      };
+    })
+  ];
+}

--- a/lib/service-uids.nix
+++ b/lib/service-uids.nix
@@ -355,6 +355,13 @@
     extraGroups = [ ];
   };
 
+  signal-api = {
+    uid = 947;
+    gid = 947;
+    description = "signal-cli-rest-api Signal bot transport (not yet deployed)";
+    extraGroups = [ ];
+  };
+
   copyparty = {
     uid = 943;
     gid = 65537;
@@ -669,7 +676,7 @@
   # When adding a new service, use the next available UID in the 996+ range
   # and document the actual deployed values after first deployment.
   #
-  # Next available: 947
+  # Next available: 948
   # ============================================================================
 
   # ============================================================================

--- a/modules/nixos/services/_categories/infrastructure.nix
+++ b/modules/nixos/services/_categories/infrastructure.nix
@@ -17,5 +17,6 @@
     ../postgresql # PostgreSQL database
     ../postgresql/databases.nix # Database provisioning
     ../postgresql/storage-integration.nix # ZFS dataset creation
+    ../signal-api # Signal messenger REST transport (signal-cli-rest-api)
   ];
 }

--- a/modules/nixos/services/signal-api/RUNBOOK.md
+++ b/modules/nixos/services/signal-api/RUNBOOK.md
@@ -1,0 +1,370 @@
+# Runbook: registering the Household Advisor Signal bot
+
+One-time manual procedure, performed by a human, to give the `signal-api`
+service a working Signal account. Everything else about the service is
+declarative; this is the part that cannot be.
+
+Expect **30–45 minutes**, most of it waiting on SMS and on Signal's rate
+limiter. Do it in one sitting — a half-registered account is awkward to
+resume.
+
+- **Service module:** [`default.nix`](./default.nix)
+- **Host config:** [`hosts/forge/services/signal-api.nix`](../../../../hosts/forge/services/signal-api.nix)
+- **Runs on:** forge, container `signal-api`, loopback `http://127.0.0.1:8484`
+
+---
+
+## 0. Before you start
+
+**The API has no authentication.** Anything that can reach it can send
+messages as the bot. On forge it is bound to `127.0.0.1` and an iptables guard
+limits it to the `root`, `homelab-mcp` and `gatus` accounts, so:
+
+> Every `curl` in this runbook must run **on forge, as root** (`sudo curl …`).
+> The same command as your normal user gets a TCP reset — that is the guard
+> working, not a bug.
+
+Never expose this service through Caddy or the Cloudflare Tunnel.
+
+### Prerequisites
+
+1. The module is deployed and the container is healthy:
+
+   ```bash
+   task nix:apply-nixos host=forge
+   ```
+
+   ```bash
+   ssh forge 'systemctl is-active podman-signal-api && sudo curl -sS -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8484/v1/health'
+   ```
+
+   Expect `active` and `204`.
+
+2. Confirm the mode is `json-rpc` and note the build:
+
+   ```bash
+   ssh forge 'sudo curl -sS http://127.0.0.1:8484/v1/about | jq'
+   ```
+
+3. A phone that can receive the verification SMS at the number below.
+
+> **Expect one red check and possibly a Pushover alert while you work.** Gatus
+> monitors *Signal Account* (`/v1/accounts`) as well as *Signal API*
+> (`/v1/health`). On a fresh deployment there is no account, so the account
+> check is red and pages after ~25 minutes. That is correct — it goes green on
+> its own once you finish step 4.
+
+---
+
+## 1. Acquire a dedicated VoIP number
+
+The bot needs its **own** number. Do not use a personal number: registering it
+with Signal here would move that person's Signal account onto this container.
+
+Requirements:
+
+- Can receive SMS (voice fallback works too, but SMS is simpler).
+- Not currently registered with Signal under any other account.
+- **Long-lived.** If the number is reclaimed by the provider and re-issued to
+  someone else, that person can take over the bot's Signal identity. This is
+  the single biggest long-term risk in this setup.
+
+Two reasonable options:
+
+| Option | Cost | Notes |
+| --- | --- | --- |
+| **Twilio** | ~$1.15/mo + per-SMS | Recommended. Numbers stay yours while billing is current; SMS shows up in the Twilio console, no phone needed. |
+| **Google Voice** | Free | Works, but Google reclaims numbers after ~9 months of inactivity, and Voice numbers are sometimes rejected by Signal. If you use one, send a text from it occasionally. |
+
+The number is used **once**, at registration. After that the account lives in
+the container's dataset and the number only matters if you ever have to
+re-register.
+
+Write the number down in E.164 form (`+15551234567`) — you will paste it into
+every command below. It also gets recorded in SOPS in step 8.
+
+---
+
+## 2. Register the number
+
+Try without a captcha first:
+
+```bash
+ssh forge 'sudo curl -sS -X POST -H "Content-Type: application/json" -d "{}" http://127.0.0.1:8484/v1/register/+15551234567'
+```
+
+- Empty response / HTTP 201 → registration accepted, **go to step 4**.
+- `{"error":"Captcha required for verification (null)\n"}` → step 3.
+- `{"error":"...RateLimit..."}` or HTTP 429 → Signal is throttling. Wait an
+  hour and retry; do not hammer it. If it persists, see Troubleshooting.
+
+## 3. Solve the captcha (only if demanded)
+
+1. Open <https://signalcaptchas.org/registration/generate.html> in a desktop
+   browser and open the developer console **before** solving.
+2. Solve the captcha.
+3. The console logs a line like:
+   `Prevented navigation to "signalcaptcha://signal-hcaptcha-short.5fad97ac-….registration.…" due to an unknown protocol.`
+4. Copy the value **without** the `signalcaptcha://` prefix.
+5. Register with it (the token is single-use and expires within minutes — have
+   the command ready to paste):
+
+   ```bash
+   ssh forge 'sudo curl -sS -X POST -H "Content-Type: application/json" -d "{\"captcha\":\"signal-hcaptcha-short.PASTE_HERE\"}" http://127.0.0.1:8484/v1/register/+15551234567'
+   ```
+
+If it still reports a captcha requirement, the token expired — generate a
+fresh one and retry immediately.
+
+## 4. Verify with the SMS code
+
+The SMS arrives within a minute or two (check the Twilio console for a Twilio
+number). The code looks like `123-456`; send it either with or without the
+hyphen:
+
+```bash
+ssh forge 'sudo curl -sS -X POST -H "Content-Type: application/json" http://127.0.0.1:8484/v1/register/+15551234567/verify/123456'
+```
+
+Confirm the account now exists:
+
+```bash
+ssh forge 'sudo curl -sS http://127.0.0.1:8484/v1/accounts | jq'
+```
+
+The response should list `+15551234567`.
+
+> **json-rpc note:** the resident signal-cli daemon picks up the new account
+> automatically. If subsequent calls insist the number is not registered,
+> restart the container once (`sudo systemctl restart podman-signal-api`) —
+> that re-runs the helper that wires the daemon up to registered accounts.
+
+---
+
+## 5. Set the profile name
+
+Signal refuses group sends from an account with no profile name ("Cannot send
+message to group - please first update your profile"), so this is required,
+not cosmetic:
+
+```bash
+ssh forge 'sudo curl -sS -X PUT -H "Content-Type: application/json" -d "{\"name\":\"Household Advisor\"}" http://127.0.0.1:8484/v1/profiles/+15551234567'
+```
+
+Expect HTTP 204.
+
+## 6. Set a username
+
+A username means group members see `householdadvisor.42` instead of the bot's
+phone number — worth doing before anyone is invited.
+
+```bash
+ssh forge 'sudo curl -sS -X POST -H "Content-Type: application/json" -d "{\"username\":\"householdadvisor\"}" http://127.0.0.1:8484/v1/accounts/+15551234567/username | jq'
+```
+
+The response returns the full username with its discriminator plus a
+`username_link`:
+
+```json
+{ "username": "householdadvisor.42", "username_link": "https://signal.me/#eu/…" }
+```
+
+Record the full username (with discriminator) in the family group description
+or wherever the household keeps that sort of thing.
+
+Optionally hide the phone number from other Signal users — do this from the
+Signal app on a linked device, or leave it: the number is a throwaway VoIP
+number that nobody outside the household knows.
+
+---
+
+## 7. Get the group ID
+
+**Preferred:** have a human create the family group in the normal Signal app
+and invite the bot (search by the username from step 6). This keeps group
+ownership with a person, not with the container.
+
+Then list the groups the bot is in:
+
+```bash
+ssh forge 'sudo curl -sS http://127.0.0.1:8484/v1/groups/+15551234567 | jq ".[] | {name, id, member}"'
+```
+
+Copy the `id` of the family group — it looks like
+`group.Y2tSemFFZDRWbVJ6TmpKYVFTQUVzYXNh…`. Make sure `member` is `true` (if the
+bot was invited but has not accepted, it will show as pending; accept from a
+linked device or use the join endpoint).
+
+<details>
+<summary>Alternative: create the group from the bot side</summary>
+
+```bash
+ssh forge 'sudo curl -sS -X POST -H "Content-Type: application/json" -d "{\"name\":\"Household\",\"members\":[\"+15559990000\",\"+15559990001\"]}" http://127.0.0.1:8484/v1/groups/+15551234567 | jq'
+```
+
+Returns the new group's id. Members get an invite they must accept.
+</details>
+
+## 8. Record the number and group ID
+
+Both values belong in configuration, not in code. The group ID is not a secret
+but it lives next to the number so there is one place to look.
+
+They go into the existing `homelab-mcp` env secret, which is the file the
+future `signal_send` tool reads:
+
+```bash
+task sops:edit host=forge
+```
+
+Under `homelab-mcp: env:`, add these lines to the dotenv blob:
+
+```dotenv
+HOMELAB_MCP_SIGNAL_BASE_URL=http://127.0.0.1:8484
+HOMELAB_MCP_SIGNAL_NUMBER=+15551234567
+HOMELAB_MCP_SIGNAL_GROUP_ID=group.Y2tSemFFZDRWbVJ6TmpKYVFTQUVzYXNh
+```
+
+Then apply so sops-nix re-renders the secret and restarts the consumer:
+
+```bash
+task nix:apply-nixos host=forge
+```
+
+> These keys are consumed by the `signal_send` tool in `~/src/mcp`, which is a
+> separate piece of work. Adding them now is harmless — homelab-mcp ignores
+> env vars it does not know about — and it means registration is fully
+> finished in one sitting.
+
+---
+
+## 9. Smoke test
+
+### 9a. Send a message
+
+```bash
+ssh forge 'sudo curl -sS -X POST -H "Content-Type: application/json" -d "{\"message\":\"Household Advisor: transport test, please ignore.\",\"number\":\"+15551234567\",\"recipients\":[\"group.Y2tSemFFZDRWbVJ6TmpKYVFTQUVzYXNh\"]}" http://127.0.0.1:8484/v2/send'
+```
+
+Expect a `{"timestamp":"…"}` response and the message visible in the family
+group, attributed to **Household Advisor**. If the sender shows as a phone
+number, step 5 or 6 did not take.
+
+### 9b. Registration survives a restart
+
+This is the whole point of the persistent dataset — verify it, do not assume
+it:
+
+```bash
+ssh forge 'sudo systemctl restart podman-signal-api'
+```
+
+```bash
+ssh forge 'sleep 60; sudo curl -sS -o /dev/null -w "health=%{http_code}\n" http://127.0.0.1:8484/v1/health; sudo curl -sS http://127.0.0.1:8484/v1/accounts'
+```
+
+Expect `health=204` and the number still listed. Then re-send 9a and confirm a
+second message arrives.
+
+### 9c. The API is not reachable by anything else
+
+```bash
+# As a normal (non-approved) user on forge: expect "Connection reset by peer"
+ssh forge 'curl -sS --max-time 5 http://127.0.0.1:8484/v1/health; echo "exit=$?"'
+```
+
+```bash
+# From your workstation: expect a timeout / refusal, never a 204
+curl -sS --max-time 5 http://forge.holthome.net:8484/v1/health; echo "exit=$?"
+```
+
+### 9d. Monitoring is green
+
+Check <https://status.holthome.net> under *Infrastructure*. Both endpoints
+should now be green:
+
+| Endpoint | Polls | Proves |
+| --- | --- | --- |
+| **Signal API** | `/v1/health`, 60s | the HTTP server is serving (a bare 204 — nothing more) |
+| **Signal Account** | `/v1/accounts`, 300s | the signal-cli daemon answers *and* the bot account exists |
+
+The account check may take up to 5 minutes to flip green after step 4.
+
+### 9e. The crown jewels are being protected
+
+```bash
+ssh forge 'zfs list -t snapshot tank/services/signal-api | tail -3'
+```
+
+After the next nightly cycle, both Restic jobs should have run:
+
+```bash
+ssh forge 'systemctl list-units "restic-backup-*signal*" --all'
+```
+
+`restic-backup-service-signal-api` (NAS) and
+`restic-backup-signal-api-offsite` (R2) are both expected.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+| --- | --- |
+| `Captcha required for verification` even with a token | Token expired (they last minutes) or was pasted with the `signalcaptcha://` prefix. Generate a fresh one. |
+| HTTP 429 / rate limit on register | Signal throttles registration attempts per number and per IP. Wait an hour. Repeated failures can require a rate-limit challenge: `POST /v1/accounts/<number>/rate-limit-challenge`. |
+| No SMS arrives | Number cannot receive SMS from short codes (common with some VoIP providers). Retry with `{"use_voice": true}` for a voice call, or use a different provider. |
+| `Cannot send message to group - please first update your profile` | Step 5 was skipped or failed. |
+| `User <number> is not registered` right after verifying | The signal-cli daemon has not picked up the account. Restart the container once. If it recurs, the container is resource-starved — check the memory limit in the module. |
+| Sends stopped working after months of silence | Almost always image age: signal-cli's protocol support goes stale and Signal rejects old clients. Bump the pinned image (see below) before debugging anything else. |
+| `curl: (56) Connection reset by peer` from a script | The caller's UID is not in `localAccess.allowedUsers`. Add it in `hosts/forge/services/signal-api.nix` — deliberately, and only for a service that should be able to speak as the bot. |
+| Container healthy, both Gatus checks red | Gatus checks from the `gatus` user; confirm it is still in `localAccess.allowedUsers`. |
+| *Signal API* green, *Signal Account* red | The container is serving but has no account — either registration was never completed, or a restore brought back an empty dataset. See "If the dataset is lost". |
+
+### Bumping the image
+
+The pin lives in [`default.nix`](./default.nix). Get the digest for a new tag:
+
+```bash
+TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:bbernhard/signal-cli-rest-api:pull" | jq -r .token); curl -sI -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.oci.image.index.v1+json" https://registry-1.docker.io/v2/bbernhard/signal-cli-rest-api/manifests/0.101 | grep -i docker-content-digest
+```
+
+Update tag and digest together, deploy, then re-run smoke test 9a. The account
+dataset is untouched by an image bump.
+
+### If the dataset is lost
+
+There is no way to recover the account from Signal's side. Recovery order:
+
+1. Restore from ZFS snapshot / syncoid replica / Restic. `preseed-signal-api`
+   attempts syncoid then a local snapshot automatically whenever it finds a
+   dataset without the `holthome:preseed_complete` marker; the offsite Restic
+   copy is a deliberate manual decision:
+
+   ```bash
+   ssh forge 'sudo restic -r /mnt/nas-backup --password-file /run/secrets/restic/password snapshots --tag signal-api'
+   ```
+
+2. **Always confirm the account came back**, whichever way it was restored:
+
+   ```bash
+   ssh forge 'sudo curl -sS http://127.0.0.1:8484/v1/accounts | jq'
+   ```
+
+   > A container that started on an empty dataset is *indistinguishable from a
+   > healthy one* at `/v1/health` — it answers 204 with or without an account,
+   > which is exactly why the *Signal Account* check exists. `[]` here means
+   > the identity is gone.
+
+3. Only if all copies are gone: re-run this entire runbook. Re-registering the
+   same number produces new identity keys, so every group member sees a safety
+   number change, and the bot must be re-invited to the group.
+
+### Retiring the bot
+
+```bash
+ssh forge 'sudo curl -sS -X POST http://127.0.0.1:8484/v1/unregister/+15551234567'
+```
+
+Then remove the service from `hosts/forge/default.nix`, delete the SOPS keys,
+and release the VoIP number.

--- a/modules/nixos/services/signal-api/default.nix
+++ b/modules/nixos/services/signal-api/default.nix
@@ -1,0 +1,293 @@
+# modules/nixos/services/signal-api/default.nix
+#
+# signal-api - Signal messenger transport (bbernhard/signal-cli-rest-api)
+#
+# A thin REST wrapper around signal-cli. It exists so other homelab services
+# can send Signal messages as a dedicated bot account without embedding
+# signal-cli themselves. On forge the only intended consumer is homelab-mcp
+# (its future `signal_send` tool).
+#
+# Reference: https://github.com/bbernhard/signal-cli-rest-api
+# API docs:  https://bbernhard.github.io/signal-cli-rest-api/
+# Runbook:   ./RUNBOOK.md (one-time human registration procedure)
+#
+# SECURITY MODEL - READ BEFORE CHANGING ANYTHING ABOUT NETWORKING
+# ---------------------------------------------------------------
+# The REST API has NO AUTHENTICATION WHATSOEVER. Anything that can open a
+# TCP connection to it can send Signal messages as the bot, read the bot's
+# messages, list its groups, or unregister the account. Three layers keep
+# that surface closed:
+#
+#   1. The published port is bound to 127.0.0.1 only (see extraConfig). It is
+#      never reachable from the LAN, and it must NEVER be given a Caddy vhost
+#      or a Cloudflare Tunnel ingress rule.
+#   2. The container runs alone on an *isolated* Podman network, so no other
+#      container on the host can reach its container IP directly.
+#   3. An iptables guard in the filter OUTPUT chain rejects connections to the
+#      API from every local UID except the ones named in
+#      `localAccess.allowedUsers` (see the localAccess option below).
+#
+# The registration state under dataDir (account keys, identity keys, session
+# state) is the crown jewel: possession of it *is* the bot's Signal identity.
+# It is stored on its own ZFS dataset with 0700 permissions and is expected to
+# be snapshotted, replicated and backed up by the host configuration.
+#
+# Factory-based implementation (see lib/service-factory.nix).
+{ lib
+, mylib
+, pkgs
+, config
+, podmanLib
+, ...
+}:
+
+let
+  serviceIds = mylib.serviceUids.signal-api;
+
+  # The image always listens on 8080 inside the container (Dockerfile
+  # `ENV PORT=8080`); cfg.port is the host-side loopback port.
+  containerPort = 8080;
+in
+mylib.mkContainerService {
+  inherit lib mylib pkgs config podmanLib;
+
+  name = "signal-api";
+  description = "Signal REST API";
+
+  spec = {
+    port = 8484;
+    inherit containerPort;
+
+    # Pinned by tag + digest.
+    #
+    # BUMP THIS PERIODICALLY. signal-cli-rest-api vendors signal-cli, which
+    # implements an unversioned, server-driven protocol: when Signal changes
+    # the protocol or retires a client version, an old image stops being able
+    # to send and the only fix is a newer image. Treat a "sending suddenly
+    # broke" incident as an image-age problem first.
+    #   Upstream releases: https://github.com/bbernhard/signal-cli-rest-api/releases
+    image = "bbernhard/signal-cli-rest-api:0.100@sha256:2399d449123cdad56c4d859277e3b9127e1a00c4d2ab4601c239882609286cf8";
+
+    operationalProfile = "infrastructure";
+    displayName = "Signal API";
+    function = "messaging_transport";
+
+    # The image ships curl and its own HEALTHCHECK hits this endpoint.
+    # /v1/health answers 204 No Content, so the factory's default
+    # "expect HTTP 200" probe would report a permanently unhealthy container.
+    healthCommand = "curl -f -s -o /dev/null http://127.0.0.1:${toString containerPort}/v1/health || exit 1";
+    # A cold JVM + signal-cli daemon start is slow; don't count health
+    # failures until it has had a chance to come up.
+    startPeriod = "120s";
+
+    # Small files (account json, protocol store, per-recipient session state).
+    zfsRecordSize = "16K";
+
+    # json-rpc mode = resident JVM, which upstream flags as the mode with
+    # "increased" memory use. 1G is a starting estimate, not a measurement -
+    # check `podman stats signal-api` after a few weeks and tighten it. Do not
+    # cut it aggressively: upstream traces "User <number> is not registered"
+    # errors to a resource-starved container.
+    resources = {
+      memory = "1G";
+      memoryReservation = "512M";
+      cpus = "2.0";
+    };
+
+    # The entrypoint must start as root: it usermod/groupmods the in-image
+    # `signal-api` account to SIGNAL_CLI_UID/GID, chowns the config dir, then
+    # drops privileges with setpriv before exec'ing the server. The PUID/PGID
+    # variables the factory injects for runAsRoot containers are replaced with
+    # the SIGNAL_CLI_* equivalents in extraConfig below.
+    runAsRoot = true;
+
+    # State lives at the signal-cli config dir, not /config.
+    skipDefaultConfigMount = true;
+    volumes = cfg': [
+      "${cfg'.dataDir}:/home/.local/share/signal-cli:rw"
+    ];
+  };
+
+  extraOptions = {
+    uid = lib.mkOption {
+      type = lib.types.int;
+      default = serviceIds.uid;
+      description = "UID for the signal-api service user (from lib/service-uids.nix).";
+    };
+
+    gid = lib.mkOption {
+      type = lib.types.int;
+      default = serviceIds.gid;
+      description = "GID for the signal-api service group (from lib/service-uids.nix).";
+    };
+
+    mode = lib.mkOption {
+      type = lib.types.enum [ "json-rpc" "json-rpc-native" "native" "normal" ];
+      default = "json-rpc";
+      description = ''
+        signal-cli execution mode.
+
+        `json-rpc` keeps a single signal-cli JVM daemon resident instead of
+        spawning a JVM per request - the difference between a multi-second and
+        a sub-second send, which matters because the caller is an interactive
+        MCP tool. The cost is a permanently resident JVM (see `resources`).
+
+        `normal`/`native` fork a process per request; `json-rpc-native` uses
+        the GraalVM build of signal-cli as the daemon (lower memory, but
+        upstream considers it less stable).
+      '';
+    };
+
+    logLevel = lib.mkOption {
+      type = lib.types.enum [ "debug" "info" "warn" "error" ];
+      default = "info";
+      description = "LOG_LEVEL passed to the container.";
+    };
+
+    # ---------------------------------------------------------------------
+    # Local access control
+    # ---------------------------------------------------------------------
+    localAccess = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Install an iptables guard restricting which local users may open a
+          connection to the unauthenticated REST API.
+
+          Disabling this leaves every process on the host able to send Signal
+          messages as the bot. Only turn it off while debugging.
+        '';
+      };
+
+      allowedUsers = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ "root" ];
+        example = [ "root" "homelab-mcp" "gatus" ];
+        description = ''
+          Local user accounts permitted to reach the API. Everything else gets
+          a TCP reset.
+
+          `root` is listed by default because it can trivially bypass a UID
+          match anyway (setuid, nsenter, podman exec), and the registration
+          runbook drives the API with curl as root.
+        '';
+      };
+
+      subnet = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "10.90.0.0/24";
+        description = ''
+          CIDR of the Podman network this container runs on.
+
+          The guard matches the *post-DNAT* destination: by the time a packet
+          reaches the filter OUTPUT chain, Podman's hostport DNAT has already
+          rewritten 127.0.0.1:<port> to <containerIP>:${toString containerPort}. Matching
+          the network's subnet therefore covers both the published loopback
+          port and any direct connection to the container IP.
+        '';
+      };
+    };
+
+    # No Prometheus endpoint upstream - liveness is covered by the container
+    # healthcheck plus the host's Gatus check against /v1/health.
+    metrics = lib.mkOption {
+      type = lib.types.nullOr mylib.types.metricsSubmodule;
+      default = null;
+      description = "Prometheus metrics collection configuration (signal-api exposes no metrics endpoint)";
+    };
+  };
+
+  extraConfig = cfg': {
+    assertions = lib.optionals cfg'.localAccess.enable (
+      [
+        {
+          assertion = cfg'.localAccess.subnet != null;
+          message = ''
+            modules.services.signal-api.localAccess.enable requires
+            localAccess.subnet to be set to the CIDR of the Podman network the
+            container runs on (see modules.virtualization.podman.networks).
+          '';
+        }
+        {
+          assertion = cfg'.localAccess.allowedUsers != [ ];
+          message = "modules.services.signal-api.localAccess.allowedUsers must not be empty (that would block every caller, including the Gatus liveness check).";
+        }
+        {
+          assertion = config.networking.firewall.enable;
+          message = "modules.services.signal-api.localAccess.enable requires networking.firewall.enable (the guard is installed via firewall extraCommands).";
+        }
+      ]
+      ++ map
+        (user: {
+          assertion = config.users.users ? ${user};
+          message = "modules.services.signal-api.localAccess.allowedUsers references unknown user '${user}'; iptables would fail to resolve it at firewall start.";
+        })
+        cfg'.localAccess.allowedUsers
+    );
+
+    virtualisation.oci-containers.containers.signal-api = {
+      # Replace the factory's LinuxServer.io-style PUID/PGID/UMASK trio with
+      # the variables this image actually reads.
+      environment = lib.mkForce {
+        TZ = cfg'.timezone;
+        MODE = cfg'.mode;
+        LOG_LEVEL = cfg'.logLevel;
+        # The entrypoint remaps its internal `signal-api` account to these
+        # ids, so everything written to the mounted dataset is owned by the
+        # host service user.
+        SIGNAL_CLI_UID = toString cfg'.uid;
+        SIGNAL_CLI_GID = toString cfg'.gid;
+        # This bot never receives attachments/stories/stickers; not
+        # downloading them keeps the dataset small and the crown-jewel
+        # backup cheap.
+        JSON_RPC_IGNORE_ATTACHMENTS = "true";
+        JSON_RPC_IGNORE_STORIES = "true";
+        JSON_RPC_IGNORE_STICKERS = "true";
+      };
+
+      # Loopback only. See the security model at the top of this file.
+      ports = lib.mkForce [
+        "127.0.0.1:${toString cfg'.port}:${toString containerPort}"
+      ];
+    };
+
+    # ---------------------------------------------------------------------
+    # iptables guard (see localAccess above)
+    #
+    # A dedicated chain keeps the rules idempotent across firewall reloads:
+    # create-if-missing, flush, repopulate, and jump to it from OUTPUT only
+    # once. NixOS itself installs nothing in filter OUTPUT and netavark only
+    # touches nat/FORWARD, so position 1 stays position 1.
+    # ---------------------------------------------------------------------
+    networking.firewall = lib.mkIf cfg'.localAccess.enable (
+      let
+        chain = "signal-api-guard";
+        jumpMatch = "-p tcp -d ${cfg'.localAccess.subnet} --dport ${toString containerPort} -j ${chain}";
+        allowRules = lib.concatMapStringsSep "\n"
+          (user: "iptables -w -A ${chain} -m owner --uid-owner ${user} -j RETURN")
+          cfg'.localAccess.allowedUsers;
+      in
+      {
+        # `-w` throughout: podman/netavark rewrites iptables whenever a
+        # container starts, and an unlucky collision on the xtables lock would
+        # otherwise fail firewall.service.
+        extraCommands = ''
+          # signal-api: restrict the unauthenticated REST API to approved local users
+          iptables -w -N ${chain} 2>/dev/null || true
+          iptables -w -F ${chain}
+          ${allowRules}
+          iptables -w -A ${chain} -j REJECT --reject-with tcp-reset
+          iptables -w -C OUTPUT ${jumpMatch} 2>/dev/null || iptables -w -I OUTPUT 1 ${jumpMatch}
+        '';
+
+        extraStopCommands = ''
+          iptables -w -D OUTPUT ${jumpMatch} 2>/dev/null || true
+          iptables -w -F ${chain} 2>/dev/null || true
+          iptables -w -X ${chain} 2>/dev/null || true
+        '';
+      }
+    );
+  };
+}

--- a/modules/nixos/virtualization/default.nix
+++ b/modules/nixos/virtualization/default.nix
@@ -38,6 +38,22 @@ in
               default = false;
               description = "Enable IPv6 for this network";
             };
+            isolate = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = ''
+                Enable netavark network isolation (`--opt isolate=true`).
+
+                Containers on an isolated network cannot exchange traffic with
+                containers on any other Podman network. Host <-> container
+                traffic (including published ports) and outbound NAT are
+                unaffected.
+
+                NOTE: only applied when the network is first created - the
+                creation command is a no-op for an existing network. Remove the
+                network (`podman network rm <name>`) to change this.
+              '';
+            };
           };
         });
         default = { };
@@ -88,6 +104,7 @@ in
                 ++ lib.optional (networkConfig.gateway != null) "--gateway=${networkConfig.gateway}"
                 ++ lib.optional networkConfig.internal "--internal"
                 ++ lib.optional networkConfig.ipv6 "--ipv6"
+                ++ lib.optional networkConfig.isolate "--opt isolate=true"
               );
             in
             ''


### PR DESCRIPTION
Deploys `bbernhard/signal-cli-rest-api` on forge as the transport for the weekly household financial pulse. The only intended consumer is homelab-mcp's future `signal_send` tool (separate work, in `~/src/mcp`).

## Network exposure

The REST API has **no authentication of any kind** — anything that can open a TCP connection to it can send messages as the bot, read its messages, or unregister the account. Four layers close that off:

1. Published on `127.0.0.1:8484` only (`mkForce`). No Caddy vhost, no Cloudflare Tunnel ingress, no LAN port.
2. The container runs alone on an isolated Podman network (`10.90.0.0/24`, `--opt isolate=true`), so no other container on forge can reach its container IP.
3. An iptables guard in filter OUTPUT rejects every local UID except `homelab-mcp`, `gatus` and `root`.
4. Eval-time assertions that the subnet is set, the allow-list is non-empty, and every named user exists.

The guard matches the **post-DNAT** destination (`-d 10.90.0.0/24 --dport 8080`) rather than `127.0.0.1:8484` — Podman's hostport DNAT rewrites the destination in nat/OUTPUT before filter/OUTPUT is reached, so the intuitive rule would never fire. Matching the network subnet also covers direct connections to the container IP.

## Data protection

Registration state (account keys, identity keys, session state) *is* the bot's Signal identity and is not reproducible from any other source — losing it means re-registering the number, which churns safety numbers for every group member and requires a re-invite.

- Dedicated ZFS dataset at 0700, 16K recordsize
- Sanoid snapshots + syncoid replication to nas-1
- Restic to `nas-primary` **and** an offsite job to `r2-offsite`
- Protection manifest reports `missingRequiredTiers: []` for all five declared tiers

`allowEmptyBootstrap = true` despite the `critical` class: the service ships with no account, so a first deployment must be able to come up empty for a human to register against it. With `false`, preseed finds nothing to restore, blocks the container, and on the syncoid path leaves the dataset renamed to a `-graveyard-<ts>` sibling. The tradeoff is documented inline.

## Monitoring

Two Gatus endpoints under *Infrastructure*:

| Endpoint | Interval | Proves |
| --- | --- | --- |
| `/v1/health` | 60s | the HTTP server is serving — upstream's handler is a bare `return 204`, nothing more |
| `/v1/accounts` | 300s | the signal-cli daemon answers *and* the bot account exists |

The second one is what catches a container restored onto an empty dataset, which is invisible to a liveness probe. **It is red by design until registration is done** and will page after ~25 minutes.

## Also in this PR

- `isolate` option on the Podman network module (`--opt isolate=true`), applied at network-create time only
- uid/gid 947 reserved in `lib/service-uids.nix`

## Manual step

Account registration is a one-time human procedure — VoIP number, captcha, SMS verification, profile name, username, group ID — documented in `modules/nixos/services/signal-api/RUNBOOK.md`, including a smoke test, a restart test, and access-control verification. The bot's number and group ID go into the existing `homelab-mcp/env` SOPS secret, never into code.

Until the runbook runs, the container is healthy but has no account and every send errors.

## Verification

`nix eval` of `config.system.build.toplevel.drvPath` succeeds (forces all assertions); `nix fmt --check`, `statix` and `deadnix` clean. Confirmed from the evaluated config: loopback-only ports, no Caddy vhost, 0700 dataset owned by 947, preseed as a soft dependency, both restic jobs with ZFS snapshot units, syncoid replication, and both Gatus endpoints rendering correctly.

Not yet deployed — nothing here has run against real hardware. Rollback is `nixos-rebuild --rollback` (restores the previous firewall rules) plus `podman network rm signal-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
