### PR TITLE
fix(home-assistant): stop a hand-edited file making the service unstartable

### DIFF
--- a/modules/nixos/services/home-assistant/default.nix
+++ b/modules/nixos/services/home-assistant/default.nix
@@ -1,6 +1,6 @@
 { config, lib, mylib, pkgs, ... }:
 let
-  inherit (lib) mkEnableOption mkOption mkIf mkMerge mkDefault mkForce types;
+  inherit (lib) mkEnableOption mkOption mkIf mkMerge mkDefault mkForce mkBefore types;
 
   # Service UID/GID from centralized registry
   serviceIds = mylib.serviceUids.home-assistant;
@@ -25,6 +25,35 @@ let
     inherit config;
     datasetName = serviceName;
   };
+
+  # dataDir doubles as an operator-managed git working tree, so files Home
+  # Assistant writes itself can be re-created under a human's ownership by a
+  # checkout and silently strip hass's write access. Repair only the paths HA
+  # actually writes; everything else (.git, packages/, dashboards/, scripts/)
+  # is read-only for hass by design and is deliberately left alone.
+  absWritableFiles = map (p: "${cfg.dataDir}/${p}") cfg.runtimeWritableFiles;
+  absWritableDirs = map (p: "${cfg.dataDir}/${p}") cfg.runtimeWritableDirs;
+
+  # Runs as root via the "+" ExecStartPre prefix. This deliberately duplicates
+  # the tmpfiles rules below: tmpfiles only fires on activation, but a git
+  # checkout between two rebuilds is exactly how the ownership drifts, so the
+  # repair has to run on every start for the service to be unbreakable.
+  ownershipRepair = pkgs.writeShellScript "${serviceName}-ownership-repair" ''
+    set -euo pipefail
+
+    for path in ${lib.escapeShellArgs absWritableFiles}; do
+      [ -e "$path" ] || continue
+      ${pkgs.coreutils}/bin/chown hass:hass "$path"
+      # A checkout can also land a read-only mode; owner-write is what matters.
+      ${pkgs.coreutils}/bin/chmod u+w "$path"
+    done
+
+    for path in ${lib.escapeShellArgs absWritableDirs}; do
+      [ -d "$path" ] || continue
+      # Modes are left alone so 0600 credentials under .storage stay restrictive.
+      ${pkgs.coreutils}/bin/chown -R hass:hass "$path"
+    done
+  '';
 in
 {
   options.modules.services.home-assistant = {
@@ -89,6 +118,38 @@ in
       type = types.bool;
       default = false;
       description = "Whether Home Assistant's configuration.yaml should remain writable by the UI (services.home-assistant.configWritable).";
+    };
+
+    runtimeWritableFiles = mkOption {
+      type = types.listOf types.str;
+      default = [ ".HA_VERSION" "automations.yaml" "scenes.yaml" "scripts.yaml" ];
+      description = ''
+        Files under dataDir that Home Assistant writes at runtime, relative to
+        dataDir. Ownership is forced to hass:hass both on activation and before
+        every service start.
+
+        These are the files that can be edited from two directions: Home
+        Assistant writes them (.HA_VERSION on every startup after a version
+        change, the rest from its UI editors), while dataDir is also a git
+        working tree an operator checks out as themselves. A checkout re-creates
+        tracked files under the invoking user, which strips hass's write access
+        and makes the service fail to start -- a fault that stays invisible until
+        the next restart, since nothing rewrites these while HA is running.
+
+        Only list paths Home Assistant genuinely writes. Config that hass merely
+        reads (packages/, dashboards/, secrets.yaml) should stay operator-owned.
+      '';
+    };
+
+    runtimeWritableDirs = mkOption {
+      type = types.listOf types.str;
+      default = [ ".storage" ];
+      description = ''
+        Directories under dataDir owned wholly by Home Assistant, relative to
+        dataDir. Ownership is forced recursively to hass:hass; file modes are
+        preserved so restrictive permissions (such as the 0600 credentials in
+        .storage) survive the repair.
+      '';
     };
 
     reverseProxy = mkOption {
@@ -348,11 +409,45 @@ in
         mode = "0770";
       };
 
+      # Repair ownership on activation as well as at start, so a rebuild heals
+      # drift even if the service is not restarted. "z"/"Z" only adjust paths
+      # that already exist; Home Assistant creates them itself otherwise.
+      # Modes are "-" throughout: only owner/group are corrected. Pinning a mode
+      # here would strip the group-write that lets an operator hand-edit
+      # scripts.yaml/scenes.yaml. Recovering from a read-only mode is left to
+      # the start-time repair, which is what actually has to guarantee startup.
+      systemd.tmpfiles.rules =
+        map (path: "z ${path} - hass hass -") absWritableFiles
+        ++ map (path: "Z ${path} - hass hass -") absWritableDirs;
+
       # Systemd unit coordination
       systemd.services.${serviceName} = {
+        # NOTE: `attrs // (mkIf cond { ... })` must not be used here. It splices
+        # `_type = "if"` into the attrset, so the module system reads the whole
+        # definition as an mkIf and keeps only the mkIf body -- silently
+        # dropping every sibling attribute. That is why RequiresMountsFor below
+        # never reached the generated unit. optionalAttrs composes plainly.
         unitConfig = {
           RequiresMountsFor = [ cfg.dataDir ];
-        } // (mkIf (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
+
+          # Home Assistant takes ~3s to fail, so systemd's default 10s window
+          # can never accumulate 5 failures: a permanently broken instance
+          # restarts forever while `systemctl is-active` still reports "active",
+          # hiding the outage. Widen the window past the failure interval so a
+          # persistent fault lands the unit in "failed" and stays there.
+          #
+          # This is also what makes the service's own ServiceDown alert usable:
+          # that rule is `for = "2m"` on node_systemd_unit_state{state="active"}
+          # == 0, and a flapping unit never holds the condition long enough to
+          # fire (measured during the 2026-08-16 outage: 60s of contiguous zero
+          # against a 120s requirement, so it went pending and reset for 43
+          # minutes). Only a unit that reaches `failed` holds it.
+          #
+          # mkDefault so a host-level restart policy can own the number without
+          # colliding with this module-level baseline.
+          StartLimitIntervalSec = mkDefault 300;
+          StartLimitBurst = mkDefault 5;
+        } // (lib.optionalAttrs (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
           OnFailure = [ "notify@home-assistant-failure:%n.service" ];
         });
         requires = mkIf (cfg.preseed.enable && !allowEmptyBootstrap) [ "preseed-${serviceName}.service" ];
@@ -361,12 +456,22 @@ in
         environment = mkIf (cfg.extraLibs != [ ]) {
           LD_LIBRARY_PATH = lib.makeLibraryPath cfg.extraLibs;
         };
+        # `ReadWritePaths = mkForce [ cfg.dataDir ]` used to sit here. It was
+        # inert for the same mkIf reason, and reviving it would have been a
+        # regression: upstream already grants dataDir, and forcing the list
+        # would have dropped the media share (/mnt/data/media) that Home
+        # Assistant writes generated content to. Removed rather than restored.
         serviceConfig =
           ({
-            ReadWritePaths = mkForce [ cfg.dataDir ];
             WorkingDirectory = mkForce cfg.dataDir;
+
+            # mkBefore so this runs ahead of the upstream module's pre-start
+            # script, and "+" so it runs as root -- hass cannot chown away files
+            # it does not own, which is the whole failure mode being repaired.
+            ExecStartPre = mkBefore [ "+${ownershipRepair}" ];
           }
-          // (mkIf (cfg.environmentFiles != [ ]) {
+          # See the unitConfig note above: optionalAttrs, never `// mkIf`.
+          // (lib.optionalAttrs (cfg.environmentFiles != [ ]) {
             EnvironmentFile = cfg.environmentFiles;
           }));
       };


### PR DESCRIPTION
## What happened

Home Assistant crash-looped for 43 minutes on 2026-08-16 (367 restarts), reporting `active` the whole time:

```
PermissionError: [Errno 13] Permission denied: '/var/lib/home-assistant/.HA_VERSION'
```

Service was restored at 12:41 by chowning that one file. This PR is the durable fix.

## Root cause

`/var/lib/home-assistant` is simultaneously Home Assistant's state directory (service runs as `hass`) **and** a git working tree of `carpenike/hass-config`, checked out as a human user. The directory is `0770 hass hass` with **no setgid bit** and the operator is in the `hass` group, so files created at the top level land `ryan:ryan` while setgid subdirectories such as `packages/` land `ryan:hass`. That asymmetry is the whole mechanism.

`.HA_VERSION` is **git-tracked** (whitelisted in that repo's `.gitignore`), so every checkout re-creates it under the operator's ownership. Home Assistant rewrites it only during `process_ha_config_upgrade` at startup — invisible while running, fatal at the next restart. Latent from 2026-08-09 until a routine rebuild restarted the service. Reproduced end-to-end: `rm` + recreate as the operator flips it straight back.

`automations.yaml` was broken the same way and is a **second, independent live breakage**: it is the UI automation editor's sink (its own header says so) and `hass` could not write it, so saving an automation from the UI had been failing silently.

## The fix

Repair only the paths Home Assistant actually writes, exposed as `runtimeWritableFiles` / `runtimeWritableDirs`. `.git`, `packages/`, `dashboards/`, `secrets.yaml` and `scripts/` are read-only for `hass` by design and stay operator-owned — a blanket recursive chown would have chowned `.git` and broken the config-as-code workflow outright.

Enforcement runs **both** via tmpfiles on activation **and** via a root `ExecStartPre` on every start. tmpfiles alone is insufficient: the drift happens on a `git pull` *between* two rebuilds. Modes are preserved throughout, so the group-write on `scripts.yaml`/`scenes.yaml` and the `0600` credentials under `.storage` survive.

## Start limit

The unit sat on systemd's default `10s`/`5`, but HA takes ~3s to fail, so five attempts span ~15s and the window resets before the burst is reached. The limit was **structurally unreachable, not merely unset** — which is why the service reported `active` for the entire outage.

This is also what makes the existing `HomeAssistantServiceDown` rule usable. It is `for="2m"` on `node_systemd_unit_state{state="active"} == 0`; measured over the outage window, the metric read `1` in 112 of 121 samples and held zero for at most **60s** at a time, so the alert went pending and reset for 43 minutes without ever firing. Only a unit that reaches `failed` holds that condition. Set via `mkDefault` so a host-level restart policy can own the number.

## Latent module bug fixed along the way

`unitConfig` and `serviceConfig` were composed as `attrs // (mkIf cond { ... })`. That splices `_type = "if"` into the attrset, so the module system reads the **whole** definition as an `mkIf` and keeps only its body — every sibling attribute silently discarded. `RequiresMountsFor` had never reached the generated unit. My first attempt at this fix evaluated clean and produced nothing; it was only caught by diffing the rendered unit. Replaced with `lib.optionalAttrs`.

The inert `ReadWritePaths = mkForce [ cfg.dataDir ]` is **removed rather than restored** — upstream already grants `dataDir`, and reviving the force would have dropped the `/mnt/data/media` share.

## Verification

- Full `forge` closure builds (built natively on forge, x86_64).
- Rendered unit confirmed against the built system:
  ```
  ExecStartPre=+/nix/store/...-home-assistant-ownership-repair
  ExecStartPre=/nix/store/...-home-assistant-pre-start
  StartLimitIntervalSec=300   StartLimitBurst=5   RequiresMountsFor=/var/lib/home-assistant
  ReadWritePaths=/var/lib/home-assistant /var/lib/home-assistant /mnt/data/media
  ```
- Repair script run against the live host: all four managed files now `hass`-writable, `.storage/auth` still `0600`, operator can still create/delete/replace in the directory (git workflow intact).
- HA healthy since 12:41, `NRestarts=0`, no `PermissionError`.

## Note

Not yet deployed — forge is still on the bare `10s`/`5` with no ownership repair in the live unit. The on-disk chown is holding it until this lands and is switched.

Follow-up recommendation, outside this PR: untrack `.HA_VERSION` in `carpenike/hass-config`. It is pure runtime state, and tracking it is what re-arms this on every checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)