### PR TITLE
fix(hermes): the advisor persona counts twelve tools, not eleven

### DIFF
--- a/hosts/forge/services/hermes-agent.nix
+++ b/hosts/forge/services/hermes-agent.nix
@@ -23,10 +23,13 @@ let
   '';
   householdAdvisorPrompt = ''
     You are Household Advisor. Be concise, factual, and family-appropriate.
-    You have access to exactly eleven Homelab MCP tools. Eight are read-only
+    You have access to exactly twelve Homelab MCP tools. Nine are read-only
     financial summaries: finances_sync_status, finances_monthly_summary,
     finances_recurring, finances_debt_status, finances_breaches,
-    finances_buffer, finances_room, and finances_ticklers. Three handle
+    finances_buffer, finances_room, finances_ticklers, and finances_sentinel.
+    That last one is the daily alarm, computed rather than reasoned: it
+    performs its own four reads and returns the exact lines to send, so call
+    it instead of re-deriving its verdict from the other tools. Three handle
     transaction context: finances_context_add, finances_context_list, and
     finances_clarify_candidates. Use the summaries for factual finance questions
     and monitoring. Never state a number unless it appears in current tool


### PR DESCRIPTION
## Ready — the gate this was held behind is satisfied

Opened as a draft on the assumption the repin was a manual step. It isn't: `notify-nix-config.yml` in carpenike/mcp dispatches on every push to `main`, and this repo's `update-flake-input.yml` opens a gated, auto-merged repin PR. That already ran twice — `de36c01b` (#792) for `fb38ab8`, then `89178574` (#798) for `ab31620`, which is the current pin.

So the ordering constraint has flipped. With #796's allowlist merged *and* the repin landed, `finances_sentinel` is live and reachable while the persona still says "exactly eleven" — the mismatch the draft status existed to prevent, reached from the other side. This is now the one piece out of step.

## What and why

`signal = [ "hermes-signal" "holthome" ]`, so Signal shares the alias cron uses. Adding `finances_sentinel` to `holthome`'s `tools.include` in #796 gives the Signal persona a twelfth tool — but `householdAdvisorPrompt` opens with *"You have access to exactly eleven Homelab MCP tools"* and then enumerates all eleven. A persona that miscounts its own toolset is exactly the prompt drift OPERATIONS.md warns about: format contracts must be exact templates, not approximations.

It also tells the persona what the tool is *for*, since the failure mode worth pre-empting is an advisor that re-derives the morning verdict from the four underlying reads instead of calling the tool that decides.

The *"at most 11 nonblank lines"* further down is the help menu's length, not a tool count, and is deliberately unchanged.

## Still not in scope

`dailySentinelPrompt` — shrinking it to "call `finances_sentinel` once; render `lines`" stays gated on a verified `systemctl start hermes-agent-daily-finance-sentinel-dry-run.service`. That gate is real and lives here, in nix-config, since the prompt does. The tool being deployed ahead of it is harmless: the cron job still runs the old four-tool flow, so the tool is present but dormant.

When that change is written it should also close the gap the 2026-08-13 outage exposed: the `[SILENT]` gate must be unreachable when the tool call itself fails, so a broken MCP connection produces a 🛑 line rather than a quiet morning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QxewkD1tN3Eh7sPwsiXpx8