### PR TITLE
fix(tautulli): restore RequiresMountsFor in unitConfig

### DIFF
--- a/modules/nixos/services/tautulli/default.nix
+++ b/modules/nixos/services/tautulli/default.nix
@@ -208,10 +208,17 @@ in
 
       # Systemd service dependencies and notifications
       systemd.services."${serviceName}" = {
+        # NOTE: use lib.optionalAttrs, NOT mkIf, when merging with `//`.
+        # mkIf returns `{ _type = "if"; condition; content; }`, so `//` splices
+        # `_type = "if"` into the attrset and the module system then treats the
+        # WHOLE definition as an mkIf node, keeping only `content` and silently
+        # discarding every sibling attribute (here: RequiresMountsFor).
+        # optionalAttrs is safe because the condition depends only on `config`,
+        # not on the option being defined.
         unitConfig = {
           # Ensure ZFS mount is available before service starts
           RequiresMountsFor = [ cfg.dataDir ];
-        } // (mkIf (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
+        } // (lib.optionalAttrs (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
           OnFailure = [ "notify@tautulli-failure:%n.service" ];
         });
         wants = mkIf cfg.preseed.enable [ "preseed-tautulli.service" ];


### PR DESCRIPTION
## Problem

`modules/nixos/services/tautulli/default.nix` built `unitConfig` as:

```nix
unitConfig = {
  RequiresMountsFor = [ cfg.dataDir ];
} // (mkIf cond { OnFailure = [ ... ]; });
```

`mkIf` returns `{ _type = "if"; condition; content; }`, so `//` splices `_type = "if"` into the attrset. The module system then reads the *entire* definition as an mkIf node and keeps only `content`, silently discarding every sibling attribute.

Net effect: `RequiresMountsFor` was dropped, so tautulli could start before its ZFS dataset was mounted. Confirmed on forge — both `nix eval ...systemd.services.tautulli.unitConfig` and `systemctl cat tautulli` showed `OnFailure` with no `RequiresMountsFor`.

## Fix

Use `lib.optionalAttrs` instead. The condition depends only on `config`, not on the option being defined, so it composes plainly. Added a NOTE comment documenting the trap.

## Verification

```
nix eval --json .#nixosConfigurations.forge.config.systemd.services.tautulli.unitConfig
{"After":"network.target preseed-tautulli.service","Description":"Tautulli Plex Monitor","OnFailure":["notify@tautulli-failure:%n.service"],"RequiresMountsFor":["/var/lib/tautulli"],"Wants":"preseed-tautulli.service"}
```

Both keys present.

## Note

The identical bug exists in `modules/nixos/services/home-assistant/default.nix` (`unitConfig` and `serviceConfig`). That fix is being handled separately and is intentionally not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)