### PR TITLE
chore(deps): repin homelab-mcp to 0.22.0 — project tag amount form

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786281032,
-        "narHash": "sha256-ACTvHZeqH+GPCE5ZNNh4wbENPN0pwKwtG7fDxTwGV5U=",
+        "lastModified": 1786281112,
+        "narHash": "sha256-Dz0R60oOYnrnkgvKD5Y5mg8U0k76Jyi9kz+HpFmXMlk=",
         "owner": "carpenike",
         "repo": "mcp",
-        "rev": "ee8c887ae79c7ee36005f5712486dc5b8d132c5c",
+        "rev": "c6e65d1a4a67467e346d27ea6a7d00fddfa42695",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Repins `inputs.homelab-mcp` from `ee8c887a` to **`c6e65d1`** (v0.22.0), picking up [carpenike/mcp#47](https://github.com/carpenike/mcp/pull/47).

**Note this supersedes the pin in a052f12a** (`ee8c887a`, #46 samsclub), which landed minutes before #47 merged. `c6e65d1` contains it — nothing from the samsclub work is lost.

## What it fixes

The exporter's `project_spend` was summing **whole** tagged transactions, which overstates a MIXED charge. Two Costco runs that happened to include the patio-lighting fixtures put their entire receipts — groceries and all — against the project: **$812.49** against receipt-verified shares of $239.92 + $86.97.

OPERATIONS.md's project tag convention (`ce6f652`) now has an amount form, and the exporter implements it:

```
[proj:patio-lighting]           the whole charge is project spend
[proj:patio-lighting=239.92]    only this much of it is
```

## Verified against the real register before merge

Run twice on forge, identical both times, `degraded = {}`:

```
patio-lighting   348.09   (239.92 + 86.97 + 21.20)
berry-garden      21.19
```

`project_spend` went 2 rows → 4: the existing rows were **updated in place** and two added, with no stale rows — upsert-plus-prune exercised against a real change in the underlying notes.

The wire-rope order is the case that justified the convention: one $42.39 Amazon charge serving two projects, booked in PLANNED.md under the berry garden while also read as patio-lighting spend. Two documents were double-counting one purchase; two stated shares on one note (`[proj:patio-lighting=21.20] [proj:berry-garden=21.19]`) reconcile it to the cent.

## Checks

`nix eval` of `forge.config.system.build.toplevel` succeeds, and the export unit resolves to `homelab-mcp-0.22.0/bin/homelab-finances-export`. Lock-file change only — no module or option changes.

**After deploy**, the first nightly run (05:30 ET) produces the corrected project totals. Until then the dashboard shows the bare-form figures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)