### PR TITLE
fix(zigbee2mqtt): stop discarding serviceConfig via chained `// mkIf`

### DIFF
--- a/modules/nixos/services/zigbee2mqtt/default.nix
+++ b/modules/nixos/services/zigbee2mqtt/default.nix
@@ -671,6 +671,13 @@ in
             after = [ "network-online.target" ] ++ lib.optional cfg.preseed.enable "preseed-${serviceName}.service";
             requires = lib.optional (cfg.preseed.enable && !allowEmptyBootstrap) "preseed-${serviceName}.service";
             wants = [ "network-online.target" ] ++ lib.optional (cfg.preseed.enable && allowEmptyBootstrap) "preseed-${serviceName}.service";
+            # NOTE: use lib.optionalAttrs, NOT mkIf, when merging with `//`.
+            # mkIf returns `{ _type = "if"; condition; content; }`, so `//` splices
+            # `_type = "if"` into the attrset and the module system then treats the
+            # WHOLE definition as an mkIf node, keeping only `content` and silently
+            # discarding every sibling attribute (here: StateDirectory and friends).
+            # optionalAttrs is safe because the conditions depend only on `cfg`,
+            # not on the option being defined.
             serviceConfig = {
               StateDirectory = mkForce serviceName;
               StateDirectoryMode = mkForce "0750";
@@ -678,10 +685,10 @@ in
               RestartSec = mkForce "5s";
               SupplementaryGroups = mkForce (lib.unique cfg.extraGroups);
             }
-            // mkIf needsRuntimeEnv {
+            // lib.optionalAttrs needsRuntimeEnv {
               EnvironmentFile = [ runtimeEnvPath ];
             }
-            // mkIf (loadCredentialEntries != [ ]) {
+            // lib.optionalAttrs (loadCredentialEntries != [ ]) {
               LoadCredential = loadCredentialEntries;
             };
           }


### PR DESCRIPTION
## Problem

`mkIf` returns `{ _type = "if"; condition; content; }`. So `attrs // (mkIf cond { ... })` splices `_type = "if"` into the attrset, and the module system then treats the **whole** definition as an mkIf node — keeping only `content` and silently discarding every sibling attribute.

Same bug class as tautulli (#814) and home-assistant (#820). This PR started out covering home-assistant too, but #820 landed that half independently while this was open; rebased down to the one remaining occurrence in the repo.

## What broke

`zigbee2mqtt` chained **two** `// mkIf`, so the second overwrote the first's `_type`/`condition`/`content` and `serviceConfig` collapsed to nothing but `LoadCredential`. Confirmed against the deployed unit on forge:

| Setting | forge (before) | declared |
|---|---|---|
| `UMask` | `0077` (systemd default) | `0027` |
| `RestartUSec` | `100ms` (nixpkgs default) | `5s` |
| `StateDirectoryMode` | `0700` (nixpkgs default) | `0750` |
| `EnvironmentFiles` | *(empty)* | `/var/lib/zigbee2mqtt/.zigbee2mqtt-env` |

`StateDirectory` and `SupplementaryGroups=dialout` still looked right on the host only because the upstream nixpkgs module sets them itself.

The dropped `EnvironmentFile` is the one that matters: `preStart` generates that file specifically to carry `pan_id`/`ext_pan_id` out of `LoadCredential` and into the process environment, and it was never loaded into the unit.

## Fix

`mkIf` → `lib.optionalAttrs` at both sites, matching tautulli and home-assistant, with the explanatory NOTE comment carried over. Both conditions depend only on `cfg` — never on the option being defined — so `optionalAttrs` is safe (no infinite recursion).

A repo-wide multiline grep for `// mkIf` / `// (mkIf` / `// lib.mkIf` now returns only the explanatory comments in home-assistant.

## Verification

`nix eval` against `nixosConfigurations.forge`, post-fix — every sibling attribute survives:

`StateDirectory`, `StateDirectoryMode=0750`, `UMask=0027`, `RestartSec=5s`, `SupplementaryGroups=["dialout"]`, plus `EnvironmentFile` and `LoadCredential`.

Full `system.build.toplevel` evaluates cleanly. Note forge is not in the CI build matrix, so that check is local-only.

## Follow-up after deploy

Since the env file was never loaded, the Zigbee network has been running on whatever `pan_id`/`ext_pan_id` Z2M fell back to rather than the sops-managed values. Worth checking what the running network actually uses before/after the restart — a changed PAN ID means re-pairing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)