### PR TITLE
fix(intel-gpu): stop assuming renderD128 is the Intel render node

### DIFF
--- a/hosts/forge/default.nix
+++ b/hosts/forge/default.nix
@@ -202,7 +202,17 @@ in
       common.intelDri = {
         enable = true;
         driver = "iHD"; # Use iHD (intel-media-driver) for modern Intel GPUs; set to "i965" for legacy hardware
-        services = [ "podman-dispatcharr.service" ];
+        # This box has two GPUs: renderD128 is the discrete NVIDIA (nouveau) and
+        # renderD129 is the Intel UHD 630 (i915). Stable alias: /dev/dri/intel-render.
+        renderNode = "/dev/dri/renderD129";
+        # `services` is deliberately empty. It was previously set to
+        # [ "podman-dispatcharr.service" ], which never took effect: the ".service"
+        # suffix produced an inert podman-dispatcharr.service.service unit. Restoring it
+        # correctly would be worse than useless -- podman containers run in their own
+        # cgroup under machine.slice, so a unit-level DeviceAllow cannot reach them, and
+        # turning DeviceAllow on flips the unit to a device whitelist for no gain.
+        # Container GPU access is granted by accelerationDevices (--device=/dev/dri).
+        services = [ ];
       };
 
       # (moved) VA-API driver exposure configured via top-level 'hardware.opengl'

--- a/hosts/forge/services/dispatcharr.nix
+++ b/hosts/forge/services/dispatcharr.nix
@@ -44,8 +44,11 @@ in
     {
       modules.services.dispatcharr = {
         enable = true;
-        # DRY: derive VA-API driver from host hardware profile
+        # DRY: derive VA-API driver and render node from the host hardware profile.
+        # renderNode matters here: forge has two GPUs and /dev/dri/renderD128 is the
+        # discrete NVIDIA (nouveau), not the Intel iGPU.
         vaapiDriver = config.modules.common.intelDri.driver;
+        vaapiDevice = config.modules.common.intelDri.renderNode;
         # Pass the entire /dev/dri directory to the container. This is more robust
         # than hardcoding specific device nodes, which can change between reboots.
         # The application inside the container will automatically find the correct
@@ -115,9 +118,17 @@ in
     })
   ];
 }
-# If the dispatcharr container/service runs locally as a podman/docker unit,
-# allow it to access the Intel render node for VA-API without adding broad
-# privileges. This grants only the render node device; prefer DeviceAllow
-# instead of making the service user a member of the host "video" group.
-# Hardware access (DeviceAllow) is centralized via profiles/hardware/intel-gpu.nix
-# using common.intelDri.services = [ "podman-dispatcharr.service" ] on this host.
+# GPU access notes:
+# Dispatcharr runs as a podman container, so its render-node access comes from
+# accelerationDevices above (podman --device=/dev/dri:/dev/dri:rwm), not from a
+# systemd DeviceAllow. A unit-level DeviceAllow on podman-dispatcharr.service would
+# have no effect on the container -- podman places the container payload in its own
+# cgroup under machine.slice, outside the unit's cgroup -- which is why
+# common.intelDri.services is empty for this host.
+#
+# Note that forge exposes two render nodes: /dev/dri/renderD128 is the discrete
+# NVIDIA card (nouveau) and /dev/dri/renderD129 is the Intel UHD 630 (i915). VAAPI_DEVICE
+# is derived from common.intelDri.renderNode above so it follows the host, but transcode
+# profiles are stored in Dispatcharr's own database -- any profile configured in the UI
+# must target renderD129 itself. See hosts/forge/services/scrypted.nix for why the
+# container-visible node name has to match the real host node name.

--- a/modules/nixos/services/dispatcharr/default.nix
+++ b/modules/nixos/services/dispatcharr/default.nix
@@ -130,6 +130,26 @@ in
       description = "VA-API driver name to set inside the container (iHD for modern Intel, i965 for legacy).";
     };
 
+    # Optional VA-API render node. Host-derived rather than hardcoded: render node
+    # numbering follows probe order, so renderD128 is NOT reliably the Intel iGPU on
+    # multi-GPU hosts. Wire this from the host's hardware profile, e.g.
+    #   vaapiDevice = config.modules.common.intelDri.renderNode;
+    vaapiDevice = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "/dev/dri/renderD129";
+      description = ''
+        Render node exposed to the container as VAAPI_DEVICE. When null the variable is
+        omitted and libva/the transcode profile picks a node on its own.
+
+        The path is evaluated *inside* the container, so it must be a node that
+        `accelerationDevices` actually passes in, and it must keep its real host node
+        name: iHD resolves the GPU through /sys/class/drm/<node>, which the container
+        shares with the host, so renaming the node on the way in points the driver at
+        the wrong card.
+      '';
+    };
+
     accelerationDevices = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ "/dev/dri" ];
@@ -350,6 +370,14 @@ in
           assertion = cfg.reverseProxy.hostName != null;
           message = "Dispatcharr reverseProxy.enable requires reverseProxy.hostName to be set.";
         })
+        ++ (lib.optional (cfg.vaapiDevice != null) {
+          # VAAPI_DEVICE names a path inside the container, so the node has to be
+          # passed in -- either directly or via an enclosing directory like /dev/dri.
+          assertion = lib.any
+            (dev: dev == cfg.vaapiDevice || lib.hasPrefix "${dev}/" cfg.vaapiDevice)
+            cfg.accelerationDevices;
+          message = "Dispatcharr vaapiDevice (${cfg.vaapiDevice}) is not covered by accelerationDevices (${lib.concatStringsSep ", " cfg.accelerationDevices}); the container cannot see that render node.";
+        })
         ++ [
           {
             assertion = config.modules.services.postgresql.enable or false;
@@ -456,8 +484,6 @@ in
           PGID = cfg.group;
           TZ = cfg.timezone;
           DISPATCHARR_ENV = "modular";
-          # Enable VA-API inside the container when /dev/dri is mapped
-          VAAPI_DEVICE = "/dev/dri/renderD128"; # Preferred render node for acceleration
           # PostgreSQL connection configuration
           # Use TCP host connection to avoid Unix socket peer authentication issues
           # The container user "dispatcharr" (UID 569) doesn't exist on the host, causing peer auth to fail
@@ -474,6 +500,9 @@ in
           DISPATCHARR_LOG_LEVEL = "info";
         } // (lib.optionalAttrs (cfg.vaapiDriver != null) {
           LIBVA_DRIVER_NAME = cfg.vaapiDriver;
+        }) // (lib.optionalAttrs (cfg.vaapiDevice != null) {
+          # Render node for VA-API, resolved on the host so it names the real Intel node
+          VAAPI_DEVICE = cfg.vaapiDevice;
         }) // (lib.optionalAttrs (cfg.reverseProxy != null && cfg.reverseProxy.enable) {
           # Reverse proxy configuration for Django
           # Tells Django to trust X-Forwarded-Host from the proxy
@@ -581,7 +610,10 @@ in
           requires = [ "postgresql-provision-databases.service" "redis-default.service" ];
           after = [ "postgresql.service" "postgresql-provision-databases.service" "redis-default.service" ];
 
-          # Hardware access is managed at the host level (profiles/hardware/intel-gpu.nix services list)
+          # GPU access is granted by passing accelerationDevices into the container
+          # (podman --device), not by a systemd DeviceAllow on this unit: podman runs the
+          # container payload in its own cgroup under machine.slice, so a unit-level
+          # device filter would never reach it.
 
           # Securely load the database password using systemd's native credential handling.
           # The password will be available at $CREDENTIALS_DIRECTORY/db_password

--- a/profiles/hardware/intel-gpu.nix
+++ b/profiles/hardware/intel-gpu.nix
@@ -13,7 +13,7 @@ let
     else if config ? common && config.common ? intelDri then
       config.common.intelDri
     else
-      { enable = false; driver = "iHD"; services = [ ]; };
+      { enable = false; driver = "iHD"; renderNode = "/dev/dri/renderD128"; services = [ ]; };
 
 in
 {
@@ -27,12 +27,36 @@ in
       description = "Which VA-API userspace driver to install (intel-media-driver = iHD, legacy = i965).";
     };
 
+    # Which render node to hand out via DeviceAllow. NOT always renderD128: on
+    # multi-GPU hosts the numbering depends on probe order, so the Intel node may
+    # be renderD129 or higher (check /dev/dri/by-path or /sys/class/drm/*/device/uevent).
+    renderNode = lib.mkOption {
+      type = lib.types.str;
+      default = "/dev/dri/renderD128";
+      example = "/dev/dri/renderD129";
+      description = "Path to the Intel render node granted by the `services` DeviceAllow entries.";
+    };
+
     # Optional list of systemd unit names to automatically grant DeviceAllow to.
-    # Example: [ "podman-dispatcharr.service" ]
+    # Either spelling works: "foo" and "foo.service" both target foo.service.
+    #
+    # NOTE: this is only useful for *native* systemd services. Podman/Docker
+    # containers run in their own cgroup under machine.slice, not under the
+    # unit's cgroup, so a unit-level DeviceAllow does not reach the container --
+    # pass the device into the container instead (--device=/dev/dri:/dev/dri:rwm).
+    # Example: [ "jellyfin" ]
     services = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
-      description = "List of systemd unit names to which the module will add a DeviceAllow for /dev/dri/renderD128 (opt-in).";
+      example = [ "jellyfin" ];
+      description = ''
+        List of systemd unit names to which the module will add a DeviceAllow for
+        `renderNode` (opt-in). A trailing ".service" is stripped, so both "foo" and
+        "foo.service" refer to foo.service.
+
+        Only affects native systemd services; container runtimes need the device
+        passed in at the container level instead.
+      '';
     };
   };
 
@@ -56,20 +80,31 @@ in
 
       How to grant a service access (recommended):
        - For native systemd services, add a DeviceAllow line and prefer the render node only:
-         systemd.services.<name>.serviceConfig.DeviceAllow = [ "/dev/dri/renderD128 rwm" ];
+         systemd.services.<name>.serviceConfig.DeviceAllow = [ "${cfg.renderNode} rwm" ];
         # Prefer DeviceAllow. Adding `Group = "video"` is usually unnecessary when
         # DeviceAllow is used because DeviceAllow grants the service cgroup direct
         # access to the device node. Only add `Group = "video"` if the service
         # (or a container's internal user mapping) explicitly requires group membership.
+        # Note that DeviceAllow is a whitelist: once any entry is present, every other
+        # device node is denied to that unit.
 
        - For containers (podman/docker), bind the render node into the container and avoid --privileged:
            podman run --device /dev/dri:/dev/dri:rw ...
+        # DeviceAllow on the *unit* does nothing for these: the container payload lives in
+        # its own cgroup under machine.slice, outside the unit's cgroup, so the unit's
+        # device filter never applies to it.
 
-      Validation commands:
+      Identifying the Intel render node (numbering is probe-order dependent, so
+      renderD128 may well belong to a discrete GPU):
+       - ls -l /dev/dri/by-path
+       - grep -H DRIVER /sys/class/drm/render*/device/uevent
+
+      Validation commands (pass the device explicitly; vainfo's default is renderD128,
+      which is not necessarily the Intel node):
        - ls -l /dev/dri
-       - vainfo
+       - vainfo --display drm --device ${cfg.renderNode}
        - sudo intel_gpu_top
-       - ffmpeg -hwaccel vaapi -i input.mp4 -f null -
+       - ffmpeg -hwaccel vaapi -vaapi_device ${cfg.renderNode} -i input.mp4 -f null -
         Notes: `vainfo` is provided by `libva-utils`. `intel_gpu_top` is provided by `intel-gpu-tools`.
     '';
 
@@ -85,7 +120,7 @@ in
     systemd.services = builtins.listToAttrs (builtins.map
       (s: {
         name = lib.removeSuffix ".service" s;
-        value = { serviceConfig = { DeviceAllow = [ "/dev/dri/renderD128 rwm" ]; }; };
+        value = { serviceConfig = { DeviceAllow = [ "${cfg.renderNode} rwm" ]; }; };
       })
       cfg.services);
   };


### PR DESCRIPTION
Rebased onto #817, which fixed the `.service` suffix bug repo-wide. This PR keeps that implementation verbatim and addresses what it exposed: now that the `DeviceAllow` entries land on real units, the device they name matters.

## renderD128 is not the Intel GPU on forge

Render node numbering follows probe order. On forge, `renderD128` is the discrete NVIDIA GTX 1080 (nouveau) and the Intel UHD 630 is `renderD129`:

```
/dev/dri/by-path/pci-0000:01:00.0-render -> renderD128   # nouveau
/dev/dri/by-path/pci-0000:00:02.0-render -> renderD129   # i915
```

Verified inside the dispatcharr container:

```
renderD128 → iHD_drv_video.so init failed / Failed to initialise VAAPI connection: 18
renderD129 → clean h264_vaapi encode
```

So on current main, forge's `podman-dispatcharr.service` gets `DeviceAllow = ["/dev/dri/renderD128 rwm"]` — the wrong card. Replaced the hardcoded path with a `renderNode` option, set to `renderD129` on forge.

## Dropping forge's `services` entry

The entry targets `podman-dispatcharr`, and a unit-level `DeviceAllow` cannot reach a podman container: the unit's cgroup is `/system.slice/podman-dispatcharr.service`, but podman runs the payload in `/machine.slice/libpod-….scope/container`. The container's GPU access already comes from `accelerationDevices` — `podman inspect` confirms card1, card2, renderD128 and renderD129 are all passed in and usable.

Since `DeviceAllow` is a whitelist — once any entry exists, every other device is denied to that unit — keeping the entry only narrows the unit, naming the wrong GPU, for no gain.

Note this means the premise in #817's message ("dispatcharr had no /dev/dri/renderD128 access and hardware transcoding was silently unavailable") does not hold: absent `DeviceAllow`, systemd imposes no device restriction at all, so the unit was never denied anything.

## VAAPI_DEVICE

`modules/nixos/services/dispatcharr` hardcoded `VAAPI_DEVICE=/dev/dri/renderD128` — same wrong node. Added a nullable `vaapiDevice` option wired from `common.intelDri.renderNode`, mirroring the existing `vaapiDriver` derivation, plus an assertion that the node is covered by `accelerationDevices`.

## Impact

No functional change today. Device access was already working, and forge's active stream profile is `-c copy` — Dispatcharr is remuxing, not transcoding, so there is no VA-API path to have been falling back from. This is latent correctness for whenever a transcode profile is configured; those live in Dispatcharr's own database, so a profile set in the UI must target `renderD129` itself.

The container environment changes, so the next deploy restarts `podman-dispatcharr`.

## Verification

- All 8 `nixosConfigurations` evaluate; only forge's derivation changes.
- forge: `DeviceAllow` absent, no phantom unit, `VAAPI_DEVICE=/dev/dri/renderD129`.
- #817's new no-suffix assertion still passes.
- New assertion fires on a bad config: `vaapiDevice (/dev/foo/renderD129) is not covered by accelerationDevices (/dev/dri)`.
- `nix fmt --check` and `statix` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)