### PR TITLE
docs(hermes): correct the heartbeat alarm status — fixed, not yet merged

### DIFF
--- a/hosts/forge/services/hermes-agent.nix
+++ b/hosts/forge/services/hermes-agent.nix
@@ -1140,19 +1140,33 @@ in
         # No dependency on hermes-agent: this must still run, and still be able
         # to complain, when hermes is wedged, stopped, or gone.
         #
-        # WARNING (2026-08-16): this alarm is currently INERT. The detection
-        # below is verified in both directions, but notify@ only delivers to
-        # backends whose per-instance .path unit was declared by the caller,
-        # and forge has 4 such declarations against 34 template registrations.
-        # A test-fire confirmed the payload is written to /run/notify and then
-        # read by nobody; the dispatcher still exits 0. So this unit detects a
-        # dead sentinel and cannot yet tell anyone.
+        # ALARM STATUS (2026-08-16): fixed and proven, but the fix is not in
+        # this repo yet. Read both halves before trusting or distrusting it.
         #
-        # Deliberately NOT patched here with a private path instance: that
-        # would be the 5th copy of the pattern that caused the outage, and it
-        # would arm this one alarm while ~30 other services stayed dark. The
-        # fix belongs in modules/nixos/notifications. Re-test end-to-end when
-        # it lands — a page on a real device, not a green unit.
+        # It WAS inert. notify@ delivered only to backends whose per-instance
+        # .path unit a caller had declared — 4 declarations against 34 template
+        # registrations — so a test-fire wrote a payload to /run/notify that
+        # nothing ever read, while the dispatcher exited 0. Payloads had been
+        # accumulating unread since 2026-07-13.
+        #
+        # It was deliberately NOT patched here with a private path instance:
+        # that would have been a 5th copy of the pattern that caused the
+        # outage, arming this one alarm while ~30 other services stayed dark.
+        #
+        # The real fix lives in modules/nixos/notifications and is verified:
+        # the dispatcher resolves this dynamic instance and renders this
+        # template correctly, and a genuine unit failure carried an OnFailure
+        # notification through to Pushover returning HTTP 200. It is DEPLOYED
+        # ON FORGE but NOT YET MERGED to main. So on the running host this
+        # alarm pages; from this repo alone it does not, and deploying main
+        # over forge would silently un-arm it again.
+        #
+        # When that fix merges, delete this paragraph — and note the template
+        # carries no placeholders, so the page says only that the sentinel is
+        # not reporting, never whether it failed to run or ran blind. Those
+        # want different responses; the reason is in
+        # `journalctl -u hermes-agent-sentinel-heartbeat` until the template
+        # declares a "reason" placeholder fed from the check below.
         onFailure = [ "notify@hermes-sentinel-stale:%n.service" ];
         serviceConfig = pulseServiceHardening // {
           Type = "oneshot";


### PR DESCRIPTION
Follow-up to #815. Comment-only; the built system is unchanged.

#815 landed a note saying the sentinel heartbeat's alarm was **INERT** — true when written, and now half wrong in a way that misleads in both directions.

**What changed underneath it:** the notifications delivery fix has been built and verified. The dispatcher resolves this alarm's dynamic instance and renders its template correctly, and a genuine unit failure carried an `OnFailure` notification through to Pushover returning **HTTP 200**. So on forge, this alarm pages.

**What has not changed:** that fix is not merged to main. `notify-drain` does not exist in `modules/nixos/notifications` on this branch's base, and neither does the `placeholders` option.

So the accurate statement is split, and both halves are load-bearing:

- A comment claiming **"inert"** sends the next reader to re-fix a solved problem.
- A comment claiming **"works"** lets someone deploy main over forge and silently un-arm it — the same repo-behind-host inversion that nearly reverted this work earlier today, pointed the other way.

The note now states both, and says which paragraph to delete when the notifications PR merges.

## Also recorded

The template carries no placeholders, so the page says only that the sentinel is not reporting — never whether it **failed to run** or **ran blind**. Those are different problems wanting different responses, and today's outage was the second kind.

The mechanism to fix that (`placeholders = [ "reason" ]` plus a context file written before the check exits non-zero) lands with the notifications PR. Deliberately **not** half-implemented here: writing the heartbeat's context file with no consumer is dead code, and the build assertion that prevents half-doing it does not exist on main yet either.

## Verification

`task nix:build-nixos host=forge` — exit 0. Nix comments do not affect evaluation, so no redeploy is required.

## Note

This is the fourth instance today of something that looks like coverage and is not — after the decoy log directory, the alert that cannot fire for either real failure mode, and the original inert alarm. This one was my own comment, written specifically to prevent that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)