### PR TITLE
fix(monitoring): make crash-looping units reach `failed` so alerts fire

### DIFF
--- a/hosts/forge/core/crash-loop-detection.nix
+++ b/hosts/forge/core/crash-loop-detection.nix
@@ -1,0 +1,191 @@
+{ config, lib, ... }:
+# Crash-loop detection for forge
+#
+# WHY THIS FILE EXISTS
+#
+# forge has 44 per-service ServiceDown alerts of the form
+#
+#     node_systemd_unit_state{name="<unit>.service",state="active"} == 0   for 2m
+#
+# plus the host-wide SystemdUnitFailed alert. Every one of them requires the
+# unit to *stay* non-active. A crash-looping unit does not: it cycles through
+# activating -> active -> failed-start every couple of seconds, so most scrapes
+# sample it as active and the alert never leaves "pending".
+#
+# systemd will park a unit in `failed` and stop the loop, but only once
+# StartLimitBurst starts have occurred inside StartLimitIntervalSec. Those
+# N starts are spread over (N - 1) * (failure duration + RestartSec), so the
+# systemd default of 10s / 5 starts is reachable only for failures under 2.4s,
+# and is unreachable at any speed once RestartSec >= 2.5s.
+#
+# Home Assistant proved this on 2026-08-16: 367 restarts over 43 minutes, the
+# longest contiguous run of state != active was 60s against the 120s `for`, and
+# HomeAssistantServiceDown went pending and reset for the entire outage without
+# ever firing. Two independent alerting paths existed and neither delivered.
+#
+# forgeDefaults.mkCrashLoopLimit sizes the window from each unit's own restart
+# timing (see lib/host-defaults.nix for the arithmetic). Widening the window
+# does not make a unit restart less - it makes the burst *reachable*, so a
+# genuinely broken unit lands in `failed`, where all three existing paths
+# (ServiceDown, SystemdUnitFailed, OnFailure=notify@) can finally see it.
+#
+# NOT LISTED HERE
+#
+# Units left alone keep restarting forever on purpose; they are covered by the
+# SystemdUnitCrashLooping alert in core/monitoring.nix, which watches restart
+# churn directly and needs no behaviour change:
+#
+#   cloudflared-forge     retries until the network/edge is reachable
+#   github-runner-forge   Restart=on-success is the job loop, not a failure loop
+#   postgresql            every other service depends on it; keep retrying
+#
+let
+  forgeDefaults = import ../lib/defaults.nix { inherit config lib; };
+
+  # Units whose crash-loops must become visible. Each has a ServiceDown alert
+  # and a Restart= policy that can loop. RestartSec is read from the unit
+  # itself, so this table never drifts out of sync with it; `failureSec` is the
+  # only tuning knob - how long a broken start may survive before dying.
+  #
+  # The 60s default covers everything measured on forge (Home Assistant took
+  # ~3s). Raise it for services that fail slowly rather than lowering it.
+  protectedUnits = {
+    actual = { };
+    ambit = { };
+    beszel-agent = { };
+    cooklang = { };
+    cooklang-federation = { };
+    filebrowser-quantum = { };
+    gatus = { };
+    glances-web = { };
+    grafana = { };
+    hermes-agent = { };
+    # The module carries its own 300/5 baseline as mkDefault (#820) so any host
+    # gets a usable window. Listing it here makes forge the owner of the number
+    # without conflicting - the derived value is the same 300, and a future
+    # failureSec change here simply wins over the default.
+    home-assistant = { };
+    homelab-mcp = { };
+    homepage-dashboard = { };
+    lading = { };
+    marginalia = { };
+    miniflux = { };
+    phpfpm-grocy = { };
+    pinchflat = { };
+    pocket-id = { };
+    podman-bgutil-pot = { };
+    podman-emqx = { };
+    podman-valhalla = { };
+    replog = { };
+    schoolhouse = { };
+    tautulli = { };
+    whiskey-whiskey-whiskey = { };
+    worldmonitor-api = { };
+    zigbee2mqtt = { };
+    zwave-js-ui = { };
+
+    # Paperless runs Django migrations on every start; a broken start can sit in
+    # migrate/collectstatic well past a minute before giving up.
+    paperless-consumer = { failureSec = 180; };
+    paperless-scheduler = { failureSec = 180; };
+    paperless-task-queue = { failureSec = 180; };
+    paperless-web = { failureSec = 180; };
+  };
+
+  # RestartSec as systemd accepts it: a bare number is seconds, otherwise a
+  # suffixed duration. Unset means systemd's 100ms default, which rounds to 0 -
+  # the 25% headroom in mkCrashLoopLimit absorbs the difference.
+  unitSeconds = {
+    ms = 0; # sub-second, below the resolution this arithmetic needs
+    s = 1;
+    sec = 1;
+    m = 60;
+    min = 60;
+    h = 3600;
+  };
+
+  parseSeconds =
+    raw:
+    let
+      matched = builtins.match "([0-9]+)(min|sec|ms|s|m|h)?" (toString raw);
+      count = lib.toInt (builtins.elemAt matched 0);
+      suffix = builtins.elemAt matched 1;
+      unit = if suffix == null then "s" else suffix;
+    in
+    if raw == null then 0 else if matched == null then null else count * unitSeconds.${unit};
+
+  restartSecOf =
+    unit:
+    parseSeconds (config.systemd.services.${unit}.serviceConfig.RestartSec or null);
+
+  hasUnit = unit: config.systemd.services ? ${unit};
+
+  restartsOf =
+    unit: config.systemd.services.${unit}.serviceConfig.Restart or null;
+
+  # Every alert mkSystemdServiceDownAlert produces, reduced back to the unit it
+  # watches. An alert naming a unit that does not exist on this host scrapes no
+  # metric at all, so `== 0` is never true and the alert is silently dead -
+  # cloudflared, emqx and searx were all in that state before this check.
+  downAlertPrefix = ''node_systemd_unit_state{name="'';
+  downAlertSuffix = ''.service",state="active"} == 0'';
+
+  downAlertUnits = lib.concatMap
+    (rule:
+      let expr = rule.expr or ""; in
+      lib.optional (lib.hasPrefix downAlertPrefix expr && lib.hasSuffix downAlertSuffix expr)
+        (lib.removeSuffix downAlertSuffix (lib.removePrefix downAlertPrefix expr)))
+    (lib.attrValues config.modules.alerting.rules);
+in
+{
+  systemd.services = lib.mapAttrs
+    (unit: opts:
+      forgeDefaults.mkCrashLoopLimit ({ restartSec = restartSecOf unit; } // opts))
+    protectedUnits;
+
+  assertions =
+    # Every protected unit must have a Restart= policy.
+    #
+    # This doubles as the typo/rename guard. There is deliberately no separate
+    # "does the unit exist" check: defining startLimitIntervalSec above *creates*
+    # systemd.services.<name>, so an existence test on a misspelled name would
+    # always pass and always be useless. A conjured unit has no Restart= though,
+    # so a bad name lands here instead - the same way beszel.service ended up as
+    # an empty unit elsewhere in this config.
+    (lib.mapAttrsToList
+      (unit: _: {
+        assertion = !(builtins.elem (restartsOf unit) [ null "no" ]);
+        message = ''
+          crash-loop-detection: systemd.services."${unit}" has Restart=${toString (restartsOf unit)},
+          so a start limit has no effect. Either the unit name is wrong (in which
+          case this file has just created an empty unit under that name) or it
+          genuinely never restarts. Fix or drop the entry in
+          hosts/forge/core/crash-loop-detection.nix.
+        '';
+      })
+      protectedUnits)
+
+    # An unparseable RestartSec would silently size the window from 0.
+    ++ (lib.mapAttrsToList
+      (unit: _: {
+        assertion = restartSecOf unit != null;
+        message = ''
+          crash-loop-detection: cannot parse RestartSec for systemd.services."${unit}".
+          Teach parseSeconds the new duration form in
+          hosts/forge/core/crash-loop-detection.nix.
+        '';
+      })
+      protectedUnits)
+
+    ++ (map
+      (unit: {
+        assertion = hasUnit unit;
+        message = ''
+          alerting: a ServiceDown alert watches "${unit}.service", which is not a unit
+          on this host. node_systemd_unit_state is never exported for it, so the alert
+          can never fire. Correct the service name passed to
+          forgeDefaults.mkSystemdServiceDownAlert.
+        '';
+      })
+      downAlertUnits);
+}

--- a/hosts/forge/core/monitoring.nix
+++ b/hosts/forge/core/monitoring.nix
@@ -190,6 +190,44 @@
       };
     };
 
+    # SystemD unit crash-looping
+    #
+    # The other half of SystemdUnitFailed. A unit that restarts every few
+    # seconds never *stays* non-active, so node_systemd_unit_state samples it as
+    # active on most scrapes and neither SystemdUnitFailed nor any per-service
+    # ServiceDown alert can hold its `for` window. Home Assistant crash-looped
+    # for 43 minutes on 2026-08-16 without a single alert firing for exactly
+    # this reason.
+    #
+    # Restart churn is the signal that survives, so watch it directly. This
+    # needs no start limit and no unit-level change, which is what makes it the
+    # safety net for units deliberately left to retry forever (cloudflared,
+    # postgresql) - see core/crash-loop-detection.nix for the ones that are
+    # instead pushed into `failed`.
+    #
+    # Requires --collector.systemd.enable-restarts-metrics (modules/nixos/monitoring.nix).
+    #
+    # Threshold: units with a start limit park in `failed` after 4 restarts and
+    # are reported by SystemdUnitFailed, so >5 deliberately picks up only the
+    # units that keep going. A nixos-rebuild switch restarts a unit once, well
+    # under the threshold. Podman healthcheck transients (64-hex names) are
+    # excluded as they are for SystemdTimerStale.
+    "systemd-unit-crash-looping" = {
+      type = "promql";
+      alertname = "SystemdUnitCrashLooping";
+      expr = ''
+        increase(node_systemd_service_restart_total{name!~".*[0-9a-f]{64}.*"}[10m]) > 5
+      '';
+      for = "2m";
+      severity = "high";
+      labels = { service = "system"; category = "systemd"; };
+      annotations = {
+        summary = "SystemD unit {{ $labels.name }} is crash-looping on {{ $labels.instance }}";
+        description = "{{ $labels.name }} restarted {{ $value | printf \"%.0f\" }} times in the last 10 minutes. It is failing repeatedly but restarting fast enough to look active. Check: journalctl -u {{ $labels.name }} -n 100";
+        command = "systemctl status {{ $labels.name }}";
+      };
+    };
+
     # Critical memory pressure - host is nearly out of memory
     # Fires at 95% (vs HighMemoryUsage at 90%) for immediate attention
     "memory-pressure-critical" = {

--- a/hosts/forge/default.nix
+++ b/hosts/forge/default.nix
@@ -29,6 +29,7 @@ in
     ./core/packages.nix
     ./core/hardware.nix
     ./core/monitoring.nix # Core system health monitoring (CPU, memory, disk, systemd)
+    ./core/crash-loop-detection.nix # Start limits so flapping units reach `failed` and alert
     ./core/system-services.nix # System service configurations (rsyslog, journald)
 
     # Infrastructure (Cross-cutting operational concerns)

--- a/hosts/forge/services/cloudflare-tunnel.nix
+++ b/hosts/forge/services/cloudflare-tunnel.nix
@@ -70,8 +70,9 @@ in
     # Co-located Service Monitoring
     (lib.mkIf serviceEnabled {
       modules.alerting.rules."cloudflare-tunnel-service-down" =
-        # cloudflared is a native systemd service, not a container
-        forgeDefaults.mkSystemdServiceDownAlert "cloudflared" "CloudflareTunnel" "external access gateway";
+        # cloudflared is a native systemd service, not a container. The unit is
+        # named after the tunnel, so it is cloudflared-forge - not cloudflared.
+        forgeDefaults.mkSystemdServiceDownAlert "cloudflared-forge" "CloudflareTunnel" "external access gateway";
     })
   ];
 }

--- a/hosts/forge/services/emqx.nix
+++ b/hosts/forge/services/emqx.nix
@@ -47,9 +47,9 @@ in
     (lib.mkIf serviceEnabled {
       modules.backup.sanoid.datasets.${dataset} = forgeDefaults.mkSanoidDataset "emqx";
 
-      # Service availability alert (emqx is a native systemd service, not container)
+      # Service availability alert (emqx runs as a podman container)
       modules.alerting.rules."emqx-service-down" =
-        forgeDefaults.mkSystemdServiceDownAlert "emqx" "EMQX" "MQTT broker";
+        forgeDefaults.mkSystemdServiceDownAlert "podman-emqx" "EMQX" "MQTT broker";
     })
   ];
 }

--- a/hosts/forge/services/searxng.nix
+++ b/hosts/forge/services/searxng.nix
@@ -76,9 +76,11 @@ in
         };
       };
 
-      # Service-down alert (native systemd service)
+      # Service-down alert. With runInUwsgi the app has no searx.service of its
+      # own - it is served by uwsgi.service (see mainServiceUnit in
+      # modules/nixos/services/searxng/default.nix).
       modules.alerting.rules."searxng-service-down" =
-        forgeDefaults.mkSystemdServiceDownAlert "searx" "SearXNG" "meta search engine";
+        forgeDefaults.mkSystemdServiceDownAlert "uwsgi" "SearXNG" "meta search engine";
 
       # Homepage dashboard contribution
       modules.services.homepage.contributions.searxng = {

--- a/hosts/nas-0/core/monitoring.nix
+++ b/hosts/nas-0/core/monitoring.nix
@@ -59,6 +59,14 @@
       "udp_queues"
       "xfs"
     ];
+
+    # node_systemd_service_restart_total, which the systemd collector leaves off
+    # by default. A crash-looping unit restarts too fast to ever sample as
+    # non-active, so restart churn is the only signal that separates "looping"
+    # from "healthy". Consumed by the SystemdUnitCrashLooping alert, defined on
+    # forge in hosts/forge/core/monitoring.nix and evaluated for every scraped
+    # instance including this one.
+    extraFlags = [ "--collector.systemd.enable-restarts-metrics" ];
   };
 
   # =============================================================================

--- a/hosts/nas-1/core/monitoring.nix
+++ b/hosts/nas-1/core/monitoring.nix
@@ -59,6 +59,14 @@
       "udp_queues"
       "xfs"
     ];
+
+    # node_systemd_service_restart_total, which the systemd collector leaves off
+    # by default. A crash-looping unit restarts too fast to ever sample as
+    # non-active, so restart churn is the only signal that separates "looping"
+    # from "healthy". Consumed by the SystemdUnitCrashLooping alert, defined on
+    # forge in hosts/forge/core/monitoring.nix and evaluated for every scraped
+    # instance including this one.
+    extraFlags = [ "--collector.systemd.enable-restarts-metrics" ];
   };
 
   # =============================================================================

--- a/lib/host-defaults.nix
+++ b/lib/host-defaults.nix
@@ -308,6 +308,54 @@ in
   };
 
   # =============================================================================
+  # Crash-Loop Detection (fully reusable)
+  # =============================================================================
+
+  # mkCrashLoopLimit sizes StartLimitIntervalSec so a flapping unit actually
+  # reaches `failed` instead of restarting forever.
+  #
+  # systemd only marks a unit `failed` once StartLimitBurst starts have occurred
+  # inside StartLimitIntervalSec, and N starts are spread over
+  #
+  #     (N - 1) * (how long a broken start survives + RestartSec)
+  #
+  # The systemd default of 10s / 5 starts is therefore reachable only when a
+  # start dies in under 2.4s, and is unreachable at *any* failure speed once
+  # RestartSec >= 2.5s. A unit that never reaches `failed` keeps cycling through
+  # activating/active, so node_systemd_unit_state{state="active"} == 0 is true
+  # for isolated scrape samples only - it never holds for the 2m that
+  # mkSystemdServiceDownAlert requires, SystemdUnitFailed never sees `failed`,
+  # and the OnFailure=notify@ hook never runs.
+  #
+  # Observed on forge 2026-08-16: home-assistant restarted 367 times over 43
+  # minutes; the longest contiguous run of state != active was 60s against the
+  # 120s `for`. Its alert reached "pending" repeatedly and never fired.
+  #
+  # Arguments (all in seconds):
+  #   restartSec - the unit's RestartSec (0 = systemd's 100ms default)
+  #   failureSec - how long a broken start may survive before dying
+  #   burst      - starts allowed inside the window
+  #
+  # Window = 1.25 * (burst - 1) * (failureSec + restartSec), floored at 60s:
+  # the burst stays reachable for any failure up to failureSec, with 25%
+  # headroom. Raise failureSec for services that die slowly (heavy init,
+  # database migrations) - a window that is too small is precisely the bug.
+  #
+  # Returns systemd.services.<name> attributes, so it merges with the rest of a
+  # unit's definition:
+  #   systemd.services.marginalia = forgeDefaults.mkCrashLoopLimit { restartSec = 5; };
+  mkCrashLoopLimit =
+    { restartSec ? 0
+    , failureSec ? 60
+    , burst ? 5
+    }:
+    {
+      startLimitIntervalSec =
+        lib.max 60 ((5 * (burst - 1) * (failureSec + restartSec) + 3) / 4);
+      startLimitBurst = burst;
+    };
+
+  # =============================================================================
   # Common Tags (fully reusable)
   # =============================================================================
 

--- a/modules/nixos/monitoring.nix
+++ b/modules/nixos/monitoring.nix
@@ -75,9 +75,18 @@ in
       listenAddress = cfg.nodeExporter.listenAddress;
       enabledCollectors = mkDefault cfg.nodeExporter.enabledCollectors;
 
-      extraFlags = mkIf cfg.nodeExporter.textfileCollector.enable [
-        "--collector.textfile.directory=${cfg.nodeExporter.textfileCollector.directory}"
-      ];
+      extraFlags =
+        optionals cfg.nodeExporter.textfileCollector.enable [
+          "--collector.textfile.directory=${cfg.nodeExporter.textfileCollector.directory}"
+        ]
+        # node_systemd_service_restart_total is off by default upstream. Without
+        # it a crash-loop is unobservable: the unit cycles fast enough that
+        # node_systemd_unit_state samples it as active, so restart churn is the
+        # only signal that distinguishes "looping" from "healthy". Consumed by
+        # the SystemdUnitCrashLooping alert.
+        ++ optionals (elem "systemd" config.services.prometheus.exporters.node.enabledCollectors) [
+          "--collector.systemd.enable-restarts-metrics"
+        ];
     };
 
     # Open firewall if requested


### PR DESCRIPTION
## The gap

Home Assistant crash-looped for 43 minutes on 2026-08-16 (367 restarts) against a healthy Prometheus/Alertmanager stack and never fired an alert. Queried over the outage window:

```
node_systemd_unit_state{name="home-assistant.service",state="active"}
  121 samples at 30s step: 112 = 1 (active), 9 = 0
  longest contiguous run of 0: 60 seconds

ALERTS{alertname="HomeAssistantServiceDown"}
  reached "pending" (10 samples), NEVER reached "firing"
```

`mkSystemdServiceDownAlert` is `for = "2m"`. 60s of contiguous zero against a 120s requirement — it could not have fired.

#820 fixed that for Home Assistant. **The same arithmetic applies to every other unit on the host, and none of them had a start limit either.**

systemd only parks a unit in `failed` once `StartLimitBurst` starts occur inside `StartLimitIntervalSec`, and N starts span `(N - 1) * (failure duration + RestartSec)`. The default 10s / 5 window is reachable only for failures under 2.4s, and unreachable at **any** speed once `RestartSec >= 2.5s`. 85 of forge's 99 restarting units were blind to crash-loops on that basis: 29 could never trip the limit, 56 only if a start died within 2.4s.

## The fix, from both directions

**1. Let broken units actually fail.** `forgeDefaults.mkCrashLoopLimit` sizes the window as `1.25 * (burst - 1) * (failureSec + restartSec)`, floored at 60s. Applied to 33 alerted units through one table in `hosts/forge/core/crash-loop-detection.nix` rather than 33 scattered edits.

`RestartSec` is **read from each unit** rather than restated, so the window cannot drift when someone retunes a service. Rendered values:

| RestartSec | window | units |
|---|---|---|
| unset (100ms) | 300 | grafana, home-assistant, gatus, actual, podman-emqx, … |
| 5s | 325 | marginalia, homelab-mcp, replog, zwave-js-ui, ambit, … |
| 10s | 350 | hermes-agent, lading, cooklang, schoolhouse |
| 30s | 450 | beszel-agent |
| unset, `failureSec = 180` | 900 | paperless-{web,consumer,scheduler,task-queue} |

Pre-existing limits (caddy 14400, pgbackrest 2h, postgresql 605, homelab-mcp-actual-sidecar 900) are untouched.

Home Assistant is listed too. Its module keeps the 300/5 `mkDefault` baseline from #820 so any host gets a usable window, while forge's table becomes the owner of the number — which is what that commit's comment invites. The derived value is the same 300, so no behaviour change; verified that a differing host-level value overrides cleanly (600 rendered as a single directive) rather than colliding or duplicating.

**2. Watch churn directly.** `SystemdUnitCrashLooping` — `increase(node_systemd_service_restart_total[10m]) > 5`, for 2m — needs no unit-level change, so it covers the units deliberately left retrying forever. `>5` is chosen so the two alerts don't overlap: limited units park in `failed` after 4 restarts and belong to `SystemdUnitFailed`. This required node_exporter's `--collector.systemd.enable-restarts-metrics`, which is off by default; enabled for forge and both NAS hosts.

### Left restarting forever, on purpose

`cloudflared-forge` (retries until the edge is reachable) and `github-runner-forge` (`Restart=on-success` is the job loop, not a failure loop). Both are covered by the churn alert instead. `postgresql` keeps its existing upstream 605s window.

## Three alerts that could never have fired

Cross-checking every ServiceDown target against forge's real unit names found alerts naming units that don't exist — absent metric, so `== 0` is never true:

- `cloudflared` → the unit is `cloudflared-forge`
- `emqx` → it's a container, `podman-emqx`
- `searx` → with `runInUwsgi` it's served by `uwsgi.service` (the module already knew: `mainServiceUnit` in `modules/nixos/services/searxng/default.nix`)

A new assertion rejects any `mkSystemdServiceDownAlert` target that isn't a real unit.

## Verification

- All 8 host configurations evaluate (`config.system.build.toplevel.drvPath`)
- forge's failing-assertion list is empty
- Both new assertions negative-tested by deliberately breaking a unit name
- `promtool check rules` accepts the new alert
- `nix fmt -- --check .` clean
- Re-audited after each rebase: 44 ServiceDown alerts, none naming a missing unit; the only alerted, restarting units still without a start limit are the two excluded on purpose

## Rebase notes

Rebased twice while open. The Tautulli and Home Assistant `unitConfig` fixes this branch originally carried were dropped in favour of #814 and #820, which landed the same repair independently. #820 also settled the `ReadWritePaths` question this branch had deferred — by removing the inert `mkForce` rather than reviving it, keeping `/mnt/data/media` writable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)