### PR TITLE
fix(systemd): drop ".service" suffix from systemd.services attr keys

### DIFF
--- a/modules/nixos/services/litellm/default.nix
+++ b/modules/nixos/services/litellm/default.nix
@@ -36,7 +36,13 @@ let
   cfg = config.modules.services.litellm;
   serviceName = "litellm";
   backend = config.virtualisation.oci-containers.backend;
-  mainServiceUnit = "${backend}-${serviceName}.service";
+  # NixOS systemd module attribute keys must NOT include the `.service`
+  # suffix — NixOS appends it when rendering the unit. Using the suffixed
+  # name as a key creates a phantom attribute that NixOS silently ignores.
+  # mainServiceUnit (with suffix) is for places that need the unit *name*
+  # for cross-references (OnFailure, Wants, After, etc).
+  mainServiceName = "${backend}-${serviceName}";
+  mainServiceUnit = "${mainServiceName}.service";
 
   # LiteLLM container listens on port 4000 internally (hardcoded in image CMD)
   internalContainerPort = 4000;
@@ -797,7 +803,7 @@ in
       # Systemd Service Configuration
       # ========================================================================
 
-      systemd.services."${mainServiceUnit}" = lib.mkMerge [
+      systemd.services."${mainServiceName}" = lib.mkMerge [
         {
           after = [ "network-online.target" "${serviceName}-env.service" ]
             ++ optional cfg.database.localInstance "postgresql.service"

--- a/modules/nixos/services/unifi/default.nix
+++ b/modules/nixos/services/unifi/default.nix
@@ -9,7 +9,13 @@ let
   cfg = config.modules.services.unifi;
   storageCfg = config.modules.storage;
   datasetPath = "${storageCfg.datasets.parentDataset}/unifi";
-  mainServiceUnit = "${config.virtualisation.oci-containers.backend}-unifi.service";
+  # NixOS systemd module attribute keys must NOT include the `.service`
+  # suffix — NixOS appends it when rendering the unit. Using the suffixed
+  # name as a key creates a phantom attribute that NixOS silently ignores.
+  # mainServiceUnit (with suffix) is for places that need the unit *name*
+  # for cross-references (OnFailure, Wants, After, etc).
+  mainServiceName = "${config.virtualisation.oci-containers.backend}-unifi";
+  mainServiceUnit = "${mainServiceName}.service";
   hasCentralizedNotifications = config.modules.notifications.enable or false;
   unifiTcpPorts = [ 8080 8443 ];
   unifiUdpPorts = [ 3478 ];
@@ -257,7 +263,7 @@ in
         ];
       };
 
-      systemd.services.${mainServiceUnit} = lib.mkMerge [
+      systemd.services.${mainServiceName} = lib.mkMerge [
         (lib.mkIf (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
           unitConfig.OnFailure = [ "notify@unifi-failure:%n.service" ];
         })

--- a/modules/nixos/services/unpackerr/default.nix
+++ b/modules/nixos/services/unpackerr/default.nix
@@ -33,7 +33,12 @@ let
   hasCentralizedNotifications = notificationsCfg.enable or false;
   nfsMountName = cfg.nfsMountDependency;
   nfsMountConfig = storageHelpers.mkNfsMountConfig { inherit config; nfsMountDependency = nfsMountName; };
-  mainServiceUnit = "${config.virtualisation.oci-containers.backend}-unpackerr.service";
+  # NixOS systemd module attribute keys must NOT include the `.service`
+  # suffix — NixOS appends it when rendering the unit. Using the suffixed
+  # name as a key creates a phantom attribute that NixOS silently ignores.
+  # Anything needing the unit *name* for a cross-reference (OnFailure, Wants,
+  # After, ...) must append ".service" to this at the point of use.
+  mainServiceName = "${config.virtualisation.oci-containers.backend}-unpackerr";
 
   # Build environment variables for container
   # Unpackerr uses UN_ prefix for environment variables
@@ -380,7 +385,7 @@ in
     };
 
     # Systemd service overrides
-    systemd.services.${mainServiceUnit} = {
+    systemd.services.${mainServiceName} = {
       # Wait for NFS mount
       after = lib.optionals (nfsMountConfig != null) [
         (if nfsMountConfig.autoMount or false

--- a/modules/nixos/systemd.nix
+++ b/modules/nixos/systemd.nix
@@ -1,6 +1,35 @@
-_: {
+{ lib, config, ... }:
+let
+  # NixOS appends ".service" when rendering each `systemd.services.<name>`
+  # attribute, so a key that already carries the suffix produces a unit file
+  # named `<name>.service.service`. That unit has no ExecStart, is referenced
+  # by nothing, and never loads — every setting attached to it vanishes with
+  # no error. Catch the typo at eval time instead of discovering it in prod.
+  phantomServiceUnits =
+    builtins.filter (lib.hasSuffix ".service") (builtins.attrNames config.systemd.services);
+in
+{
   # Disable automatic generation of /etc/machine-id to allow impermanence to manage it
   systemd.services."systemd-machine-id-setup" = {
     enable = false; # Prevent NixOS from overwriting /etc/machine-id
   };
+
+  assertions = [
+    {
+      assertion = phantomServiceUnits == [ ];
+      message = ''
+        systemd.services attribute keys must not end in ".service" — NixOS
+        appends the suffix itself, so these keys render as phantom
+        "<name>.service.service" units that never load, silently discarding
+        everything defined under them:
+
+        ${lib.concatMapStringsSep "\n" (n: "  - systemd.services.\"${n}\"") phantomServiceUnits}
+
+        Drop the ".service" suffix from the attribute key. If the same string
+        is also needed as a unit *name* for cross-references (after, requires,
+        OnFailure, partOf), keep two bindings — an unsuffixed one for the key
+        and a suffixed one for the references.
+      '';
+    }
+  ];
 }

--- a/profiles/hardware/intel-gpu.nix
+++ b/profiles/hardware/intel-gpu.nix
@@ -76,7 +76,17 @@ in
     # If the user supplied services to auto-allow, construct systemd.services entries
     # that add a DeviceAllow for the render node. This is intentionally opt-in.
     # We build an attrset mapping unit name -> { serviceConfig = { DeviceAllow = [...] } }
-    systemd.services = (if cfg.services == [ ] then { }
-    else builtins.listToAttrs (builtins.map (s: { name = s; value = { serviceConfig = { DeviceAllow = [ "/dev/dri/renderD128 rwm" ]; }; }; }) cfg.services));
+    #
+    # NixOS appends ".service" to each `systemd.services.<name>` key, so a key
+    # that already carries the suffix renders as `<name>.service.service` — a
+    # phantom unit that is never loaded, silently discarding the DeviceAllow.
+    # Callers historically wrote the suffix (the option's example above shows
+    # it), so strip a trailing ".service" and accept both spellings.
+    systemd.services = builtins.listToAttrs (builtins.map
+      (s: {
+        name = lib.removeSuffix ".service" s;
+        value = { serviceConfig = { DeviceAllow = [ "/dev/dri/renderD128 rwm" ]; }; };
+      })
+      cfg.services);
   };
 }


### PR DESCRIPTION
## Problem

NixOS appends `.service` when rendering each `systemd.services.<name>` attribute, so a key that **already** carries the suffix produces a unit file named `<name>.service.service`. That unit has no `ExecStart`, is referenced by nothing, and never loads — every setting attached to it vanishes with no error.

## Instances fixed

| Module | What was silently discarded |
|---|---|
| `profiles/hardware/intel-gpu.nix` | `DeviceAllow` for `/dev/dri/renderD128` — **dispatcharr had no render node access on forge; hardware transcoding was silently unavailable** |
| `modules/nixos/services/unpackerr` | NFS mount `after`/`requires` ordering (startup race), `OnFailure` notification hook, `Restart=always` / `RestartSec=30s` (real unit sat at the 100ms default) |
| `modules/nixos/services/unifi` | `OnFailure` hook, preseed `wants`/`after` — latent, not enabled on any host |
| `modules/nixos/services/litellm` | `Restart`/`RestartSec`, postgres + env-file `after`/`wants`/`requires`, `OnFailure` — latent, not enabled on any host |

`intel-gpu`'s option docstring/example tells callers to include the suffix, and `hosts/forge/default.nix` does. Rather than break that calling convention, the module now strips a trailing `.service` so both spellings work; the host config is unchanged.

`unifi` and `litellm` still need the suffixed unit *name* for cross-references (`mkPreseedService`, `journalUnit`, `before`/`requiredBy`/`partOf`), so they keep two bindings — matching the convention `scrypted` already documents.

## Guard

Added an assertion in `modules/nixos/systemd.nix`, reached by every host via `base.nix`, so a recurrence fails evaluation and names the offending key.

## Verification

All eight hosts return no suffixed keys:

```
nix eval --impure --json --expr 'let f = builtins.getFlake (toString ./.); lib = f.inputs.nixpkgs.lib; in lib.mapAttrs (n: c: lib.filter (lib.hasSuffix ".service") (lib.attrNames c.config.systemd.services)) f.nixosConfigurations'
```

→ `{"forge":[],"luna":[],"nas-0":[],"nas-1":[],"nixos-bootstrap":[],"nixpi":[],"nixpi-image":[],"rydev":[]}`

The settings now land on the real forge units: `podman-dispatcharr` has `DeviceAllow = ["/dev/dri/renderD128 rwm"]`, and `podman-unpackerr` has `Restart=always`, `RestartSec=30s`, `after` including `mnt-data.mount`, `requires = ["mnt-data.mount"]`.

The guard was confirmed non-vacuous by re-injecting the bug into unpackerr — eval failed naming `systemd.services."podman-unpackerr.service"` — then reverting. `deadnix --fail`, `statix check`, and `nixpkgs-fmt --check` are clean, and forge's `system.build.toplevel` evaluates.

I swept every other `systemd.services.${...}` key in the tree and traced each variable to its definition; the rest are unsuffixed and clean.

### Note (not fixed here)

`unpackerr`'s `OnFailure` is still absent on forge, but that's genuine gating rather than a leftover: `modules.services.unpackerr.notifications.enable` is `false` there (host-level notifications are `true`). Enabling it is a separate config decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)