### PR TITLE
feat(homelab-mcp): allowlist finances_sentinel in both enforcement layers

### DIFF
--- a/hosts/forge/services/hermes-agent.nix
+++ b/hosts/forge/services/hermes-agent.nix
@@ -697,6 +697,14 @@ in
             "finances_context_list"
             "finances_clarify_candidates"
             "finances_ticklers"
+            # The daily sentinel, as one call. It performs the four reads
+            # itself and returns `silent` plus the exact lines to send; the
+            # cron prompt shrinks to rendering them. The four reads stay in
+            # this list because the weekly pulse still calls them directly.
+            # Mirrors HOMELAB_MCP_RESTRICTED_SCOPES.hermes in
+            # services/homelab-mcp.nix, which is the authoritative boundary —
+            # both must name it or the tool is invisible here or 403 there.
+            "finances_sentinel"
           ];
           sampling.enabled = false;
         };

--- a/hosts/forge/services/homelab-mcp.nix
+++ b/hosts/forge/services/homelab-mcp.nix
@@ -189,6 +189,11 @@ in
               "finances_context_consume"
               "finances_clarify_candidates"
               "finances_ticklers"
+              # The daily 08:00 alarm, decided in code rather than in the cron
+              # prompt. In BOTH scopes: hermes calls it and renders its lines,
+              # and an advisor session needs the same verdict — and the
+              # `evidence` behind it — to explain or challenge a morning.
+              "finances_sentinel"
               "finances_decision_append"
               "finances_tickler_append"
               "finances_planned_append"
@@ -246,6 +251,13 @@ in
               "finances_context_list"
               "finances_clarify_candidates"
               "finances_ticklers"
+              # The sentinel composes the four reads above and decides; the
+              # cron prompt only renders what comes back. The four sources
+              # stay listed because the weekly pulse reads them directly.
+              # This middleware allowlist is authoritative — the tool is
+              # 403 at tools/call without it, however the alias is
+              # configured client-side.
+              "finances_sentinel"
               "homelab_list_status"
             ];
           };


### PR DESCRIPTION
The daily sentinel's decision logic moved from `dailySentinelPrompt` into a tool (carpenike/mcp#48). Scope enforcement is three-layer — scope advertisement, `tools/list` filtering, call-time 403 — and the server-side half lives **here**, not in the Python: `HOMELAB_MCP_RESTRICTED_SCOPES` overrides the code default in `config.py`, the same way costco/samsclub/fidelity were added in `a052f12`. So the tool has to be named in two files or it is invisible to the client, or 403 at the server.

- **`services/homelab-mcp.nix`** — the `advisor` and `hermes` entries of `HOMELAB_MCP_RESTRICTED_SCOPES` (authoritative boundary).
- **`services/hermes-agent.nix`** — `mcpServers.holthome.tools.include` (the client-side view of the same boundary).

Both scopes get it. hermes calls it and renders its `lines`; an advisor session needs the same verdict — and the `evidence` behind it — to explain or challenge a morning.

## Safe to merge ahead of the repin

An allowlist entry naming a tool the server does not serve yet simply never matches, so this is inert until `flake.lock` moves to `fb38ab8`. Nothing here touches the running system, including the current hermes→MCP outage.

## Deliberately not in this change

- **`nix flake update homelab-mcp`** — Renovate repins this input; it has done so three times in the past week.
- **`householdAdvisorPrompt`'s "exactly eleven Homelab MCP tools" inventory.** That edit has the *opposite* sequencing constraint to these allowlists — it must not land before the repin, or the persona advertises a tool that does not exist. Queued separately.
- **`dailySentinelPrompt`** — shrinking it stays gated on a verified `systemctl start hermes-agent-daily-finance-sentinel-dry-run.service`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxewkD1tN3Eh7sPwsiXpx8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QxewkD1tN3Eh7sPwsiXpx8)_