### PR TITLE
fix(home-assistant): restore RequiresMountsFor, stop forcing ReadWritePaths

### DIFF
--- a/modules/nixos/services/home-assistant/default.nix
+++ b/modules/nixos/services/home-assistant/default.nix
@@ -350,9 +350,17 @@ in
 
       # Systemd unit coordination
       systemd.services.${serviceName} = {
+        # NOTE: use lib.optionalAttrs, NOT mkIf, when merging with `//`.
+        # mkIf returns `{ _type = "if"; condition; content; }`, so `//` splices
+        # `_type = "if"` into the attrset and the module system then treats the
+        # WHOLE definition as an mkIf node, keeping only `content` and silently
+        # discarding every sibling attribute (here: RequiresMountsFor).
+        # optionalAttrs is safe because the condition depends only on `config`,
+        # not on the option being defined.
         unitConfig = {
+          # Ensure ZFS mount is available before service starts
           RequiresMountsFor = [ cfg.dataDir ];
-        } // (mkIf (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
+        } // (lib.optionalAttrs (hasCentralizedNotifications && cfg.notifications != null && cfg.notifications.enable) {
           OnFailure = [ "notify@home-assistant-failure:%n.service" ];
         });
         requires = mkIf (cfg.preseed.enable && !allowEmptyBootstrap) [ "preseed-${serviceName}.service" ];
@@ -361,14 +369,15 @@ in
         environment = mkIf (cfg.extraLibs != [ ]) {
           LD_LIBRARY_PATH = lib.makeLibraryPath cfg.extraLibs;
         };
-        serviceConfig =
-          ({
-            ReadWritePaths = mkForce [ cfg.dataDir ];
-            WorkingDirectory = mkForce cfg.dataDir;
-          }
-          // (mkIf (cfg.environmentFiles != [ ]) {
-            EnvironmentFile = cfg.environmentFiles;
-          }));
+        # ReadWritePaths and WorkingDirectory are deliberately left to the
+        # upstream module: it sets WorkingDirectory = configDir (== dataDir)
+        # and ReadWritePaths = [ configDir ] ++ allowlist_external_dirs, so
+        # hosts widen the writable set by declaring allowlist_external_dirs
+        # rather than by overriding here. Forcing a single-element list would
+        # revoke access to those declared paths (on forge, the NAS media share).
+        serviceConfig = mkIf (cfg.environmentFiles != [ ]) {
+          EnvironmentFile = cfg.environmentFiles;
+        };
       };
 
       # Ensure native Home Assistant account follows repo-wide conventions


### PR DESCRIPTION
Two `{ ... } // (mkIf cond { ... })` merge traps in `modules/nixos/services/home-assistant/default.nix`. `mkIf` returns `{ _type = "if"; condition; content; }`, so `//` splices `_type = "if"` into the attrset and the module system reads the whole definition as an mkIf node, keeping only `content` and silently discarding every sibling attribute.

### `unitConfig` — real bug, real fix

`RequiresMountsFor` was being dropped, so Home Assistant could start before its ZFS dataset was mounted. Same bug and same fix as beef64af (tautulli): `lib.optionalAttrs` composes plainly because the condition depends only on `config`, not on the option being defined.

This one was *not* covered by the earlier fix — beef64af touched only `tautulli/default.nix`, and forge's rendered unit had no `RequiresMountsFor` at all.

### `serviceConfig` — dropped rather than repaired

Only `EnvironmentFile` survived; the two `mkForce` lines never applied. Repairing them would have been the behaviour change, not leaving them out:

- Upstream nixpkgs already sets `WorkingDirectory = cfg.configDir`, and this module sets `configDir = cfg.dataDir`, so `mkForce cfg.dataDir` was a no-op regardless.
- Upstream derives `ReadWritePaths = [ configDir ] ++ allowlist_external_dirs`. That is where `/mnt/data/media` comes from — forge declares it via `allowlist_external_dirs` in `hosts/forge/services/home-assistant.nix`. Forcing a single-element list would have revoked HA's write access to the NAS media share and broken the integrations that write there (LLM Vision snapshots, Chime TTS).

So hosts widen the writable set by declaring `allowlist_external_dirs`, not by overriding here. `serviceConfig` is now a plain `mkIf` for `EnvironmentFile`.

### Verification

`nix eval --json .#nixosConfigurations.forge.config.systemd.services.home-assistant.{unitConfig,serviceConfig}`:

- `unitConfig` now contains `RequiresMountsFor: ["/var/lib/home-assistant"]` **and** `OnFailure` (was `OnFailure` only)
- `serviceConfig` is byte-identical to before: `EnvironmentFile: ["/run/secrets/home-assistant/env"]`, `ReadWritePaths: ["/var/lib/home-assistant","/var/lib/home-assistant","/mnt/data/media"]`, `WorkingDirectory: "/var/lib/home-assistant"`

forge is the only host consuming this module.

### Out of scope

`modules/nixos/services/zigbee2mqtt/default.nix:674` has the same trap chained twice, so only the last `mkIf` survives — `StateDirectoryMode` renders `0700` not the forced `0750`, `UMask` renders `0077` not `0027`, and `RestartSec = "5s"` is dropped. Left for a separate PR since restoring those forced values widens group access to `/var/lib/zigbee2mqtt` and needs its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)