### PR TITLE
feat(forge): sync Sam's Club in-club receipts for ryan

### DIFF
--- a/hosts/forge/secrets.nix
+++ b/hosts/forge/secrets.nix
@@ -1337,6 +1337,36 @@ in
             group = "root";
           };
 
+          # Sam's Club in-club receipts for ryan. A SEED, exactly like
+          # costco_tokens above, and the same install-once guard applies —
+          # Azure B2C rotates the refresh token on every redemption, so the
+          # live value lives in the unit's StateDirectory.
+          #
+          # Two things differ from the Costco seed, both worth knowing before
+          # anyone plans to re-capture this:
+          #
+          #   * It CANNOT be captured from a browser. The samsclub.com web API
+          #     does not return totals, line prices or even a machine-readable
+          #     date for this cohort; only the MOBILE app's API does. Capturing
+          #     the token means putting a phone behind mitmproxy with a CA
+          #     installed — half an hour, not thirty seconds.
+          #   * It effectively never expires. Each redemption returns a fresh
+          #     365-day token, so a unit that keeps running never needs
+          #     re-seeding. Only a lapse longer than a year, a password change
+          #     or a revoked session brings the phone back out.
+          #
+          # Which makes restoring a spent seed over a good live token much more
+          # expensive here than for Costco. The module's `[ -e "$live" ]` test
+          # is what prevents it.
+          #
+          # The value is the JSON the capture produces: client_id,
+          # refresh_token, and the device identifiers the app sends with it.
+          "lading/ryan/samsclub_tokens" = {
+            mode = "0400";
+            owner = "root";
+            group = "root";
+          };
+
           # Steffi's Amazon account. Same three keys, same shapes — the
           # symmetry is the point: a second account is a sibling block, not a
           # differently-named special case.

--- a/hosts/forge/services/lading.nix
+++ b/hosts/forge/services/lading.nix
@@ -72,6 +72,7 @@
 #            amazon_password:       <password>
 #            amazon_otp_secret_key: <base32 seed, spaces and all>
 #            costco_tokens:         <the JSON blob captured from a browser>
+#            samsclub_tokens:       <the JSON blob captured from a PHONE>
 #
 #      costco_tokens is a different KIND of secret from the three above it: a
 #      SEED, not a standing credential. Azure B2C rotates the refresh token on
@@ -171,6 +172,25 @@ let
       costco = {
         enable = true;
         tokenSeedFile = config.sops.secrets."lading/ryan/costco_tokens".path;
+      };
+
+      # Sam's Club in-club receipts. A THIRD SOURCE with a third credential,
+      # decoupled from both others in the same way Costco is.
+      #
+      # Only ryan's membership is seeded, so this is deliberately NOT mirrored
+      # onto steffi below — the same asymmetry the Costco block started with,
+      # and for the same reason: a second membership needs its own token, and
+      # capturing one here is not a browser snippet. The samsclub.com WEB API
+      # returns no totals, no line prices and no machine-readable date for this
+      # cohort; only the mobile app's API does. So seeding an account means
+      # putting THAT PERSON'S PHONE behind a proxy with a CA installed.
+      #
+      # Worth doing once for steffi eventually — Costco's numbers say so
+      # loudly: one membership matched 40.5% of charges, two matched 90.5% —
+      # but it needs her, not just her credentials.
+      samsclub = {
+        enable = true;
+        tokenSeedFile = config.sops.secrets."lading/ryan/samsclub_tokens".path;
       };
     };
 


### PR DESCRIPTION
Stacked on #773 — that branch holds the `samsclub_tokens` sops value this
change declares and uses, so it cannot target main until #773 lands. GitHub
will retarget this to main automatically when it does.

Enables the third lading source on ryan's sync unit, and bumps the lading
flake input to 0.5.0.

**The flake bump is load-bearing, not incidental.** The module options this
config references do not exist at the previously pinned rev, so the two must
land together. That is the failure this file's own header warns about, on
record from 2026-08-04.

## Why the seed comments are longer than Costco's

Two things differ, and both change what re-seeding costs:

- **It cannot be captured from a browser.** The samsclub.com web API returns
  no totals, no line prices and no machine-readable date for this cohort; only
  the mobile app's API does. Seeding means a phone behind mitmproxy with a CA
  installed — half an hour, not thirty seconds.
- **It effectively never expires.** Each redemption returns a fresh 365-day
  token, so a running unit never needs re-seeding. Which makes restoring a
  spent seed over a good live one much more expensive here than for Costco;
  the module's `[ -e "$live" ]` guard is what prevents it.

## Verified by evaluating the forge config

- `LADING_SAMSCLUB_ENABLED=true` on `lading-sync-ryan`
- `LADING_SAMSCLUB_ACCOUNTS=["ryan"]` derived on the health unit
- ExecStartPre = costco seed, samsclub seed, `lading-migrate`
- `/run/secrets/lading/ryan/samsclub_tokens` resolves

## Before deploying

`lading-sync --source samsclub` has never run end to end against a database —
only the probe has exercised the API. Worth one run against a throwaway store
first.

Only ryan's membership is seeded. Steffi's needs her phone, not just her
credentials; Costco's numbers argue for doing it eventually (one membership
matched 40.5% of charges, two matched 90.5%).