### PR TITLE
fix(notifications): deliver notifications instead of queueing them forever

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -8,13 +8,72 @@ The centralized notification system provides a unified interface for sending not
 
 ```
 modules/nixos/notifications/
-├── default.nix          # Main module with unified interface
+├── default.nix          # Options, template registry, and the notify@ dispatcher
+├── drain.nix            # Queue watcher, delivery, and the backlog alarm
 ├── pushover.nix         # Pushover backend implementation
 ├── ntfy.nix             # ntfy backend implementation
 └── healthchecks.nix     # Healthchecks.io backend implementation
 
 lib/notification-helpers.nix  # Reusable helper functions
 ```
+
+### How a notification actually travels
+
+```
+caller                    notify@<template>:<instance>       notify-drain
+------                    ----------------------------       ------------
+OnFailure= ............>  look up template in                 (woken by
+  or systemctl start      /etc/notification-templates.json    notify-drain.path)
+                          resolve placeholders                     |
+                          write /run/notify/<...>.json ......>  read payload
+                                                                route on .backend
+                                                                deliver, then unlink
+```
+
+Three properties are load-bearing:
+
+1. **The queue is watched as a directory, not per notification.**
+   `notify-drain.path` globs `/run/notify/*.json`. It must never be replaced by
+   per-instance `.path` units: instance names are chosen by the caller at
+   failure time (`notify@<template>:%n`), so they cannot be enumerated at build
+   time. That mistake is what left notifications undelivered for a month while
+   every dispatch still exited 0.
+
+2. **The payload carries its own backend.** The drain routes on the `backend`
+   field. Without it, the only record of the destination was the name of the
+   service that would have been started.
+
+3. **Undelivered payloads alarm.** `notify-backlog-check` pages, and fails its
+   unit, if anything sits in `/run/notify` for more than a few minutes. A
+   notification system that stops working is otherwise invisible: the symptom is
+   the absence of a message.
+
+### Placeholders
+
+Template `title` and `body` may reference `${name}` placeholders, substituted by
+exact name at dispatch time. Note that inside a Nix indented string you write
+`''${name}` — `''${` is the escape sequence that emits a literal `${`.
+
+Built-ins, always available: `hostname`, `serviceName`, `template`, `instance`,
+`timestamp`, plus `errormessage`, `dataset`, `jobname` and `repository` when the
+instance names a failed unit the dispatcher can derive them from.
+
+Anything else must be declared in the template's `placeholders` list, and
+supplied in one of two ways:
+
+- **`modules.notifications.context.<unit>`** — build-time values, for callers
+  that cannot run code first. `OnFailure` handlers are the main case: they fire
+  the notifier directly, with no opportunity to write anything.
+- **A runtime context file** — `/run/notify/ctx/<template>:<instance>.json`,
+  written before `systemctl start notify@<template>:<instance>.service`.
+
+Do **not** try to pass context by exporting environment variables before
+`systemctl start`. That asks PID 1 to launch the unit, so it inherits nothing
+from the calling shell; the values are silently dropped.
+
+Using a placeholder that is neither a built-in nor declared fails evaluation.
+Anything declared but unresolved at runtime renders as `(unset: name)` rather
+than as a blank, so a mistake is visible on the page instead of silent.
 
 ## Features
 
@@ -184,6 +243,19 @@ modules.notifications.healthchecks = {
 
 ## Pre-defined Templates
 
+> **Stale section.** The `backup-success`, `backup-failure`, `service-failure`,
+> `boot-notification` and `disk-alert` templates described below do not exist.
+> Templates are registered by the modules that own them, so the accurate list
+> for a host is whatever it actually built:
+>
+> ```bash
+> jq -r 'keys[]' /etc/notification-templates.json
+> ```
+>
+> The corresponding `notify-ntfy-*` and `healthcheck-*` services have been
+> removed — they referenced these non-existent templates, so enabling the ntfy
+> or Healthchecks backend would have failed evaluation outright.
+
 ### Backup Success
 
 Automatically notifies when backup completes successfully.
@@ -261,24 +333,42 @@ modules.notifications.templates.disk-alert = {
 
 ### Custom Notifications
 
-Send custom notifications from scripts:
+Notifications go through the dispatcher, which renders a registered template.
+Register the template in Nix:
+
+```nix
+modules.notifications.templates.my-alert = {
+  priority = "high";
+  placeholders = [ "detail" ];       # anything beyond the built-ins
+  title = ''Something happened on ''${hostname}'';
+  body = ''
+    <b>Host:</b> ''${hostname}
+    <b>When:</b> ''${timestamp}
+
+    ''${detail}
+  '';
+};
+```
+
+Then fire it, supplying the declared placeholders via a context file:
 
 ```bash
-# Using Pushover backend
-systemctl start notify-pushover@custom.service \
-  --setenv=NOTIFY_TITLE="Custom Alert" \
-  --setenv=NOTIFY_MESSAGE="Something happened!" \
-  --setenv=NOTIFY_PRIORITY="high" \
-  --setenv=NOTIFY_URL="https://example.com" \
-  --setenv=NOTIFY_URL_TITLE="View Details"
-
-# Using ntfy backend
-systemctl start notify-ntfy@custom.service \
-  --setenv=NOTIFY_TITLE="Custom Alert" \
-  --setenv=NOTIFY_MESSAGE="Something happened!" \
-  --setenv=NOTIFY_PRIORITY="high" \
-  --setenv=NOTIFY_TAGS="warning,custom"
+jq -n --arg detail "the thing went wrong" '{detail: $detail}' \
+  > /run/notify/ctx/my-alert:some-instance.json
+systemctl start notify@my-alert:some-instance.service
 ```
+
+For an `OnFailure` hook, no context file is possible — declare the values under
+`modules.notifications.context` keyed by unit name instead:
+
+```nix
+systemd.services.my-service.unitConfig.OnFailure = [ "notify@my-alert:%n.service" ];
+modules.notifications.context."my-service.service".detail = "check the widget";
+```
+
+Note there is no `--setenv` form. `systemctl start --setenv` sets the
+environment of the *started unit*, but the dispatcher renders from the template
+and its context sources, so those variables are ignored.
 
 ### Multiple Backends
 
@@ -400,20 +490,54 @@ modules.backup.monitoring.enable = true;
 
 ## Troubleshooting
 
-### Check Notification Services
+### Is delivery working at all?
+
+Start here. A dispatch exiting 0 does **not** mean anything was delivered — the
+dispatcher's job ends when the payload is queued.
 
 ```bash
-# List all notification services
-systemctl list-units 'notify-*'
+# Anything sitting here is undelivered. It should normally be empty.
+doas ls -la /run/notify/ /run/notify/failed/
 
-# Test Pushover notification
-systemctl start notify-pushover@test.service \
-  --setenv=NOTIFY_TITLE="Test" \
-  --setenv=NOTIFY_MESSAGE="Test message"
+# The watcher must be loaded and waiting
+systemctl status notify-drain.path notify-drain.service
 
-# View logs
-journalctl -u notify-pushover@test.service
+# The watchdog that catches a stalled queue
+systemctl status notify-backlog-check.timer
+journalctl -u notify-backlog-check.service -n 50
 ```
+
+If payloads are accumulating in `/run/notify`, delivery is broken regardless of
+what the dispatcher units report.
+
+### Test-fire a notification end to end
+
+Use a *dynamic* instance — one whose name is chosen at dispatch time, which is
+the case that was historically broken. Verifying only a hardcoded instance
+proves nothing.
+
+```bash
+doas systemctl start 'notify@sonarr-failure:podman-sonarr.service.service'
+journalctl -u 'notify@sonarr-failure:podman-sonarr.service.service' -n 30
+journalctl -u notify-drain.service -n 30
+```
+
+The payload should appear in `/run/notify` and disappear within a second or two
+as the drain delivers it. If it lingers, the drain is not being triggered.
+
+### Placeholder rendered wrong
+
+Inspect a queued payload before it drains, or one in `/run/notify/archive`:
+
+```bash
+doas jq -r '.message' '/run/notify/<template>:<instance>.json'
+```
+
+- A literal `${something.dotted}` in the output means a template used
+  `''${...}` around a Nix expression — `''${` escapes, it does not interpolate.
+- `(unset: name)` means the placeholder is declared but nothing supplied it:
+  check for a context file under `/run/notify/ctx/`, or a
+  `modules.notifications.context` entry for that unit.
 
 ### Verify Secret Files
 

--- a/modules/nixos/auto-upgrade.nix
+++ b/modules/nixos/auto-upgrade.nix
@@ -156,12 +156,22 @@ let
 
         # Build JSON safely with jq so arbitrary diff content (arrows, quotes,
         # newlines) can't corrupt the payload.
+        #
+        # Written to a temp name and renamed into place: notify-drain.path
+        # watches *.json, so an in-place write could be picked up half-finished.
+        # The backend is carried in the payload because this unit bypasses the
+        # dispatcher and there is no template registered for it to fall back on.
         ${pkgs.jq}/bin/jq -n \
           --arg priority "$PRIORITY" \
           --arg title "$TITLE" \
           --arg message "$MESSAGE" \
-          '{priority: $priority, title: $title, message: $message}' \
-          > "$PAYLOAD_DIR/nixos-upgrade-success.json"
+          --arg backend "${config.modules.notifications.defaultBackend}" \
+          --arg template "nixos-upgrade-success" \
+          '{priority: $priority, title: $title, message: $message,
+            backend: $backend, template: $template}' \
+          > "$PAYLOAD_DIR/nixos-upgrade-success.json.tmp"
+        ${pkgs.coreutils}/bin/chgrp notify-ipc "$PAYLOAD_DIR/nixos-upgrade-success.json.tmp" || true
+        mv "$PAYLOAD_DIR/nixos-upgrade-success.json.tmp" "$PAYLOAD_DIR/nixos-upgrade-success.json"
 
         rm -f /run/nixos-upgrade-start-time /run/nixos-upgrade-old-system
   '';
@@ -326,21 +336,10 @@ in
       };
     };
 
-    # Path unit to trigger success notification
-    systemd.paths."notify-pushover@nixos-upgrade-success" = lib.mkIf notificationsEnabled {
-      wantedBy = [ "multi-user.target" ];
-      pathConfig = {
-        PathExists = "/run/notify/nixos-upgrade-success.json";
-      };
-    };
-
-    # Path unit to trigger failure notification
-    systemd.paths."notify-pushover@nixos-upgrade-failure" = lib.mkIf notificationsEnabled {
-      wantedBy = [ "multi-user.target" ];
-      pathConfig = {
-        PathExists = "/run/notify/nixos-upgrade-failure.json";
-      };
-    };
+    # No path units here any more: notify-drain.path watches /run/notify as a
+    # directory, so a payload is picked up regardless of its name. These two
+    # were among only three such declarations that ever existed, which is why
+    # upgrade notifications kept working while almost everything else did not.
 
     # Extend nixos-upgrade service with metrics, notifications, and OOM protection
     systemd.services.nixos-upgrade = {

--- a/modules/nixos/notifications/default.nix
+++ b/modules/nixos/notifications/default.nix
@@ -417,8 +417,11 @@ in
       serviceConfig = {
         Type = "oneshot";
         DynamicUser = true;
-        # Join the notify-ipc group to access the shared IPC directory
-        SupplementaryGroups = [ "notify-ipc" ];
+        # notify-ipc: access to the shared IPC directory.
+        # systemd-journal: read the failed unit's log to fill ${errormessage}.
+        # Without it, a DynamicUser sees only its own logs, so every failure
+        # notification reported "No log available" no matter what the unit said.
+        SupplementaryGroups = [ "notify-ipc" "systemd-journal" ];
         # Create files with 0660 permissions (rw-rw----) for group-only access
         UMask = "0007";
         # DynamicUser enables ProtectSystem=strict by default, making most paths read-only
@@ -473,9 +476,22 @@ in
           FAILED_UNIT="$INSTANCE_INFO"
           echo "[notify] Detected failed unit: $FAILED_UNIT"
 
-          # Extract last 10 lines of journal for error context
-          # Using awk to properly escape newlines for JSON/HTML
-          export NOTIFY_ERRORMESSAGE=$(journalctl --no-pager -n 10 -u "$FAILED_UNIT" 2>/dev/null | awk '{printf "%s\\n", $0}' || echo "No log available")
+          # Last few journal lines, as error context.
+          #
+          # -o cat drops the timestamp/host/unit prefix that would otherwise
+          # consume most of a phone notification; the template carries
+          # ''${timestamp} and ''${serviceName} separately. Capped, because
+          # backends reject over-long messages outright.
+          #
+          # Real newlines, not the literal \n escapes the previous version
+          # emitted: substitution now happens in jq, which handles multi-line
+          # values, so the escaping envsubst needed is actively harmful.
+          export NOTIFY_ERRORMESSAGE=$(
+            journalctl --no-pager -n 10 -o cat -u "$FAILED_UNIT" 2>/dev/null \
+              | tail -c 600 \
+              || echo "No log available"
+          )
+          [ -n "$NOTIFY_ERRORMESSAGE" ] || export NOTIFY_ERRORMESSAGE="No log available"
 
           # Extract job/dataset names from unit name patterns
           # Pattern: restic-backups-JOBNAME.service -> JOBNAME

--- a/modules/nixos/notifications/default.nix
+++ b/modules/nixos/notifications/default.nix
@@ -5,9 +5,70 @@
 }:
 let
   cfg = config.modules.notifications;
+
+  # Placeholders the dispatcher always resolves by itself, without any help
+  # from the caller. Anything else a template references must be declared in
+  # that template's `placeholders` list and supplied at dispatch time via
+  # `modules.notifications.context` (static) or a runtime context file.
+  builtinPlaceholders = [
+    "hostname"
+    "serviceName"
+    "template"
+    "instance"
+    "timestamp"
+    # Derived from the failed unit when the instance names one
+    "errormessage"
+    "dataset"
+    "jobname"
+    "repository"
+  ];
+
+  # Pull every ''${...} occurrence out of a template string. Deliberately
+  # matches ANY brace content, not just valid identifiers, so that shell-isms
+  # such as ''${dataset:-"unknown"} and stray Nix expressions such as
+  # ''${config.networking.hostName} are caught rather than silently passed
+  # through to the rendered message.
+  extractPlaceholders = str:
+    lib.concatMap (p: if builtins.isList p then p else [ ])
+      (builtins.split "\\$\\{([^}]*)\\}" str);
+
+  # Placeholder names are substituted by exact match, so they must be plain
+  # identifiers. Anything else can never resolve.
+  isIdentifier = name: builtins.match "[a-zA-Z_][a-zA-Z0-9_]*" name != null;
+
+  templateProblems = name: template:
+    let
+      allowed = builtinPlaceholders ++ template.placeholders;
+      used = extractPlaceholders template.title ++ extractPlaceholders template.body;
+      malformed = lib.filter (p: !isIdentifier p) used;
+      undeclared = lib.filter (p: isIdentifier p && !lib.elem p allowed) used;
+      hasCommandSubst =
+        lib.hasInfix "$(" template.title || lib.hasInfix "$(" template.body;
+    in
+    lib.optional (malformed != [ ])
+      (
+        "notification template '${name}' uses placeholder(s) that can never resolve: "
+        + lib.concatMapStringsSep ", " (p: "\${${p}}") malformed
+        + ". Placeholders are substituted by exact name, so only plain identifiers work. "
+        + "In a Nix indented string, ''\${foo} emits a literal \${foo}; use \${foo} "
+        + "(unescaped) if you meant to interpolate a Nix value at build time."
+      )
+    ++ lib.optional (undeclared != [ ]) (
+      "notification template '${name}' references undeclared placeholder(s): "
+      + lib.concatMapStringsSep ", " (p: "\${${p}}") undeclared
+      + ". Either use one of the built-ins (${lib.concatStringsSep ", " builtinPlaceholders}) "
+      + "or declare them in this template's `placeholders` list and supply them via "
+      + "`modules.notifications.context` or a runtime context file."
+    )
+    ++ lib.optional hasCommandSubst (
+      "notification template '${name}' contains a shell command substitution '$(...)'. "
+      + "Template bodies are rendered by literal placeholder substitution, not by a shell, "
+      + "so this would be delivered verbatim. Use \${timestamp} or a declared placeholder."
+    );
 in
 {
   imports = [
+    ./drain.nix
     ./pushover.nix
     ./ntfy.nix
     ./healthchecks.nix
@@ -53,6 +114,28 @@ in
             description = "Title of the notification message. Can use placeholders like \${hostname}, \${serviceName}";
           };
 
+          placeholders = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [ ];
+            example = [ "pool" "state" ];
+            description = ''
+              Extra placeholder names this template's title/body may reference,
+              beyond the built-ins (${lib.concatStringsSep ", " builtinPlaceholders}).
+
+              Every placeholder used must be either a built-in or listed here;
+              otherwise evaluation fails. This is what stops a template from
+              silently rendering a blank service name or a literal
+              "''${config.networking.hostName}" in a real page.
+
+              Declared placeholders must be supplied at dispatch time, either
+              statically via `modules.notifications.context.<unit>` or at runtime
+              by writing /run/notify/ctx/<template>:<instance>.json before
+              starting notify@<template>:<instance>.service. Anything still
+              unresolved is rendered as "(unset: name)" rather than silently
+              dropped.
+            '';
+          };
+
           body = lib.mkOption {
             type = lib.types.lines;
             description = "Body of the notification message. Can use HTML formatting if backend supports it";
@@ -85,6 +168,50 @@ in
             body = "...";
           };
       '';
+    };
+
+    context = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.attrsOf lib.types.str);
+      default = { };
+      example = lib.literalExpression ''
+        { "syncoid-tank-services-plex.service".targetHost = "vault"; }
+      '';
+      description = ''
+        Static placeholder values, keyed by the instance info the dispatcher is
+        called with (for OnFailure handlers using %n, that is the failed unit
+        name).
+
+        This exists for context that is known at build time but cannot be
+        written at dispatch time. An OnFailure handler gets no chance to run
+        code before the notifier fires, so it cannot write a runtime context
+        file; anything it needs must be declared here instead.
+      '';
+    };
+
+    # Delivery backends register themselves here so the drain can route a
+    # payload without knowing which backends exist. Adding a backend must not
+    # require touching the drain.
+    backends = lib.mkOption {
+      internal = true;
+      default = { };
+      description = "Registered delivery backends, populated by backend modules.";
+      type = lib.types.attrsOf (lib.types.submodule {
+        options = {
+          credentials = lib.mkOption {
+            type = lib.types.listOf lib.types.str;
+            default = [ ];
+            description = "LoadCredential entries this backend needs to deliver.";
+          };
+          deliver = lib.mkOption {
+            type = lib.types.lines;
+            description = ''
+              Shell body that delivers one notification. It may read TITLE,
+              MESSAGE and PRIORITY from the environment and must exit non-zero
+              if delivery did not happen.
+            '';
+          };
+        };
+      });
     };
 
     # Backend configurations are defined in their respective modules
@@ -216,6 +343,24 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # Fail the build on a template that could only ever render garbage.
+    # Root cause of the month-long outage was a template whose contract read
+    # correct and whose output was blank; nothing checked it until a human did.
+    assertions =
+      let
+        problems = lib.concatLists (
+          lib.mapAttrsToList templateProblems (lib.filterAttrs (_: t: t.enable) cfg.templates)
+        );
+      in
+      map (p: { assertion = false; message = p; }) problems
+      ++ [{
+        assertion = cfg.backends != { };
+        message =
+          "modules.notifications.enable is true but no delivery backend is enabled. "
+          + "Payloads would queue in /run/notify and never be delivered. "
+          + "Enable one of modules.notifications.{pushover,ntfy,healthchecks}.";
+      }];
+
     # Create a dedicated group for notification services to share files securely
     # Using 'notify-ipc' to avoid conflicts with DynamicUser creating groups named 'notify'
     users.groups.notify-ipc = { };
@@ -225,17 +370,25 @@ in
     # - Only services in the 'notify-ipc' group can read/write files (group access only)
     # - Sticky bit prevents services from deleting each other's files
     # - Files are created with 0660 (rw-rw----) via UMask=0007
+    # Pending payloads live directly in /run/notify; the drain watches that
+    # directory with a glob. Subdirectories are deliberately outside the glob:
+    # ctx/ holds caller-supplied context awaiting dispatch, failed/ quarantines
+    # payloads that could not be delivered so a permanent failure cannot spin
+    # the path unit in a hot retry loop.
     systemd.tmpfiles.rules = [
       "d /run/notify 0770 root notify-ipc -"
-      "d /run/notify/env 0770 root notify-ipc -"
+      "d /run/notify/ctx 0770 root notify-ipc -"
+      "d /run/notify/failed 0770 root notify-ipc -"
     ];
 
-    # Ensure directory exists during nixos-rebuild switch (activation time)
+    # Ensure directories exist during nixos-rebuild switch (activation time)
     # This complements tmpfiles which runs at boot
-    system.activationScripts.createNotifyEnvDir = {
+    system.activationScripts.createNotifyDirs = {
       text = ''
-        # Ensure runtime directory exists for newly started services during activation
-        ${pkgs.coreutils}/bin/install -d -m 0770 -g notify-ipc /run/notify/env
+        # Ensure runtime directories exist for newly started services during activation
+        ${pkgs.coreutils}/bin/install -d -m 0770 -g notify-ipc /run/notify
+        ${pkgs.coreutils}/bin/install -d -m 0770 -g notify-ipc /run/notify/ctx
+        ${pkgs.coreutils}/bin/install -d -m 0770 -g notify-ipc /run/notify/failed
       '';
       deps = [ "users" ]; # Ensures users/groups are created first
     };
@@ -245,18 +398,21 @@ in
     environment.etc."notification-templates.json".text = builtins.toJSON (
       lib.mapAttrs
         (_name: template: {
-          inherit (template) enable priority backend title body;
+          inherit (template) enable priority backend title body placeholders;
           extraOptions = template.extraOptions or { };
         })
         cfg.templates
     );
+
+    # Build-time placeholder values, keyed by instance info (usually a unit name)
+    environment.etc."notification-context.json".text = builtins.toJSON cfg.context;
 
     # Generic notification dispatcher service
     # Services call this as: notify@template-name:instance-info.service
     # Example: notify@backup-failure:system-job.service
     systemd.services."notify@" = {
       description = "Notification dispatcher for %I";
-      path = with pkgs; [ coreutils jq bash curl gettext systemd gawk ];
+      path = with pkgs; [ coreutils jq bash curl systemd gawk ];
 
       serviceConfig = {
         Type = "oneshot";
@@ -268,9 +424,6 @@ in
         # DynamicUser enables ProtectSystem=strict by default, making most paths read-only
         # Explicitly allow writes to /run/notify for IPC
         ReadWritePaths = [ "/run/notify" ];
-        # Load environment variables from instance-specific file
-        # The '-' prefix makes this optional, preventing errors if file doesn't exist
-        EnvironmentFile = "-/run/notify/env/%i.env";
       };
 
       # Pass %i as command-line argument - systemd expands it in ExecStart directive
@@ -282,8 +435,15 @@ in
         # Parse the instance string: template-name:instance-info
         # Receive instance string as $1 (passed via scriptArgs)
         INSTANCE_STRING="$1"
-        TEMPLATE_NAME=$(echo "$INSTANCE_STRING" | cut -d: -f1)
-        INSTANCE_INFO=$(echo "$INSTANCE_STRING" | cut -d: -f2-)
+        TEMPLATE_NAME="''${INSTANCE_STRING%%:*}"
+        # An instance string with no colon (e.g. "nixos-upgrade-failure") has no
+        # instance info at all. `cut -d: -f2-` used to echo the whole string back
+        # here, so serviceName silently became the template name.
+        if [ "$INSTANCE_STRING" = "$TEMPLATE_NAME" ]; then
+          INSTANCE_INFO=""
+        else
+          INSTANCE_INFO="''${INSTANCE_STRING#*:}"
+        fi
 
         echo "[notify] Dispatching notification for template: $TEMPLATE_NAME, instance: $INSTANCE_INFO"
 
@@ -346,56 +506,121 @@ in
           fi
         fi
 
-        # Export common variables for envsubst
-        export hostname="${cfg.hostname}"
-        export serviceName="$INSTANCE_INFO"
+        # ---- Resolve placeholder values -------------------------------------
+        # Three sources, lowest precedence first:
+        #   1. derived   - computed here from the instance and the failed unit
+        #   2. static    - modules.notifications.context, for build-time-known
+        #                  values a caller cannot supply (e.g. OnFailure hooks,
+        #                  which get no chance to run code before firing)
+        #   3. runtime   - /run/notify/ctx/<instance>.json, written by callers
+        #                  that DO run code first
+        #
+        # NOTIFY_* variables set above are folded in under their placeholder
+        # names: NOTIFY_ERROR_MESSAGE -> errormessage (lowercased, underscores
+        # stripped). These are set by this script, in this process, so they
+        # actually reach the substitution - unlike an `export` in a caller,
+        # which never survives `systemctl start`.
+        DERIVED=$(jq -n \
+          --arg hostname "${cfg.hostname}" \
+          --arg template "$TEMPLATE_NAME" \
+          --arg instance "$INSTANCE_INFO" \
+          --arg timestamp "$(date -Iseconds)" \
+          '{hostname: $hostname, template: $template, instance: $instance, timestamp: $timestamp}')
 
-        # Transform NOTIFY_* environment variables to placeholder format
-        # This allows services to use idiomatic names like NOTIFY_BOOT_TIME
-        # which get transformed to ''${boottime} placeholders (lowercase, no underscores)
-        for var in $(env | grep '^NOTIFY_' | cut -d= -f1); do
-          value=$(printenv "$var")
-          # Transform: NOTIFY_BOOT_TIME -> boottime
+        if [ -n "$INSTANCE_INFO" ]; then
+          DERIVED=$(echo "$DERIVED" | jq -c --arg v "$INSTANCE_INFO" '. + {serviceName: $v}')
+        fi
+
+        for var in $(env | grep '^NOTIFY_' | cut -d= -f1 || true); do
           placeholder=$(echo "$var" | sed 's/^NOTIFY_//' | tr '[:upper:]' '[:lower:]' | tr -d '_')
-          export "$placeholder"="$value"
+          DERIVED=$(echo "$DERIVED" | jq -c \
+            --arg k "$placeholder" --arg v "$(printenv "$var")" '. + {($k): $v}')
         done
 
-        # Use envsubst for safe variable substitution
-        TITLE=$(echo "$TITLE" | envsubst)
-        BODY=$(echo "$BODY" | envsubst)
+        # Only identifier-like keys are usable: substitution is by exact
+        # ''${name} match, so anything else could never be referenced anyway.
+        SANITIZE='if type == "object" then
+                    with_entries(select(.key | test("^[a-zA-Z_][a-zA-Z0-9_]*$")) | .value |= tostring)
+                  else {} end'
+
+        STATIC='{}'
+        if [ -n "$INSTANCE_INFO" ]; then
+          STATIC=$(jq -c --arg u "$INSTANCE_INFO" ".[\$u] // {} | $SANITIZE" \
+            /etc/notification-context.json 2>/dev/null || echo '{}')
+        fi
+
+        RUNTIME='{}'
+        CTX_FILE="/run/notify/ctx/$INSTANCE_STRING.json"
+        if [ -f "$CTX_FILE" ]; then
+          if PARSED=$(jq -c "$SANITIZE" "$CTX_FILE" 2>/dev/null); then
+            RUNTIME="$PARSED"
+          else
+            echo "[notify] WARNING: $CTX_FILE is not valid JSON; ignoring it" >&2
+          fi
+          rm -f "$CTX_FILE"
+        fi
+
+        VARS=$(jq -n --argjson a "$DERIVED" --argjson b "$STATIC" --argjson c "$RUNTIME" \
+          '$a * $b * $c')
+
+        # Every placeholder the template is allowed to use. Anything in this set
+        # that did not resolve is rendered as "(unset: name)" - a visibly wrong
+        # page beats a silently blank one.
+        DECLARED=$(echo "$TEMPLATE_JSON" | jq -c \
+          '(.placeholders // []) + ${builtins.toJSON builtinPlaceholders}')
+
+        # Literal substitution, done in jq rather than envsubst. envsubst was
+        # the original mechanism and it silently ate any name it could not
+        # resolve while leaving dotted names like ''${config.networking.hostName}
+        # untouched, which is how a blank service name and a literal Nix
+        # expression both reached production.
+        render() {
+          jq -rn --arg s "$1" --argjson vars "$VARS" --argjson declared "$DECLARED" '
+            ($vars | to_entries
+             | reduce .[] as $e ($s; gsub("\\$\\{" + $e.key + "\\}"; $e.value)))
+            | . as $substituted
+            | ($declared | unique
+               | reduce .[] as $p ($substituted; gsub("\\$\\{" + $p + "\\}"; "(unset: " + $p + ")")))
+          '
+        }
+
+        TITLE=$(render "$TITLE")
+        BODY=$(render "$BODY")
 
         echo "[notify] Dispatching to $BACKEND (template: $TEMPLATE_NAME, instance: $INSTANCE_INFO)"
 
-        # Use instance ID directly, creating subdirectories as needed
+        # ---- Queue the payload ----------------------------------------------
+        # The payload carries its own backend. Without that, the only record of
+        # where a notification should go was the name of the service that would
+        # have been started, so a single drain could not route it.
         PAYLOAD_FILE="/run/notify/$INSTANCE_STRING.json"
-        mkdir -p "$(dirname "$PAYLOAD_FILE")"
+        TMP_FILE="$PAYLOAD_FILE.tmp"
 
-        # Create JSON payload for the backend service
-        # File will be automatically group-readable (0660) via umask
-        ${pkgs.jq}/bin/jq -n \
+        # Written to a temp name and renamed into place: the drain watches
+        # *.json, so it can never observe a half-written payload.
+        jq -n \
           --arg title "$TITLE" \
           --arg message "$BODY" \
           --arg priority "$PRIORITY" \
-          '{title: $title, message: $message, priority: $priority}' \
-          > "$PAYLOAD_FILE"
+          --arg backend "$BACKEND" \
+          --arg template "$TEMPLATE_NAME" \
+          --arg instance "$INSTANCE_INFO" \
+          --arg created "$(date -Iseconds)" \
+          '{title: $title, message: $message, priority: $priority,
+            backend: $backend, template: $template, instance: $instance, created: $created}' \
+          > "$TMP_FILE"
 
-        # Set group ownership to notify-ipc so backend services can read it
-        chgrp notify-ipc "$PAYLOAD_FILE"
+        # Set group ownership to notify-ipc so the drain can read and unlink it
+        chgrp notify-ipc "$TMP_FILE"
+        mv "$TMP_FILE" "$PAYLOAD_FILE"
 
-        echo "[notify] Payload created at $PAYLOAD_FILE"
+        echo "[notify] Payload queued at $PAYLOAD_FILE (backend: $BACKEND)"
 
-        # The backend service will be triggered automatically by its .path unit
-        # which watches for the creation of $PAYLOAD_FILE
-        # No need to explicitly start the service - avoids permission issues with DynamicUser
-        BACKEND_SERVICE="notify-$BACKEND@$INSTANCE_STRING.service"
-        echo "[notify] Backend service $BACKEND_SERVICE will be triggered by path unit"
-
-        # Clean up the environment file now that it has been consumed
-        ENV_FILE="/run/notify/env/$INSTANCE_STRING.env"
-        if [ -f "$ENV_FILE" ]; then
-          rm -f "$ENV_FILE"
-          # Note: We don't remove the parent directory as it's managed by tmpfiles
-        fi
+        # notify-drain.path watches /run/notify/*.json and will pick this up.
+        # A single directory watcher replaces the old per-instance .path units:
+        # those had to be declared per caller, but instance names are chosen at
+        # failure time (template:%n), so they could never be enumerated at build
+        # time. Only 3 of 34 call sites ever had one.
       '';
     };
 

--- a/modules/nixos/notifications/default.nix
+++ b/modules/nixos/notifications/default.nix
@@ -28,9 +28,16 @@ let
   # such as ''${dataset:-"unknown"} and stray Nix expressions such as
   # ''${config.networking.hostName} are caught rather than silently passed
   # through to the rendered message.
+  #
+  # The special characters are written as bracket expressions rather than
+  # backslash escapes: builtins.split uses POSIX extended regular expressions,
+  # where "\{" and "\}" are undefined. glibc rejects them outright, so a
+  # backslash-escaped version evaluates fine on darwin and dies with "invalid
+  # regular expression" on Linux - including when nixos-rebuild is run on the
+  # target host itself.
   extractPlaceholders = str:
     lib.concatMap (p: if builtins.isList p then p else [ ])
-      (builtins.split "\\$\\{([^}]*)\\}" str);
+      (builtins.split "[$][{]([^}]*)[}]" str);
 
   # Placeholder names are substituted by exact match, so they must be plain
   # identifiers. Anything else can never resolve.

--- a/modules/nixos/notifications/drain.nix
+++ b/modules/nixos/notifications/drain.nix
@@ -1,0 +1,395 @@
+# Delivery of queued notification payloads.
+#
+# The dispatcher (default.nix) writes /run/notify/<template>:<instance>.json and
+# does not start any backend itself, to avoid permission problems with
+# DynamicUser. Something else has to notice the file.
+#
+# That used to be a per-instance systemd .path unit, one per notification. It
+# could never work: the instance is chosen by the caller at failure time
+# (notify@<template>:%n), so the set of instance names does not exist until a
+# unit actually fails, and therefore cannot be enumerated at build time. Only 3
+# instances were ever declared against 34 registration sites, so payloads
+# accumulated unread in /run/notify for over a month while every dispatch
+# reported Result=success.
+#
+# One directory watcher removes the whole bug class: no per-caller
+# registration, dynamic instances work by construction, and there is nothing
+# left to forget to declare.
+{ lib
+, config
+, pkgs
+, ...
+}:
+let
+  cfg = config.modules.notifications;
+  backlogCfg = cfg.backlogAlarm;
+
+  funcName = name: "deliver_" + lib.replaceStrings [ "-" ] [ "_" ] name;
+
+  # Each backend contributes a shell function. Delivery is invoked in a
+  # subshell so that a backend calling `exit` or flipping `set -e` cannot take
+  # the drain down with it and strand the rest of the queue.
+  deliverFunctions = lib.concatStringsSep "\n" (
+    lib.mapAttrsToList
+      (name: backend: ''
+        ${funcName name}() {
+        ${backend.deliver}
+        }
+      '')
+      cfg.backends
+  );
+
+  deliverDispatch = ''
+    # Deliver one notification. Reads TITLE, MESSAGE and PRIORITY from the
+    # environment; returns non-zero if it did not actually go out.
+    deliver_to() {
+      case "$1" in
+    ${lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (name: _: ''    ${name}) ( ${funcName name} ) ;;'') cfg.backends
+    )}
+        all)
+          _rc=0
+    ${lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (name: _: ''      ( ${funcName name} ) || _rc=1'') cfg.backends
+    )}
+          return "$_rc"
+          ;;
+        *)
+          echo "[notify] ERROR: no enabled backend named '$1'" >&2
+          return 1
+          ;;
+      esac
+    }
+  '';
+
+  allCredentials = lib.unique (
+    lib.concatLists (lib.mapAttrsToList (_: b: b.credentials) cfg.backends)
+  );
+
+  # Common serviceConfig for units that deliver notifications directly.
+  deliveryServiceConfig = {
+    Type = "oneshot";
+    DynamicUser = true;
+    PrivateNetwork = false;
+    PrivateTmp = true;
+    SupplementaryGroups = [ "notify-ipc" ];
+    UMask = "0007";
+    ReadWritePaths = [ "/run/notify" ];
+    LoadCredential = allCredentials;
+  };
+
+  deliveryPath = with pkgs; [ coreutils jq curl systemd findutils ];
+in
+{
+  options.modules.notifications = {
+    staleAfterMinutes = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 120;
+      description = ''
+        A payload older than this is archived to /run/notify/archive instead of
+        being delivered, and reported in a single summary page.
+
+        Delivery being restored after an outage must not fire the whole backlog
+        at a phone: a burst of stale, mostly-resolved alerts is worse than
+        useless, because it buries anything current. A month-old page is not
+        actionable, but the fact that it went undelivered is - so the payloads
+        are kept, and reported once, as a count rather than as pages.
+      '';
+    };
+
+    backlogAlarm = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Alarm when notification payloads are not being delivered.
+
+          A queue that stops draining is invisible by construction: every
+          dispatch still exits 0, and the failure is the *absence* of a page.
+          This watches the queue itself so that can never again be discovered by
+          accident a month later.
+        '';
+      };
+
+      afterMinutes = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 5;
+        description = "How long a payload may sit undelivered before it is itself an alarm.";
+      };
+
+      intervalMinutes = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 5;
+        description = "How often to check the queue.";
+      };
+
+      repeatHours = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 6;
+        description = "Minimum gap between backlog pages, so a stuck queue does not become a pager storm.";
+      };
+
+      maxAttempts = lib.mkOption {
+        type = lib.types.ints.positive;
+        default = 5;
+        description = ''
+          How many delivery attempts a payload gets before it stops being
+          retried and starts being reported as permanently undelivered.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf (cfg.enable && cfg.backends != { }) {
+    systemd.tmpfiles.rules = [
+      "d /run/notify/archive 0770 root notify-ipc -"
+    ];
+
+    # ---- The watcher ------------------------------------------------------
+    # One glob over the whole directory, rather than one PathExists per
+    # notification. wantedBy is correct here precisely because this is a real
+    # unit and not a template: there is exactly one of it.
+    systemd.paths.notify-drain = {
+      description = "Watch for queued notification payloads";
+      wantedBy = [ "multi-user.target" ];
+      pathConfig = {
+        # Temp files are written as *.json.tmp and renamed into place, so this
+        # can never match a partially written payload.
+        PathExistsGlob = "/run/notify/*.json";
+      };
+    };
+
+    systemd.services.notify-drain = {
+      description = "Deliver queued notification payloads";
+      # Delivery needs the network; a path unit can fire during early boot.
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      path = deliveryPath;
+
+      serviceConfig = deliveryServiceConfig // {
+        TimeoutStartSec = "5min";
+      };
+
+      script = ''
+        # Deliberately not `set -e`: one undeliverable payload must not abort
+        # the drain and strand every payload behind it.
+        set -uo pipefail
+        shopt -s nullglob
+
+        ${deliverFunctions}
+        ${deliverDispatch}
+
+        pending=0
+        delivered=0
+        quarantined=0
+        archived=0
+        ARCHIVED_LIST=""
+
+        for PAYLOAD in /run/notify/*.json; do
+          [ -f "$PAYLOAD" ] || continue
+          pending=$((pending + 1))
+          NAME=$(basename "$PAYLOAD")
+
+          # Too old to be worth paging about. Archived, not deleted: an
+          # undelivered alert is evidence of a real failure even when the
+          # failure itself is long resolved.
+          if [ -n "$(find "$PAYLOAD" -maxdepth 0 -mmin +${toString cfg.staleAfterMinutes} 2>/dev/null)" ]; then
+            if mv -f "$PAYLOAD" "/run/notify/archive/$NAME" 2>/dev/null; then
+              archived=$((archived + 1))
+              # Only the first few are named. Backends cap message length, and a
+              # list truncated mid-entry is worse than an honest count.
+              if [ "$archived" -le 10 ]; then
+                ARCHIVED_LIST="$ARCHIVED_LIST
+        • ''${NAME%.json}"
+              fi
+            else
+              echo "[notify] ERROR: could not archive stale payload $NAME" >&2
+            fi
+            continue
+          fi
+
+          if ! JSON=$(jq -e . "$PAYLOAD" 2>/dev/null); then
+            echo "[notify] ERROR: $NAME is not valid JSON; quarantining" >&2
+            mv -f "$PAYLOAD" "/run/notify/failed/$NAME" 2>/dev/null || rm -f "$PAYLOAD"
+            quarantined=$((quarantined + 1))
+            continue
+          fi
+
+          TITLE=$(printf '%s' "$JSON" | jq -r '.title // "Notification"')
+          MESSAGE=$(printf '%s' "$JSON" | jq -r '.message // ""')
+          PRIORITY=$(printf '%s' "$JSON" | jq -r '.priority // "normal"')
+          BACKEND=$(printf '%s' "$JSON" | jq -r '.backend // ""')
+          TEMPLATE=$(printf '%s' "$JSON" | jq -r '.template // ""')
+          ATTEMPTS=$(printf '%s' "$JSON" | jq -r '.attempts // 0')
+
+          # Payloads written directly by other units carry no backend field
+          # (nixos-upgrade writes its own success payload, for example). Fall
+          # back to the template's configured backend, then to the global
+          # default, so an unlabelled payload still goes somewhere.
+          if [ -z "$BACKEND" ]; then
+            [ -n "$TEMPLATE" ] || TEMPLATE="''${NAME%.json}"
+            TEMPLATE="''${TEMPLATE%%:*}"
+            BACKEND=$(jq -r --arg t "$TEMPLATE" '.[$t].backend // empty' \
+              /etc/notification-templates.json 2>/dev/null || true)
+          fi
+          [ -n "$BACKEND" ] || BACKEND="${cfg.defaultBackend}"
+
+          export TITLE MESSAGE PRIORITY
+
+          if deliver_to "$BACKEND"; then
+            rm -f "$PAYLOAD"
+            delivered=$((delivered + 1))
+            echo "[notify] delivered $NAME via $BACKEND"
+          else
+            # Quarantined rather than left in place: a payload that keeps
+            # failing would otherwise re-satisfy the path unit the instant the
+            # drain exits and spin it in a hot loop. notify-backlog-check
+            # requeues these on a timer and reports the ones that never land.
+            echo "[notify] ERROR: delivery of $NAME via $BACKEND failed" >&2
+            if printf '%s' "$JSON" \
+              | jq -c --argjson n "$((ATTEMPTS + 1))" '. + {attempts: $n}' \
+                > "/run/notify/failed/$NAME.tmp" 2>/dev/null; then
+              chgrp notify-ipc "/run/notify/failed/$NAME.tmp" 2>/dev/null || true
+              mv -f "/run/notify/failed/$NAME.tmp" "/run/notify/failed/$NAME"
+              rm -f "$PAYLOAD"
+            else
+              mv -f "$PAYLOAD" "/run/notify/failed/$NAME" 2>/dev/null || rm -f "$PAYLOAD"
+            fi
+            quarantined=$((quarantined + 1))
+          fi
+        done
+
+        # One summary instead of N stale pages.
+        if [ "$archived" -gt 0 ]; then
+          echo "[notify] archived $archived stale payload(s) to /run/notify/archive" >&2
+          if [ "$archived" -gt 10 ]; then
+            ARCHIVED_LIST="$ARCHIVED_LIST
+        … and $((archived - 10)) more"
+          fi
+          TITLE="📼 ${cfg.hostname}: $archived undelivered notification(s) archived"
+          MESSAGE="<b>Host:</b> ${cfg.hostname}
+        <b>Archived:</b> $archived notification(s) older than ${toString cfg.staleAfterMinutes} minutes
+
+        These were queued but never delivered. They are too old to page about
+        individually, so they have been moved to /run/notify/archive rather
+        than sent or discarded.
+        $ARCHIVED_LIST
+
+        <b>Review:</b> doas ls -la /run/notify/archive"
+          PRIORITY="normal"
+          export TITLE MESSAGE PRIORITY
+          deliver_to "${cfg.defaultBackend}" \
+            || echo "[notify] ERROR: archive summary could not be delivered" >&2
+        fi
+
+        echo "[notify] drain finished: $pending seen, $delivered delivered, $archived archived, $quarantined quarantined"
+
+        # Backstop against a pathological loop: if anything is still sitting in
+        # the watched directory (e.g. a payload we cannot unlink), the path unit
+        # will re-trigger us immediately. Throttle rather than spin.
+        leftover=( /run/notify/*.json )
+        if [ ''${#leftover[@]} -gt 0 ]; then
+          echo "[notify] WARNING: ''${#leftover[@]} payload(s) still queued after drain; throttling" >&2
+          sleep 5
+        fi
+      '';
+    };
+
+    # ---- The queue watchdog ------------------------------------------------
+    systemd.timers.notify-backlog-check = lib.mkIf backlogCfg.enable {
+      description = "Periodically check for undelivered notifications";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnBootSec = "${toString backlogCfg.intervalMinutes}min";
+        OnUnitActiveSec = "${toString backlogCfg.intervalMinutes}min";
+        AccuracySec = "1min";
+      };
+    };
+
+    systemd.services.notify-backlog-check = lib.mkIf backlogCfg.enable {
+      description = "Alarm on undelivered notification payloads";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      path = deliveryPath;
+
+      serviceConfig = deliveryServiceConfig // {
+        TimeoutStartSec = "3min";
+      };
+
+      script = ''
+        set -uo pipefail
+        shopt -s nullglob
+
+        ${deliverFunctions}
+        ${deliverDispatch}
+
+        STAMP=/run/notify/.backlog-alarm
+
+        # Give quarantined payloads another go. Retrying here rather than in the
+        # drain keeps attempts spaced by the timer interval instead of spinning
+        # the path unit.
+        requeued=0
+        exhausted=0
+        for FAILED in /run/notify/failed/*.json; do
+          [ -f "$FAILED" ] || continue
+          NAME=$(basename "$FAILED")
+          ATTEMPTS=$(jq -r '.attempts // 0' "$FAILED" 2>/dev/null || echo ${toString backlogCfg.maxAttempts})
+          if [ "$ATTEMPTS" -lt ${toString backlogCfg.maxAttempts} ]; then
+            mv -f "$FAILED" "/run/notify/$NAME" && requeued=$((requeued + 1))
+          else
+            exhausted=$((exhausted + 1))
+          fi
+        done
+        [ "$requeued" -eq 0 ] || echo "[notify] requeued $requeued quarantined payload(s) for retry"
+
+        # A payload still sitting in the watched directory well after it was
+        # written means the watcher is not doing its job. That is the exact
+        # failure this module shipped with for a month, and it is the one
+        # condition that cannot be reported by the queue itself.
+        STALE=$(find /run/notify -maxdepth 1 -name '*.json' -type f \
+          -mmin +${toString backlogCfg.afterMinutes} 2>/dev/null | wc -l)
+
+        if [ "$STALE" -eq 0 ] && [ "$exhausted" -eq 0 ]; then
+          exit 0
+        fi
+
+        SUMMARY=""
+        [ "$STALE" -eq 0 ] || SUMMARY="$STALE payload(s) undelivered for over ${toString backlogCfg.afterMinutes} minutes"
+        if [ "$exhausted" -gt 0 ]; then
+          [ -z "$SUMMARY" ] || SUMMARY="$SUMMARY; "
+          SUMMARY="$SUMMARY$exhausted payload(s) failed ${toString backlogCfg.maxAttempts} delivery attempts"
+        fi
+
+        echo "[notify] ALARM: notification delivery is broken: $SUMMARY" >&2
+        find /run/notify -maxdepth 1 -name '*.json' -type f -printf '  pending: %f (%TY-%Tm-%Td %TH:%TM)\n' >&2 2>/dev/null || true
+        find /run/notify/failed -maxdepth 1 -name '*.json' -type f -printf '  failed:  %f\n' >&2 2>/dev/null || true
+
+        # Paged directly, never through the queue: an alarm about a broken
+        # queue must not be enqueued into it.
+        if [ ! -f "$STAMP" ] || [ -z "$(find "$STAMP" -newermt '-${toString backlogCfg.repeatHours} hours' 2>/dev/null)" ]; then
+          TITLE="🚨 ${cfg.hostname}: notifications are not being delivered"
+          MESSAGE="<b>Host:</b> ${cfg.hostname}
+        <b>Problem:</b> $SUMMARY
+
+        Notifications are queued in /run/notify but are not reaching a device,
+        so other alarms from this host are currently silent.
+
+        <b>Check:</b> systemctl status notify-drain.service
+        <b>Queue:</b> doas ls -la /run/notify /run/notify/failed"
+          PRIORITY="emergency"
+          export TITLE MESSAGE PRIORITY
+          if deliver_to "${cfg.defaultBackend}"; then
+            touch "$STAMP"
+            echo "[notify] backlog alarm delivered"
+          else
+            echo "[notify] ERROR: backlog alarm could not be delivered either" >&2
+          fi
+        fi
+
+        # Fail the unit as well, so the backlog is visible to anything watching
+        # systemd state even if no page can get out at all.
+        exit 1
+      '';
+    };
+  };
+}

--- a/modules/nixos/notifications/healthchecks.nix
+++ b/modules/nixos/notifications/healthchecks.nix
@@ -7,77 +7,58 @@ let
   cfg = config.modules.notifications;
   hcCfg = cfg.healthchecks;
 
-  # Script to ping Healthchecks.io
-  mkHealthchecksPing =
-    { status ? "success"
-    , # success, fail, start
-      message ? null
-    ,
-    }: ''
-      set -euo pipefail
+  # Delivery script. Reads TITLE, MESSAGE and PRIORITY from the environment.
+  #
+  # Healthchecks.io has no notion of a message priority - a ping either signals
+  # health or failure - so the template priority decides which endpoint is hit.
+  deliverScript = ''
+    set -uo pipefail
 
-      # Read UUID from file
-      if [ -f "${toString hcCfg.uuidFile}" ]; then
-        HC_UUID=$(cat "${toString hcCfg.uuidFile}")
+    # Read from a systemd credential rather than the secret path directly:
+    # this runs under DynamicUser with ProtectSystem=strict, which cannot be
+    # relied on to reach a sops secret.
+    HC_UUID=$(${pkgs.systemd}/bin/systemd-creds cat HEALTHCHECKS_UUID) || return 1
+    if [ -z "$HC_UUID" ]; then
+      echo "[healthchecks] ERROR: UUID credential is empty" >&2
+      return 1
+    fi
+
+    case "''${PRIORITY:-normal}" in
+      emergency|urgent|high) ENDPOINT="${hcCfg.baseUrl}/$HC_UUID/fail" ;;
+      *)                     ENDPOINT="${hcCfg.baseUrl}/$HC_UUID" ;;
+    esac
+
+    BODY=$(printf '%s\n\n%s' "''${TITLE:-Notification}" "''${MESSAGE:-}")
+
+    MAX_RETRIES=${toString hcCfg.retryAttempts}
+    TIMEOUT=${toString hcCfg.timeout}
+    RETRY_COUNT=0
+    SUCCESS=false
+
+    while [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; do
+      HTTP_CODE=$(${pkgs.curl}/bin/curl -sS -w "%{http_code}" -o /dev/null \
+        --max-time "$TIMEOUT" \
+        --data-raw "$BODY" \
+        "$ENDPOINT" || echo "000")
+
+      if [ "$HTTP_CODE" = "200" ]; then
+        echo "Healthchecks.io ping sent successfully (HTTP $HTTP_CODE)"
+        SUCCESS=true
+        break
+      fi
+
+      RETRY_COUNT=$((RETRY_COUNT + 1))
+      if [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; then
+        echo "Healthchecks.io ping failed (HTTP $HTTP_CODE), retrying ($RETRY_COUNT/$MAX_RETRIES)..." >&2
+        sleep 2
       else
-        echo "ERROR: Healthchecks.io UUID file not found: ${toString hcCfg.uuidFile}" >&2
-        exit 1
+        echo "Healthchecks.io ping failed after $MAX_RETRIES attempts (HTTP $HTTP_CODE)" >&2
       fi
+    done
 
-      # Determine endpoint
-      case "${status}" in
-        success)
-          ENDPOINT="${hcCfg.baseUrl}/$HC_UUID"
-          ;;
-        fail)
-          ENDPOINT="${hcCfg.baseUrl}/$HC_UUID/fail"
-          ;;
-        start)
-          ENDPOINT="${hcCfg.baseUrl}/$HC_UUID/start"
-          ;;
-        *)
-          echo "ERROR: Invalid status: ${status}" >&2
-          exit 1
-          ;;
-      esac
-
-      # Send ping with retries
-      MAX_RETRIES=${toString hcCfg.retryAttempts}
-      TIMEOUT=${toString hcCfg.timeout}
-      RETRY_COUNT=0
-      SUCCESS=false
-
-      while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-        if [ -n "${lib.optionalString (message != null) "yes"}" ]; then
-          HTTP_CODE=$(${pkgs.curl}/bin/curl -fsS -w "%{http_code}" -o /dev/null \
-            --max-time "$TIMEOUT" \
-            --data-raw "${if message != null then message else ""}" \
-            "$ENDPOINT" || echo "000")
-        else
-          HTTP_CODE=$(${pkgs.curl}/bin/curl -fsS -w "%{http_code}" -o /dev/null \
-            --max-time "$TIMEOUT" \
-            "$ENDPOINT" || echo "000")
-        fi
-
-        if [ "$HTTP_CODE" = "200" ]; then
-          echo "Healthchecks.io ping sent successfully (HTTP $HTTP_CODE)"
-          SUCCESS=true
-          break
-        else
-          RETRY_COUNT=$((RETRY_COUNT + 1))
-          if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-            echo "Healthchecks.io ping failed (HTTP $HTTP_CODE), retrying ($RETRY_COUNT/$MAX_RETRIES)..." >&2
-            sleep 2
-          else
-            echo "Healthchecks.io ping failed after $MAX_RETRIES attempts (HTTP $HTTP_CODE)" >&2
-          fi
-        fi
-      done
-
-      if [ "$SUCCESS" = "false" ]; then
-        exit 1
-      fi
-    '';
+    [ "$SUCCESS" = "true" ] || return 1
+    return 0
+  '';
 in
 {
   config = lib.mkIf (cfg.enable && hcCfg.enable) {
@@ -90,79 +71,15 @@ in
       # Note: We don't check pathExists here because sops secrets won't exist until runtime
     ];
 
-    # Generic ping service template
-    systemd.services."healthcheck-ping@" = {
-      description = "Ping Healthchecks.io for %i";
-
-      serviceConfig = {
-        Type = "oneshot";
-        DynamicUser = true;
-        PrivateNetwork = false;
-        PrivateTmp = true;
-      };
-
-      # Service receives parameters via environment variables:
-      # HC_STATUS (success/fail/start), HC_MESSAGE
-      script = ''
-        STATUS="''${HC_STATUS:-success}"
-        MESSAGE="''${HC_MESSAGE:-%i check from ${cfg.hostname}}"
-
-        ${mkHealthchecksPing {
-          status = "$STATUS";
-          message = "$MESSAGE";
-        }}
-      '';
+    modules.notifications.backends.healthchecks = {
+      credentials = [ "HEALTHCHECKS_UUID:${toString hcCfg.uuidFile}" ];
+      deliver = deliverScript;
     };
 
-    # Backup success ping
-    systemd.services."healthcheck-backup-success@" = lib.mkIf cfg.templates.backup-success.enable {
-      description = "Healthchecks.io success ping for backup %i";
-
-      serviceConfig = {
-        Type = "oneshot";
-        DynamicUser = true;
-        PrivateNetwork = false;
-        PrivateTmp = true;
-      };
-
-      script = mkHealthchecksPing {
-        status = "success";
-        message = "Backup completed successfully for %i on ${cfg.hostname}";
-      };
-    };
-
-    # Backup failure ping
-    systemd.services."healthcheck-backup-failure@" = lib.mkIf cfg.templates.backup-failure.enable {
-      description = "Healthchecks.io failure ping for backup %i";
-
-      serviceConfig = {
-        Type = "oneshot";
-        DynamicUser = true;
-        PrivateNetwork = false;
-        PrivateTmp = true;
-      };
-
-      script = mkHealthchecksPing {
-        status = "fail";
-        message = "Backup failed for %i on ${cfg.hostname}";
-      };
-    };
-
-    # Backup start ping (useful for long-running backups)
-    systemd.services."healthcheck-backup-start@" = lib.mkIf cfg.templates.backup-success.enable {
-      description = "Healthchecks.io start ping for backup %i";
-
-      serviceConfig = {
-        Type = "oneshot";
-        DynamicUser = true;
-        PrivateNetwork = false;
-        PrivateTmp = true;
-      };
-
-      script = mkHealthchecksPing {
-        status = "start";
-        message = "Backup starting for %i on ${cfg.hostname}";
-      };
-    };
+    # The pre-defined healthcheck-{ping,backup-success,backup-failure,
+    # backup-start}@ services that used to live here have been removed. They
+    # referenced templates that do not exist (backup-success, backup-failure),
+    # so enabling this backend at all would have failed evaluation, and they
+    # predate the template system that supersedes them.
   };
 }

--- a/modules/nixos/notifications/ntfy.nix
+++ b/modules/nixos/notifications/ntfy.nix
@@ -7,75 +7,58 @@ let
   cfg = config.modules.notifications;
   ntfyCfg = cfg.ntfy;
 
-  # Priority mapping: string name to ntfy priority
-  priorityMap = {
-    min = "min";
-    low = "low";
-    normal = "default";
-    default = "default";
-    high = "high";
-    urgent = "urgent";
-  };
+  # Delivery script. Reads TITLE, MESSAGE and PRIORITY from the environment.
+  deliverScript = ''
+    set -uo pipefail
 
-  getPriority = priority: priorityMap.${priority} or "default";
+    TOPIC_URL="${if ntfyCfg.topic != "" then ntfyCfg.topic else ntfyCfg.server}"
+    if [ -z "$TOPIC_URL" ]; then
+      echo "[ntfy] ERROR: topic not configured" >&2
+      return 1
+    fi
 
-  # Script to send ntfy notification
-  mkNtfyScript =
-    { title
-    , message
-    , priority ? "default"
-    , tags ? [ ]
-    , url ? null
-    ,
-    }: ''
-      set -euo pipefail
+    # Map the template priority vocabulary onto ntfy's.
+    case "''${PRIORITY:-normal}" in
+      emergency)      NTFY_PRIORITY="urgent" ;;
+      high|urgent)    NTFY_PRIORITY="high" ;;
+      normal|default) NTFY_PRIORITY="default" ;;
+      low)            NTFY_PRIORITY="low" ;;
+      silent|min)     NTFY_PRIORITY="min" ;;
+      *)              NTFY_PRIORITY="${ntfyCfg.defaultPriority}" ;;
+    esac
 
-      # Determine topic URL
-      TOPIC_URL="${if ntfyCfg.topic != "" then ntfyCfg.topic else "${ntfyCfg.server}"}"
+    MAX_RETRIES=${toString ntfyCfg.retryAttempts}
+    TIMEOUT=${toString ntfyCfg.timeout}
+    RETRY_COUNT=0
+    SUCCESS=false
 
-      if [ -z "$TOPIC_URL" ]; then
-        echo "ERROR: ntfy topic not configured" >&2
-        exit 1
+    while [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; do
+      HTTP_CODE=$(${pkgs.curl}/bin/curl -s -w "%{http_code}" -o /dev/null \
+        --max-time "$TIMEOUT" \
+        -H "Title: ''${TITLE:-Notification}" \
+        -H "Priority: $NTFY_PRIORITY" \
+        -H "Markdown: no" \
+        -d "''${MESSAGE:-}" \
+        "$TOPIC_URL" || echo "000")
+
+      if [ "$HTTP_CODE" = "200" ]; then
+        echo "ntfy notification sent successfully (HTTP $HTTP_CODE)"
+        SUCCESS=true
+        break
       fi
 
-      # Build tags string
-      TAGS="${lib.concatStringsSep "," tags}"
-
-      # Send notification with retries
-      MAX_RETRIES=${toString ntfyCfg.retryAttempts}
-      TIMEOUT=${toString ntfyCfg.timeout}
-      RETRY_COUNT=0
-      SUCCESS=false
-
-      while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-        HTTP_CODE=$(${pkgs.curl}/bin/curl -s -w "%{http_code}" -o /dev/null \
-          --max-time "$TIMEOUT" \
-          -H "Title: ${title}" \
-          -H "Priority: ${getPriority priority}" \
-          ${lib.optionalString (tags != []) ''-H "Tags: $TAGS"''} \
-          ${lib.optionalString (url != null) ''-H "Click: ${url}"''} \
-          -d "${message}" \
-          "$TOPIC_URL" || echo "000")
-
-        if [ "$HTTP_CODE" = "200" ]; then
-          echo "ntfy notification sent successfully (HTTP $HTTP_CODE)"
-          SUCCESS=true
-          break
-        else
-          RETRY_COUNT=$((RETRY_COUNT + 1))
-          if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-            echo "ntfy notification failed (HTTP $HTTP_CODE), retrying ($RETRY_COUNT/$MAX_RETRIES)..." >&2
-            sleep 2
-          else
-            echo "ntfy notification failed after $MAX_RETRIES attempts (HTTP $HTTP_CODE)" >&2
-          fi
-        fi
-      done
-
-      if [ "$SUCCESS" = "false" ]; then
-        exit 1
+      RETRY_COUNT=$((RETRY_COUNT + 1))
+      if [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; then
+        echo "ntfy notification failed (HTTP $HTTP_CODE), retrying ($RETRY_COUNT/$MAX_RETRIES)..." >&2
+        sleep 2
+      else
+        echo "ntfy notification failed after $MAX_RETRIES attempts (HTTP $HTTP_CODE)" >&2
       fi
-    '';
+    done
+
+    [ "$SUCCESS" = "true" ] || return 1
+    return 0
+  '';
 in
 {
   config = lib.mkIf (cfg.enable && ntfyCfg.enable) {
@@ -87,153 +70,18 @@ in
       }
     ];
 
-    # Generic notification service template using ntfy
-    systemd.services."notify-ntfy@" = {
-      description = "Send ntfy notification for %i";
-
-      serviceConfig = {
-        Type = "oneshot";
-        DynamicUser = true;
-        PrivateNetwork = false;
-        PrivateTmp = true;
-      };
-
-      # Service receives parameters via environment variables:
-      # NOTIFY_TITLE, NOTIFY_MESSAGE, NOTIFY_PRIORITY, NOTIFY_TAGS, NOTIFY_URL
-      script = ''
-        TITLE="''${NOTIFY_TITLE:-%i}"
-        MESSAGE="''${NOTIFY_MESSAGE:-Notification from ${cfg.hostname}}"
-        PRIORITY="''${NOTIFY_PRIORITY:-default}"
-        TAGS="''${NOTIFY_TAGS:-}"
-        URL="''${NOTIFY_URL:-}"
-
-        ${mkNtfyScript {
-          title = "$TITLE";
-          message = "$MESSAGE";
-          priority = "$PRIORITY";
-          tags = [ "$TAGS" ];
-          url = "$URL";
-        }}
-      '';
+    modules.notifications.backends.ntfy = {
+      # ntfy topics here are unauthenticated URLs; no credentials to load.
+      deliver = deliverScript;
     };
 
-    # Pre-defined notification services for common events
-
-    # Backup success notification
-    systemd.services."notify-ntfy-backup-success@" = lib.mkIf cfg.templates.backup-success.enable {
-      description = "Backup success notification for %i via ntfy";
-
-      serviceConfig = {
-        Type = "oneshot";
-        DynamicUser = true;
-        PrivateNetwork = false;
-        PrivateTmp = true;
-      };
-
-      script = mkNtfyScript {
-        title = "Backup Success";
-        message = "Backup completed successfully for %i on ${cfg.hostname} at $(${pkgs.coreutils}/bin/date '+%Y-%m-%d %H:%M:%S')";
-        priority = cfg.templates.backup-success.priority;
-        tags = [ "white_check_mark" "backup" "success" ];
-      };
-    };
-
-    # Backup failure notification
-    systemd.services."notify-ntfy-backup-failure@" = lib.mkIf cfg.templates.backup-failure.enable {
-      description = "Backup failure notification for %i via ntfy";
-
-      serviceConfig = {
-        Type = "oneshot";
-        DynamicUser = true;
-        PrivateNetwork = false;
-        PrivateTmp = true;
-      };
-
-      script = mkNtfyScript {
-        title = "Backup Failed";
-        message = "Backup failed for %i on ${cfg.hostname} at $(${pkgs.coreutils}/bin/date '+%Y-%m-%d %H:%M:%S'). Check logs: journalctl -u %i";
-        priority = cfg.templates.backup-failure.priority;
-        tags = [ "x" "backup" "failure" "warning" ];
-      };
-    };
-
-    # Service failure notification
-    systemd.services."notify-ntfy-service-failure@" = lib.mkIf cfg.templates.service-failure.enable {
-      description = "Service failure notification for %i via ntfy";
-
-      serviceConfig = {
-        Type = "oneshot";
-        DynamicUser = true;
-        PrivateNetwork = false;
-        PrivateTmp = true;
-      };
-
-      script = mkNtfyScript {
-        title = "Service Failed";
-        message = "Service %i failed on ${cfg.hostname} at $(${pkgs.coreutils}/bin/date '+%Y-%m-%d %H:%M:%S')";
-        priority = cfg.templates.service-failure.priority;
-        tags = [ "rotating_light" "service" "failure" ];
-      };
-    };
-
-    # Boot notification
-    systemd.services."notify-ntfy-boot" = lib.mkIf cfg.templates.boot-notification.enable {
-      description = "Send boot notification via ntfy";
-      wantedBy = [ "multi-user.target" ];
-      after = [ "network-online.target" ];
-      wants = [ "network-online.target" ];
-
-      serviceConfig = {
-        Type = "oneshot";
-        DynamicUser = true;
-        PrivateNetwork = false;
-        PrivateTmp = true;
-      };
-
-      script = mkNtfyScript {
-        title = "System Boot";
-        message = "${cfg.hostname} has booted at $(${pkgs.coreutils}/bin/date '+%Y-%m-%d %H:%M:%S')";
-        priority = cfg.templates.boot-notification.priority;
-        tags = [ "rocket" "boot" ];
-      };
-    };
-
-    # Disk alert monitoring
-    systemd.services."notify-ntfy-disk-alert" = lib.mkIf cfg.templates.disk-alert.enable {
-      description = "Check disk usage and send alerts via ntfy";
-
-      serviceConfig = {
-        Type = "oneshot";
-        DynamicUser = true;
-        PrivateNetwork = false;
-        PrivateTmp = true;
-      };
-
-      script = ''
-        THRESHOLD=${toString cfg.templates.disk-alert.threshold}
-
-        ${pkgs.coreutils}/bin/df -h | ${pkgs.gnugrep}/bin/grep -vE '^Filesystem|tmpfs|cdrom|loop' | \
-        while read filesystem size used avail capacity mounted; do
-          usage=$(echo "$capacity" | ${pkgs.gnused}/bin/sed 's/%//')
-          if [ "$usage" -gt "$THRESHOLD" ]; then
-            ${mkNtfyScript {
-              title = "Disk Space Alert";
-              message = "Disk usage above ${toString cfg.templates.disk-alert.threshold}% on ${cfg.hostname}: $mounted is $capacity full ($avail available)";
-              priority = cfg.templates.disk-alert.priority;
-              tags = [ "floppy_disk" "warning" "disk" ];
-            }}
-          fi
-        done
-      '';
-    };
-
-    # Timer for periodic disk alerts (if enabled)
-    systemd.timers."notify-ntfy-disk-alert" = lib.mkIf cfg.templates.disk-alert.enable {
-      wantedBy = [ "timers.target" ];
-      timerConfig = {
-        OnCalendar = "hourly";
-        Persistent = true;
-      };
-    };
+    # The pre-defined notify-ntfy-{backup-success,backup-failure,service-failure,
+    # boot,disk-alert} services that used to live here have been removed. They
+    # referenced templates that do not exist (backup-success, backup-failure,
+    # service-failure, boot-notification, disk-alert) and an option that does
+    # not exist (disk-alert.threshold), so enabling this backend at all would
+    # have failed evaluation. They predate the template system and are
+    # superseded by it: any of those notifications is now a template plus a
+    # notify@ dispatch, delivered through the shared drain.
   };
 }

--- a/modules/nixos/notifications/pushover.nix
+++ b/modules/nixos/notifications/pushover.nix
@@ -7,85 +7,90 @@ let
   cfg = config.modules.notifications;
   pushoverCfg = cfg.pushover;
 
-  # Priority mapping: string name to Pushover API integer
-  priorityMap = {
-    lowest = -2;
-    low = -1;
-    normal = 0;
-    high = 1;
-    urgent = 2;
-  };
+  # Pushover's own hard limits. Exceeding either is a 4xx, which used to mean
+  # three failed retries and a dropped notification - so the long ones (a body
+  # carrying ten lines of journal output, say) were exactly the ones most
+  # likely never to arrive. Truncate instead.
+  titleLimit = 250;
+  messageLimit = 1024;
 
-  getPriority = priority:
-    if builtins.isInt priority then priority
-    else priorityMap.${priority} or 0;
+  # Delivery script. Reads TITLE, MESSAGE and PRIORITY from the environment
+  # rather than baking them in at build time.
+  #
+  # The previous version took the priority as a Nix argument and its only
+  # caller passed the *string* "$PRIORITY", so the build-time lookup missed,
+  # defaulted to 0, and then emitted `PRIORITY="0"` - clobbering the value read
+  # from the payload. Every notification went out at normal priority, including
+  # the ones registered as emergency.
+  deliverScript = ''
+    set -uo pipefail
 
-  # Script to send Pushover notification
-  mkPushoverScript =
-    { title
-    , message
-    , priority ? "normal"
-    , url ? null
-    , urlTitle ? null
-    , device ? null
-    , html ? true
-    ,
-    }: ''
-      set -euo pipefail
+    # Read tokens from systemd credentials
+    PUSHOVER_TOKEN=$(${pkgs.systemd}/bin/systemd-creds cat PUSHOVER_TOKEN) || return 1
+    PUSHOVER_USER=$(${pkgs.systemd}/bin/systemd-creds cat PUSHOVER_USER_KEY) || return 1
 
-      # Read tokens from systemd credentials
-      PUSHOVER_TOKEN=$(${pkgs.systemd}/bin/systemd-creds cat PUSHOVER_TOKEN)
-      PUSHOVER_USER=$(${pkgs.systemd}/bin/systemd-creds cat PUSHOVER_USER_KEY)
+    # Map the template priority vocabulary onto Pushover's integers, at
+    # runtime, because the priority is only known from the payload.
+    case "''${PRIORITY:-normal}" in
+      emergency|urgent) PUSHOVER_PRIORITY=2 ;;
+      high)             PUSHOVER_PRIORITY=1 ;;
+      normal|default)   PUSHOVER_PRIORITY=0 ;;
+      low)              PUSHOVER_PRIORITY=-1 ;;
+      silent|lowest)    PUSHOVER_PRIORITY=-2 ;;
+      -2|-1|0|1|2)      PUSHOVER_PRIORITY="$PRIORITY" ;;
+      *)                PUSHOVER_PRIORITY=${toString pushoverCfg.defaultPriority} ;;
+    esac
 
-      # Build notification payload
-      PRIORITY="${toString (getPriority priority)}"
-      ${lib.optionalString (device != null) ''DEVICE="${device}"''}
-      ${lib.optionalString (device == null && pushoverCfg.defaultDevice != null) ''DEVICE="${pushoverCfg.defaultDevice}"''}
+    PUSHOVER_TITLE=$(printf '%s' "''${TITLE:-Notification}" | head -c ${toString titleLimit})
+    PUSHOVER_MESSAGE=$(printf '%s' "''${MESSAGE:-}" | head -c ${toString messageLimit})
+    [ -n "$PUSHOVER_MESSAGE" ] || PUSHOVER_MESSAGE="(no message body)"
 
-      # Send notification with retries
-      MAX_RETRIES=${toString pushoverCfg.retryAttempts}
-      TIMEOUT=${toString pushoverCfg.timeout}
-      RETRY_COUNT=0
-      SUCCESS=false
+    # Pushover rejects priority 2 unless retry/expire accompany it.
+    EXTRA_ARGS=()
+    if [ "$PUSHOVER_PRIORITY" = "2" ]; then
+      EXTRA_ARGS+=(--data-urlencode "retry=60" --data-urlencode "expire=3600")
+    fi
 
-      while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-        HTTP_CODE=$(${pkgs.curl}/bin/curl -s -w "%{http_code}" -o /tmp/pushover-response.json \
-          --max-time "$TIMEOUT" \
-          --data-urlencode "token=$PUSHOVER_TOKEN" \
-          --data-urlencode "user=$PUSHOVER_USER" \
-          --data-urlencode "title=${title}" \
-          --data-urlencode "message=${message}" \
-          --data-urlencode "priority=$PRIORITY" \
-          ${lib.optionalString html ''--data-urlencode "html=1"''} \
-          ${lib.optionalString (url != null) ''--data-urlencode "url=${url}"''} \
-          ${lib.optionalString (urlTitle != null) ''--data-urlencode "url_title=${urlTitle}"''} \
-          ${lib.optionalString (device != null || pushoverCfg.defaultDevice != null) ''--data-urlencode "device=''${DEVICE:-}"''} \
-          "https://api.pushover.net/1/messages.json" || echo "000")
+    RESPONSE_FILE=$(mktemp)
+    MAX_RETRIES=${toString pushoverCfg.retryAttempts}
+    TIMEOUT=${toString pushoverCfg.timeout}
+    RETRY_COUNT=0
+    SUCCESS=false
 
-        if [ "$HTTP_CODE" = "200" ]; then
-          echo "Pushover notification sent successfully (HTTP $HTTP_CODE)"
-          SUCCESS=true
-          break
-        else
-          RETRY_COUNT=$((RETRY_COUNT + 1))
-          if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-            echo "Pushover notification failed (HTTP $HTTP_CODE), retrying ($RETRY_COUNT/$MAX_RETRIES)..." >&2
-            sleep 2
-          else
-            echo "Pushover notification failed after $MAX_RETRIES attempts (HTTP $HTTP_CODE)" >&2
-            if [ -f /tmp/pushover-response.json ]; then
-              echo "Response: $(cat /tmp/pushover-response.json)" >&2
-            fi
-          fi
-        fi
-      done
+    while [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; do
+      HTTP_CODE=$(${pkgs.curl}/bin/curl -s -w "%{http_code}" -o "$RESPONSE_FILE" \
+        --max-time "$TIMEOUT" \
+        --data-urlencode "token=$PUSHOVER_TOKEN" \
+        --data-urlencode "user=$PUSHOVER_USER" \
+        --data-urlencode "title=$PUSHOVER_TITLE" \
+        --data-urlencode "message=$PUSHOVER_MESSAGE" \
+        --data-urlencode "priority=$PUSHOVER_PRIORITY" \
+        ${lib.optionalString pushoverCfg.enableHtml ''--data-urlencode "html=1"''} \
+        ${lib.optionalString (pushoverCfg.defaultDevice != null)
+          ''--data-urlencode "device=${pushoverCfg.defaultDevice}"''} \
+        "''${EXTRA_ARGS[@]}" \
+        "https://api.pushover.net/1/messages.json" || echo "000")
 
-      rm -f /tmp/pushover-response.json
-
-      if [ "$SUCCESS" = "false" ]; then
-        exit 1
+      if [ "$HTTP_CODE" = "200" ]; then
+        echo "Pushover notification sent successfully (HTTP $HTTP_CODE)"
+        SUCCESS=true
+        break
       fi
-    '';
+
+      RETRY_COUNT=$((RETRY_COUNT + 1))
+      if [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; then
+        echo "Pushover notification failed (HTTP $HTTP_CODE), retrying ($RETRY_COUNT/$MAX_RETRIES)..." >&2
+        sleep 2
+      else
+        echo "Pushover notification failed after $MAX_RETRIES attempts (HTTP $HTTP_CODE)" >&2
+        [ -f "$RESPONSE_FILE" ] && echo "Response: $(cat "$RESPONSE_FILE")" >&2
+      fi
+    done
+
+    rm -f "$RESPONSE_FILE"
+    [ "$SUCCESS" = "true" ] || return 1
+    return 0
+  '';
 in
 {
   config = lib.mkIf (cfg.enable && pushoverCfg.enable) {
@@ -102,85 +107,23 @@ in
       # Note: We don't check pathExists here because sops secrets won't exist until runtime
     ];
 
-    # Systemd path unit template that triggers the service when a payload file appears
-    # This eliminates race conditions and the need for root escalation in the dispatcher
-    # Note: Template units should NOT have wantedBy - specific instances define their own
-    # activation (e.g., notify-pushover@system-boot:boot in system-notifications.nix)
-    systemd.paths."notify-pushover@" = {
-      pathConfig = {
-        PathExists = "/run/notify/%i.json";
-      };
-      # No wantedBy here - this is a template; instances are activated by their callers
+    # Register Pushover as a delivery backend. The drain routes to whatever
+    # is registered here, so the payload's `backend` field is all it needs -
+    # no per-backend knowledge in the drain, and adding a backend does not
+    # mean touching it.
+    modules.notifications.backends.pushover = {
+      credentials = [
+        "PUSHOVER_TOKEN:${pushoverCfg.tokenFile}"
+        "PUSHOVER_USER_KEY:${pushoverCfg.userKeyFile}"
+      ];
+      deliver = deliverScript;
     };
 
-    # Generic notification service template using Pushover
-    systemd.services."notify-pushover@" = {
-      description = "Send Pushover notification for %i";
-
-      serviceConfig = {
-        Type = "oneshot";
-        DynamicUser = true;
-        PrivateNetwork = false;
-        PrivateTmp = true;
-        # Join the notify-ipc group to read payload files from /run/notify
-        SupplementaryGroups = [ "notify-ipc" ];
-        # Override ProtectSystem=strict to allow writing/deleting in /run/notify
-        ReadWritePaths = [ "/run/notify" ];
-        LoadCredential = [
-          "PUSHOVER_TOKEN:${pushoverCfg.tokenFile}"
-          "PUSHOVER_USER_KEY:${pushoverCfg.userKeyFile}"
-        ];
-      };
-
-      # Pass %i as command-line argument for proper expansion
-      scriptArgs = "%i";
-
-      # Service reads parameters from JSON payload file via shared directory
-      script = ''
-        set -euo pipefail
-
-        INSTANCE="$1"
-
-        # Construct payload file path (may be in subdirectory)
-        PAYLOAD_FILE="/run/notify/$INSTANCE.json"
-
-        # On exit, remove the payload file and any empty parent directories
-        trap 'rm -f "$PAYLOAD_FILE" && rmdir -p "$(dirname "$PAYLOAD_FILE")" 2>/dev/null || true' EXIT
-
-        # Verify payload file exists - fail fast if dispatcher didn't create it
-        if [ ! -f "$PAYLOAD_FILE" ]; then
-          echo "[pushover] ERROR: Payload file not found at $PAYLOAD_FILE. Dispatcher may have failed." >&2
-          exit 1
-        fi
-
-        # Check if this backend should handle this notification
-        # Extract template name from instance (format: template-name:instance-info)
-        TEMPLATE_NAME=$(echo "$INSTANCE" | cut -d: -f1)
-        BACKEND=$(${pkgs.jq}/bin/jq -r --arg name "$TEMPLATE_NAME" '.[$name].backend // "${cfg.defaultBackend}"' /etc/notification-templates.json)
-
-        if [[ "$BACKEND" != "pushover" && "$BACKEND" != "all" ]]; then
-          echo "[pushover] Skipping notification for template '$TEMPLATE_NAME' (configured for backend '$BACKEND')"
-          exit 0
-        fi
-
-        # Read and parse JSON payload from shared directory
-        JSON=$(cat "$PAYLOAD_FILE")
-        TITLE=$(echo "$JSON" | ${pkgs.jq}/bin/jq -r '.title')
-        MESSAGE=$(echo "$JSON" | ${pkgs.jq}/bin/jq -r '.message')
-        PRIORITY=$(echo "$JSON" | ${pkgs.jq}/bin/jq -r '.priority // "normal"')
-
-        URL="''${NOTIFY_URL:-}"
-        URL_TITLE="''${NOTIFY_URL_TITLE:-}"
-
-        ${mkPushoverScript {
-          title = "$TITLE";
-          message = "$MESSAGE";
-          priority = "$PRIORITY";
-          url = "$URL";
-          urlTitle = "$URL_TITLE";
-        }}
-      '';
-    };
+    # The per-instance path unit template that used to live here is gone, along
+    # with the notify-pushover@ service it triggered. Its contract - "instances
+    # are activated by their callers" - could not be satisfied: callers name
+    # instances at failure time (template:%n), so there was nothing to declare
+    # at build time. notify-drain.path watches the directory instead.
 
     # Legacy services removed - migrated to distributed architecture:
     # - notify-backup-success@ -> backup.nix
@@ -212,12 +155,21 @@ in
         # Receive instance string as $1
         INSTANCE_NAME="$1"
 
-        ${mkPushoverScript {
-          title = "⚠️ Service Failed";
-          message = "<b>Service $INSTANCE_NAME failed</b><small>\n<b>Host:</b> ${cfg.hostname}\n<b>Time:</b> $(${pkgs.coreutils}/bin/date '+%b %-d, %-I:%M %p %Z')\n\n<b>Status:</b>\n$(${pkgs.systemd}/bin/systemctl status $INSTANCE_NAME --no-pager -l || true)</small>";
-          priority = "high";
-          html = true;
-        }}
+        deliver_pushover() {
+        ${deliverScript}
+        }
+
+        TITLE="⚠️ Service Failed"
+        MESSAGE="<b>Service $INSTANCE_NAME failed</b><small>
+        <b>Host:</b> ${cfg.hostname}
+        <b>Time:</b> $(${pkgs.coreutils}/bin/date '+%b %-d, %-I:%M %p %Z')
+
+        <b>Status:</b>
+        $(${pkgs.systemd}/bin/systemctl status "$INSTANCE_NAME" --no-pager -l || true)</small>"
+        PRIORITY="high"
+        export TITLE MESSAGE PRIORITY
+
+        deliver_pushover
       '';
     };
   };

--- a/modules/nixos/services/home-assistant/default.nix
+++ b/modules/nixos/services/home-assistant/default.nix
@@ -399,10 +399,23 @@ in
           enable = mkDefault true;
           priority = mkDefault "high";
           title = mkDefault ''<b><font color="red">✗ Service Failed: Home Assistant</font></b>'';
+          # ''${hostname} and ''${serviceName} are runtime placeholders resolved
+          # by the dispatcher. This previously read ''${config.networking.hostName}
+          # and ''${serviceUnit}: in a Nix indented string ''${ is the escape
+          # sequence, so those emitted literal text instead of interpolating.
+          # The dotted name survived to the page verbatim and ''${serviceUnit}
+          # resolved to nothing, producing "journalctl -u " with no unit.
           body = mkDefault ''
-            <b>Host:</b> ''${config.networking.hostName}
-            <b>Service:</b> <code>''${serviceUnit}</code>
-            <b>Action:</b> ssh ''${config.networking.hostName} 'journalctl -u ''${serviceUnit} -n 200' && sudo systemctl restart ''${serviceUnit}
+            <b>Host:</b> ''${hostname}
+            <b>Service:</b> <code>''${serviceName}</code>
+
+            Home Assistant has entered a failed state.
+
+            <b>Quick Actions:</b>
+            1. Check logs:
+               <code>ssh ''${hostname} 'journalctl -u ''${serviceName} -n 200'</code>
+            2. Restart service:
+               <code>ssh ''${hostname} 'systemctl restart ''${serviceName}'</code>
           '';
         };
       };

--- a/modules/nixos/services/postgresql/default.nix
+++ b/modules/nixos/services/postgresql/default.nix
@@ -1434,6 +1434,7 @@ in
           postgresql-backup-success = {
             enable = true;
             priority = "normal";
+            placeholders = [ "backuppath" ];
             title = "✅ PostgreSQL Backup Complete";
             body = ''
               <b>Backup Path:</b> ''${backuppath}
@@ -1464,6 +1465,7 @@ in
           postgresql-replication-lag = {
             enable = true;
             priority = "normal";
+            placeholders = [ "lag" ];
             title = "⚠ PostgreSQL Replication Lag";
             body = ''
               <b>Lag:</b> ''${lag} seconds

--- a/modules/nixos/storage/default.nix
+++ b/modules/nixos/storage/default.nix
@@ -28,6 +28,7 @@ with lib;
           enable = mkDefault true;
           priority = mkDefault "low";
           backend = mkDefault "pushover";
+          placeholders = [ "message" ];
           title = mkDefault ''<b><font color="green">✓ Preseed Success: ''${serviceName}</font></b>'';
           body = mkDefault ''
             <b>Host:</b> ''${hostname}
@@ -44,6 +45,7 @@ with lib;
           enable = mkDefault true;
           priority = mkDefault "high";
           backend = mkDefault "pushover";
+          placeholders = [ "message" ];
           title = mkDefault ''<b><font color="red">✗ Preseed Failed: ''${serviceName}</font></b>'';
           body = mkDefault ''
             <b>Host:</b> ''${hostname}
@@ -60,6 +62,7 @@ with lib;
           enable = mkDefault true;
           priority = mkDefault "high";
           backend = mkDefault "pushover";
+          placeholders = [ "message" ];
           title = mkDefault ''<b><font color="red">✗ Preseed Unit Failed: ''${serviceName}</font></b>'';
           body = mkDefault ''
             <b>Host:</b> ''${hostname}
@@ -76,6 +79,7 @@ with lib;
           enable = mkDefault true;
           priority = mkDefault "low";
           backend = mkDefault "pushover";
+          placeholders = [ "message" ];
           title = mkDefault ''<b><font color="blue">ℹ Preseed Skipped: ''${serviceName}</font></b>'';
           body = mkDefault ''
             <b>Host:</b> ''${hostname}

--- a/modules/nixos/storage/helpers-lib.nix
+++ b/modules/nixos/storage/helpers-lib.nix
@@ -75,11 +75,21 @@
 
       # Method enable checks are computed inline in script; remove unused bindings
 
-      # Helper to trigger a notification
+      # Helper to trigger a notification.
+      #
+      # The message is handed over in a context file rather than exported.
+      # `systemctl start` asks PID 1 to launch the unit, so it inherits nothing
+      # from this shell: the old `export NOTIFY_MESSAGE=...` never reached the
+      # dispatcher, and every preseed notification rendered with an empty
+      # <b>Details:</b> section.
       notify = template: message: ''
         ${lib.optionalString hasCentralizedNotifications ''
-          echo "${message}"
-          export NOTIFY_MESSAGE="${lib.escapeShellArg message}"
+          echo ${lib.escapeShellArg message}
+          ${pkgs.jq}/bin/jq -n --arg message ${lib.escapeShellArg message} \
+            '{message: $message}' \
+            > "/run/notify/ctx/${template}:${serviceName}.json"
+          ${pkgs.coreutils}/bin/chgrp notify-ipc "/run/notify/ctx/${template}:${serviceName}.json" || true
+          ${pkgs.coreutils}/bin/chmod 660 "/run/notify/ctx/${template}:${serviceName}.json" || true
           # The dispatcher service uses the instance info as the serviceName
           ${pkgs.systemd}/bin/systemctl start "notify@${template}:${serviceName}.service"
         ''}

--- a/modules/nixos/storage/sanoid.nix
+++ b/modules/nixos/storage/sanoid.nix
@@ -608,6 +608,23 @@ in
               UMask = lib.mkForce "0002";
               PermissionsStartOnly = lib.mkForce false;
 
+              # Being stopped is not a replication failure.
+              #
+              # A nixos-rebuild switch (or any systemctl stop) SIGTERMs whichever
+              # syncoid jobs happen to be mid-run. systemd already treats SIGTERM
+              # as a clean exit for most services, but explicitly not for
+              # Type=oneshot, so these units entered the failed state and fired
+              # OnFailure - sending a high-priority "ZFS Replication Failed" page
+              # for a job the admin interrupted. Three such false alarms occurred
+              # in the 14 days before notification delivery was repaired; they
+              # were invisible only because nothing was being delivered.
+              #
+              # This does NOT mask a hung replication: a job killed by
+              # TimeoutStartSec below is recorded with Result=timeout rather than
+              # Result=signal, so it still fails and still pages. Verified on
+              # forge against all three cases before this was applied.
+              SuccessExitStatus = "SIGTERM";
+
               # CRITICAL: Shorter timeout to fail faster (was 2h, now 45m)
               TimeoutStartSec = "45m";
               TimeoutStopSec = "5m";

--- a/modules/nixos/storage/sanoid.nix
+++ b/modules/nixos/storage/sanoid.nix
@@ -322,23 +322,46 @@ in
         replicationEntries;
     users.groups.${cfg.replicationGroup} = { };
 
+    # Replication failures fire from OnFailure on a per-dataset syncoid unit,
+    # which leaves no opportunity to write a context file first. The target
+    # host is known here at build time, so register it per unit instead.
+    modules.notifications.context = lib.mkIf (config.modules.notifications.enable or false) (
+      lib.mapAttrs'
+        (dataset: conf: lib.nameValuePair
+          "syncoid-${lib.strings.replaceStrings [ "/" ] [ "-" ] dataset}.service"
+          { targetHost = conf.replication.targetHost; })
+        datasetsWithReplication
+    );
+
     # -- Notification Templates --
     modules.notifications.templates = lib.mkIf (config.modules.notifications.enable or false) {
+      # Placeholders are substituted by exact ''${name} match, not by a shell.
+      # These bodies previously used shell default syntax (''${dataset:-"unknown"}),
+      # command substitution ($(date -Iseconds)) and camelCase names that the
+      # dispatcher could never produce (''${errorMessage}, ''${targetHost}), all
+      # of which were delivered to the phone verbatim.
       zfs-replication-failure = {
         enable = true;
         priority = "high";
+        # targetHost is supplied per-unit via modules.notifications.context
+        # below: this fires from OnFailure, which gets no chance to run code
+        # first, so the value has to be registered at build time.
+        placeholders = [ "targetHost" ];
         title = ''✗ ZFS Replication Failed'';
         body = ''
-          <b>Dataset:</b> ''${dataset:-"unknown"}
-          <b>Target:</b> ''${targetHost:-"unknown"}
-          <b>Error:</b> ''${errorMessage:-"No error details available"}
-          <b>Timestamp:</b> $(date -Iseconds)
+          <b>Host:</b> ''${hostname}
+          <b>Dataset:</b> ''${dataset}
+          <b>Target:</b> ''${targetHost}
+          <b>Unit:</b> <code>''${serviceName}</code>
+          <b>Timestamp:</b> ''${timestamp}
+
+          <b>Error:</b>
+          ''${errormessage}
 
           <b>Troubleshooting:</b>
           • Check SSH connectivity: ssh ''${targetHost}
-          • Review logs: journalctl -u syncoid-*.service
+          • Review logs: journalctl -u ''${serviceName} -n 100
           • Verify SSH key: ls -la /var/lib/zfs-replication/.ssh/
-          • Test ZFS send: zfs send -nv ''${dataset}@latest
         '';
       };
       zfs-snapshot-failure = {
@@ -346,21 +369,25 @@ in
         priority = "high";
         title = ''✗ ZFS Snapshot Failed'';
         body = ''
-          <b>Dataset:</b> ''${dataset:-"unknown"}
-          <b>Host:</b> ''${hostname:-"unknown"}
-          <b>Error:</b> ''${errorMessage:-"No error details available"}
-          <b>Timestamp:</b> $(date -Iseconds)
+          <b>Host:</b> ''${hostname}
+          <b>Dataset:</b> ''${dataset}
+          <b>Unit:</b> <code>''${serviceName}</code>
+          <b>Timestamp:</b> ''${timestamp}
+
+          <b>Error:</b>
+          ''${errormessage}
 
           <b>Troubleshooting:</b>
           • Check ZFS pool health: zpool status
-          • Review logs: journalctl -u sanoid.service
-          • Verify permissions: zfs allow ''${dataset}
+          • Review logs: journalctl -u ''${serviceName} -n 100
           • Check disk space: df -h /
         '';
       };
       pool-degraded = {
         enable = true;
         priority = "emergency";
+        # Supplied at dispatch time by zfs-health-check via a context file.
+        placeholders = [ "pool" "state" "status" ];
         title = ''🚨 URGENT: ZFS Pool Degraded'';
         body = ''
           <b>Pool:</b> ''${pool}
@@ -688,10 +715,24 @@ in
 
                     if [[ "$state" != "ONLINE" ]]; then
                       status=$(${pkgs.zfs}/bin/zpool status "$pool" 2>&1 || echo "Failed to get pool status")
-                      export NOTIFY_POOL="$pool"
-                      export NOTIFY_HOSTNAME="${config.networking.hostName}"
-                      export NOTIFY_STATE="$state"
-                      export NOTIFY_STATUS="$status"
+
+                      # Hand the values to the dispatcher through a context
+                      # file. Exporting them did nothing: `systemctl start`
+                      # launches the unit from PID 1, not from this shell, so
+                      # the environment never reached it and every pool-degraded
+                      # page rendered with empty pool, state and status.
+                      # JSON also survives the multi-line `zpool status` output,
+                      # which an EnvironmentFile would have mangled.
+                      CTX_FILE="/run/notify/ctx/pool-degraded:$pool.json"
+                      ${pkgs.jq}/bin/jq -n \
+                        --arg pool "$pool" \
+                        --arg state "$state" \
+                        --arg status "$status" \
+                        '{pool: $pool, state: $state, status: $status}' \
+                        > "$CTX_FILE"
+                      ${pkgs.coreutils}/bin/chgrp notify-ipc "$CTX_FILE" || true
+                      ${pkgs.coreutils}/bin/chmod 660 "$CTX_FILE" || true
+
                       ${pkgs.systemd}/bin/systemctl start "notify@pool-degraded:$pool.service"
                       echo "[$(date -Iseconds)] WARNING: Pool $pool is $state - notification sent"
 

--- a/modules/nixos/system-notifications.nix
+++ b/modules/nixos/system-notifications.nix
@@ -27,6 +27,7 @@ in
         enable = mkDefault cfg.boot.enable;
         priority = mkDefault "low"; # Low priority to reduce noise
         backend = mkDefault "pushover";
+        placeholders = [ "boottime" "bootstatus" "kernel" "generation" ];
         title = mkDefault ''🚀 System Boot'';
         body = mkDefault ''
           <b>Host:</b> ''${hostname}
@@ -45,6 +46,9 @@ in
         enable = mkDefault cfg.shutdown.enable;
         priority = mkDefault "low";
         backend = mkDefault "pushover";
+        # Registered for documentation only: the shutdown path cannot start a
+        # service, so notify-shutdown.service below renders this content itself.
+        placeholders = [ "shutdowntime" "uptime" ];
         title = mkDefault ''⏸️ System Shutdown'';
         body = mkDefault ''
           <b>Host:</b> ''${hostname}
@@ -57,18 +61,12 @@ in
       };
     };
 
-    # Enable path unit for boot notifications
-    # Watches for payload file and triggers the backend service
-    # Must explicitly define PathExists since we're creating an instance, not using the template
-    systemd.paths."notify-pushover@system-boot:boot" = mkIf cfg.boot.enable {
-      wantedBy = [ "multi-user.target" ];
-      pathConfig = {
-        PathExists = "/run/notify/system-boot:boot.json";
-      };
-    };
-
-    # Note: No path unit for shutdown - it sends notifications directly in ExecStop
-    # to avoid systemd's restrictions on starting new services during shutdown
+    # No path unit here any more: notify-drain.path watches /run/notify as a
+    # directory, so every payload is picked up rather than only the handful
+    # that happened to have an instance declared.
+    #
+    # Note: shutdown still sends its notification directly in ExecStop, to
+    # avoid systemd's restrictions on starting new services during shutdown.
 
     # Boot notification service
     systemd.services.notify-boot = mkIf cfg.boot.enable {
@@ -87,39 +85,43 @@ in
         # Check for graceful shutdown marker
         MARKER_FILE="/persist/var/lib/shutdown-marker/clean"
         if [ -f "$MARKER_FILE" ]; then
-          NOTIFY_BOOT_STATUS="✅ Clean boot (graceful shutdown)"
+          BOOT_STATUS="✅ Clean boot (graceful shutdown)"
           # Clean up the marker so next boot is considered unclean by default
           rm "$MARKER_FILE"
         else
           # Check if ZFS had to recover (additional confirmation of dirty boot)
           if ${pkgs.systemd}/bin/journalctl -b 0 --no-pager | ${pkgs.gnugrep}/bin/grep -qi "zfs.*import"; then
-            NOTIFY_BOOT_STATUS="⚠️ Unclean boot (crash/power loss - ZFS recovery)"
+            BOOT_STATUS="⚠️ Unclean boot (crash/power loss - ZFS recovery)"
           else
-            NOTIFY_BOOT_STATUS="⚠️ Unclean boot (crash/power loss)"
+            BOOT_STATUS="⚠️ Unclean boot (crash/power loss)"
           fi
         fi
 
         # Gather system information
-        NOTIFY_HOSTNAME="${config.networking.hostName}"
-        NOTIFY_BOOTTIME="$(${pkgs.coreutils}/bin/date '+%b %-d, %-I:%M %p %Z')"
-        NOTIFY_KERNEL="$(${pkgs.coreutils}/bin/uname -r)"
-        NOTIFY_GENERATION="$(${pkgs.coreutils}/bin/basename $(${pkgs.coreutils}/bin/readlink /run/current-system) | ${pkgs.gnused}/bin/sed 's/.*-//')"
+        BOOT_TIME="$(${pkgs.coreutils}/bin/date '+%b %-d, %-I:%M %p %Z')"
+        KERNEL="$(${pkgs.coreutils}/bin/uname -r)"
+        GENERATION="$(${pkgs.coreutils}/bin/basename $(${pkgs.coreutils}/bin/readlink /run/current-system) | ${pkgs.gnused}/bin/sed 's/.*-//')"
 
         # Wait a bit for network to be fully ready
         sleep 5
 
-        # Write environment variables to a file for the dispatcher
-        # Directory is created by tmpfiles (boot) and activationScripts (nixos-rebuild)
-        ENV_FILE="/run/notify/env/system-boot:boot.env"
-        {
-          echo "NOTIFY_HOSTNAME=$NOTIFY_HOSTNAME"
-          echo "NOTIFY_BOOTTIME=$NOTIFY_BOOTTIME"
-          echo "NOTIFY_KERNEL=$NOTIFY_KERNEL"
-          echo "NOTIFY_GENERATION=$NOTIFY_GENERATION"
-          echo "NOTIFY_BOOT_STATUS=$NOTIFY_BOOT_STATUS"
-        } > "$ENV_FILE"
-        chgrp notify-ipc "$ENV_FILE"
-        chmod 640 "$ENV_FILE"
+        # Hand the dispatcher this boot's placeholder values as JSON.
+        #
+        # This used to be an EnvironmentFile, which cannot carry the multi-line
+        # values other callers need and silently mangles anything with quoting
+        # in it. JSON has one unambiguous representation, and the keys are the
+        # placeholder names verbatim rather than being run through a lossy
+        # NOTIFY_BOOT_TIME -> boottime transform.
+        CTX_FILE="/run/notify/ctx/system-boot:boot.json"
+        ${pkgs.jq}/bin/jq -n \
+          --arg boottime "$BOOT_TIME" \
+          --arg bootstatus "$BOOT_STATUS" \
+          --arg kernel "$KERNEL" \
+          --arg generation "$GENERATION" \
+          '{boottime: $boottime, bootstatus: $bootstatus, kernel: $kernel, generation: $generation}' \
+          > "$CTX_FILE"
+        chgrp notify-ipc "$CTX_FILE"
+        chmod 660 "$CTX_FILE"
 
         # Trigger notification through generic dispatcher
         ${pkgs.systemd}/bin/systemctl start "notify@system-boot:boot.service"


### PR DESCRIPTION
Service-failure notifications were dispatched successfully and never sent. Payloads accumulated unread in `/run/notify` on forge from 2026-07-13 onward — 119 of them — while every dispatch reported `Result=success` and `ExecMainStatus=0`. Found on 2026-08-16 while test-firing an unrelated alarm; nobody had noticed for a month.

## Root cause: delivery depended on units that could not exist

The dispatcher writes `/run/notify/<template>:<instance>.json` and deliberately starts no backend, to avoid permission problems with `DynamicUser`. Something else had to notice the file. That was a per-instance systemd `.path` unit — one per notification.

That can never work. Callers name instances at failure time (`notify@<template>:%n`), so the identifiers do not exist until a unit actually fails and cannot be enumerated at build time. **Only 3 path instances were ever declared against 34 registration sites.** The template unit even documented the contract — "instances are activated by their callers" — which is precisely the contract that cannot be met.

Replaced with one directory watcher, `notify-drain.path`, globbing `/run/notify/*.json`. No per-caller registration, dynamic instances work by construction, nothing left to forget to declare. Payloads now carry their own `backend` so a single drain can route across the three backends, and are written to a temp name and renamed so the watcher can never observe a partial write.

## The failure was invisible by construction

A queue that stops draining produces no symptom except the *absence* of a message. `notify-backlog-check` now pages — and fails its own unit — when anything sits undelivered past five minutes. It delivers that alarm directly rather than through the queue, because an alarm about a broken queue must not be enqueued into it.

Payloads older than two hours are archived and reported as a single summary rather than fired at a phone in a burst, so restoring delivery after an outage can't itself become the incident.

## Root cause: the messages were unusable anyway

The queued Home Assistant payload rendered as:

```
Host: ${config.networking.hostName}
Service: <code></code>
Action: ssh ${config.networking.hostName} 'journalctl -u  -n 200'
```

Three separate mistakes, all silent:

- **Escaped Nix interpolations.** `''${config.networking.hostName}` in an indented string emits literal text. `envsubst` left it alone (dots aren't a valid identifier) so it reached the page verbatim.
- **Names that could never resolve.** `''${serviceUnit}` is a valid identifier, so envsubst substituted it with the empty string — producing `journalctl -u ` with no unit.
- **Shell syntax in a non-shell context.** `zfs-replication-failure` used `''${dataset:-"unknown"}` and `$(date -Iseconds)`, delivered verbatim.

Substitution now happens by exact name in `jq`. **An assertion rejects any template referencing a placeholder that cannot resolve** — verified by reintroducing the original bug and confirming the build fails with the fix in the message. Declared-but-unresolved placeholders render `(unset: name)`; a visibly wrong page beats a silently blank one.

## Root cause: caller context was silently discarded

Callers passed context with `export NOTIFY_FOO=... ; systemctl start notify@...`. `systemctl` asks PID 1 to launch the unit, so it inherits nothing from the calling shell. This blanked `${message}` in all four preseed templates and *every* field of `pool-degraded`.

Callers now write a JSON context file (which also survives multi-line values like `zpool status`, where an `EnvironmentFile` would not). `OnFailure` hooks get no chance to run code first, so they declare build-time values via the new `modules.notifications.context`, keyed by unit name.

## Also fixed, found along the way

- **Emergency notifications were sent at normal priority.** The priority was resolved at build time from the literal string `"$PRIORITY"`, then the generated script emitted `PRIORITY="0"`, clobbering the payload value. Pushover also rejects priority 2 without `retry`/`expire`.
- **The dispatcher could not read the journal it quotes.** `DynamicUser` sees only its own logs, so `${errormessage}` always said "No log available".
- **Over-long messages were rejected rather than truncated** — so the most detailed notifications were the least likely to arrive.
- **ntfy and Healthchecks were unbuildable.** Both referenced templates that do not exist (`backup-success`, `service-failure`, `disk-alert`…); enabling either backend would have failed evaluation.
- **Rebuild-interrupted replication paged as a failure.** `nixos-rebuild switch` SIGTERMs in-flight syncoid jobs; systemd exempts SIGTERM for most services but explicitly not for `Type=oneshot`, so they entered the failed state and fired `OnFailure`.

## Verification

Exit 0 is not delivery, so this was verified end to end on forge rather than by reading the code.

- **Sandbox run of the generated scripts** on forge with stubbed delivery: delivery, stale archiving, quarantine, retry escalation, alarm rate limiting, and a regression test reproducing the exact undrained-queue state forge sat in for a month (alarms within 5 minutes, unit goes failed).
- **Real dynamic instance:** a unit whose name exists nowhere in the config, failed for real, `OnFailure=notify@preseed-skipped:%n.service` → queued → drained → **Pushover HTTP 200** → unlinked, same second. Confirmed received on device.
- **Rendering** checked against live payloads for a service failure, a static-context case (`targetHost`), a runtime-context case, and a multi-line `zpool status`.
- **SIGTERM change** verified across all three cases — stopped without the setting (`failed`/`signal`), stopped with it (`success`), timed out with it (**`failed`/`timeout`**, so a hung replication still pages) — then against a real syncoid job interrupted mid-run: no dispatch, no payload, clean re-run after.

Forge is currently running this tree: 0 pending, 0 failed, 119 archived, 0 failed units.

## Notes for review

- The 119-payload backlog was archived to `/run/notify/archive` rather than delivered or deleted, and copied off-host. It is a month of real unreported failures — dominated by 43 datasets with replication failures and one benign 44-payload preseed event.
- `notify-pushover@`, the legacy `notify-ntfy-*` and `healthcheck-*` services, and the three hardcoded path instances are removed.
- `docs/notifications.md` is updated where it was actively wrong; the "Pre-defined Templates" section is marked stale rather than rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)