### PR TITLE
chore(deps): bump lading and homelab-mcp for the Costco corrections

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786131418,
-        "narHash": "sha256-jIpjTLYId42Slpiqf1ViYDaZ//p/5faMffWv5Mw3fP0=",
+        "lastModified": 1786132919,
+        "narHash": "sha256-ZbKfSXEQUlj5xdXl4QyiNw9di2/ZO5qvGEnzZB880N4=",
         "owner": "carpenike",
         "repo": "mcp",
-        "rev": "a80d0388e913e0bd53cf0a787b9c172a762a1bd5",
+        "rev": "0b6058a58763f68398678129b4a509eaec81dff6",
         "type": "github"
       },
       "original": {
@@ -361,11 +361,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786131415,
-        "narHash": "sha256-SWJ4oTpR3ZdReroVYx512AS3tmNrotZYEN40whidgJ0=",
+        "lastModified": 1786132327,
+        "narHash": "sha256-SxNqbgSn7gIWqMizPA4x9E6w6Q9r0gwJvWt2/0ImTRI=",
         "owner": "carpenike",
         "repo": "lading",
-        "rev": "6948f97560058cb40b8ef31b95a088a3b9416c3b",
+        "rev": "5213e0beb04d3673c250550e11bb506c7b80055f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Both by hand. Renovate watches homelab-mcp but hadn't opened one yet, and it
doesn't watch lading at all — the gap that let the deployed closure outrun the
committed lock on 2026-08-04.

## lading `6a381ce` → `5213e0b`

- **Corrects two field-note claims production disproved.** Costco retains ~3
  years, not 15 months — the original figure was my query's own start date
  reflected back. And `exact` is *not* reachable for Costco, so the card map
  must stay empty: the accounts hold ten and five distinct card last-4s while
  the map holds one, so populating it would downgrade most matches to
  `ambiguous`.
- **Clamps `sync_coverage` to the source's observed horizon.** A 5-year
  backfill had recorded **58 months as covered** in which Costco has nothing
  and never did. A charge from that period would have been reported "we looked,
  there is no such receipt" when the truth is "Costco may have aged it out" —
  which matters ahead of importing older Costco charges into Actual.

## homelab-mcp `607ee50` → `0b6058a`

- **The same two corrections in the tool `INSTRUCTIONS`**, which are served to
  the model at connection time. Sessions are still being told `exact` should be
  routine — the claim that leads someone to populate the card map and make
  matching worse.
- **Adds `costco_price_history`** plus date filters. Price questions are what
  this data actually gets asked, and `costco_search_items` answered them wrongly
  in four silent ways: a broad word averaged several products into one trend,
  the 200-line newest-first cap truncated the recent end of a series, the line
  total moves with weight on weighed goods, and Costco renumbers its own
  products so `item_number` splits or truncates a series.

Verified: forge's whole system closure evaluates, and only these four commits
ride along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)