### PR TITLE
fix(zigbee2mqtt): restore EnvironmentFile dropped by chained mkIf merge

### DIFF
--- a/modules/nixos/services/zigbee2mqtt/default.nix
+++ b/modules/nixos/services/zigbee2mqtt/default.nix
@@ -671,17 +671,29 @@ in
             after = [ "network-online.target" ] ++ lib.optional cfg.preseed.enable "preseed-${serviceName}.service";
             requires = lib.optional (cfg.preseed.enable && !allowEmptyBootstrap) "preseed-${serviceName}.service";
             wants = [ "network-online.target" ] ++ lib.optional (cfg.preseed.enable && allowEmptyBootstrap) "preseed-${serviceName}.service";
+            # NOTE: use optionalAttrs, NOT mkIf, when merging with `//`.
+            # mkIf returns `{ _type = "if"; condition; content; }`, so `//` splices
+            # `_type = "if"` into the attrset and the module system then treats the
+            # WHOLE definition as an mkIf node, keeping only `content` and silently
+            # discarding every sibling attribute. Chained twice as this was, the
+            # LAST mkIf won outright: only LoadCredential survived, and
+            # EnvironmentFile plus every forced value below was dropped.
+            # optionalAttrs is safe because the conditions depend only on `config`,
+            # not on the option being defined.
+            #
+            # StateDirectoryMode/UMask are deliberately left at upstream's 0700/0077
+            # rather than forced to 0750/0027: the zigbee2mqtt group has no other
+            # members and restic runs as root, so nothing needs group read on
+            # cfg.dataDir.
             serviceConfig = {
               StateDirectory = mkForce serviceName;
-              StateDirectoryMode = mkForce "0750";
-              UMask = mkForce "0027";
               RestartSec = mkForce "5s";
               SupplementaryGroups = mkForce (lib.unique cfg.extraGroups);
             }
-            // mkIf needsRuntimeEnv {
+            // optionalAttrs needsRuntimeEnv {
               EnvironmentFile = [ runtimeEnvPath ];
             }
-            // mkIf (loadCredentialEntries != [ ]) {
+            // optionalAttrs (loadCredentialEntries != [ ]) {
               LoadCredential = loadCredentialEntries;
             };
           }


### PR DESCRIPTION
## Problem

`modules/nixos/services/zigbee2mqtt/default.nix` hit the `attrs // (mkIf ...)` merge trap, chained twice:

```nix
serviceConfig = {
  StateDirectory = mkForce serviceName;
  StateDirectoryMode = mkForce "0750";
  UMask = mkForce "0027";
  RestartSec = mkForce "5s";
  SupplementaryGroups = mkForce (lib.unique cfg.extraGroups);
}
// mkIf needsRuntimeEnv { EnvironmentFile = [ runtimeEnvPath ]; }
// mkIf (loadCredentialEntries != [ ]) { LoadCredential = loadCredentialEntries; };
```

`mkIf cond attrs` evaluates to `{ _type = "if"; condition; content; }`, so `//` splices `_type = "if"` into the attrset and the module system treats the WHOLE definition as an mkIf node, keeping only `content`. With two chained mkIfs the last one wins outright — only `LoadCredential` survived.

Same class of bug as beef64af (tautulli) and the home-assistant fix on `claude/trusting-jackson-6eb52b`.

## This was live on forge, not just latent drift

forge sets both `advanced.panIdFile` and `advanced.extPanIdFile` ([hosts/forge/services/zigbee2mqtt.nix#L86-L87](https://github.com/carpenike/nix-config/blob/main/hosts/forge/services/zigbee2mqtt.nix#L86-L87)), so `needsRuntimeEnv` is **true** and `EnvironmentFile` has been silently dropped in production.

When `panIdFile` is set, the module writes `pan_id = null` into the generated settings and `sanitizeAttrs` strips it — confirmed, `services.zigbee2mqtt.settings.advanced` on forge contains no `pan_id` or `ext_pan_id`. The values were supposed to arrive via `ZIGBEE2MQTT_CONFIG_ADVANCED_PAN_ID` from the env file `preStart` writes, and that env file has never been loaded. `git log -S runtimeEnvPath` dates the breakage to f1e9df70 (2025-12-09), broken from the first commit — so zigbee2mqtt has been running on its built-in PAN ID defaults this whole time.

## Changes

- Both `mkIf` uses → `optionalAttrs` (bare, matching this file's existing style). Safe because the conditions depend only on `config`, not on the option being defined.
- Explanatory NOTE comment, following the beef64af pattern.
- `RestartSec = "5s"` restored — without it the unit fell back to the 100ms default backoff.
- `StateDirectoryMode`/`UMask` mkForce lines **dropped**, keeping upstream's stricter 0700/0077.

Restoring 0750/0027 would have widened group access to `/var/lib/zigbee2mqtt`, and nothing needs it: `users.groups.zigbee2mqtt.members` is empty, no user carries the group in `extraGroups`, and restic runs as root.

## Verification

`nix eval --json .#nixosConfigurations.forge.config.systemd.services.zigbee2mqtt.serviceConfig`:

| key | before | after |
|---|---|---|
| `StateDirectory` | `zigbee2mqtt` | `zigbee2mqtt` |
| `StateDirectoryMode` | `0700` | `0700` (upstream, intentional) |
| `UMask` | `0077` | `0077` (upstream, intentional) |
| `RestartSec` | *absent* | `5s` |
| `SupplementaryGroups` | `["dialout"]` | `["dialout"]` |
| `EnvironmentFile` | *absent* | `["/var/lib/zigbee2mqtt/.zigbee2mqtt-env"]` |
| `LoadCredential` | 4 entries | 4 entries |

`config.system.build.toplevel` still evaluates.

## ⚠️ Deploy note — check before rebuilding forge

This merge is safe; the **deploy** is what needs care. Restoring `EnvironmentFile` hands zigbee2mqtt the real PAN ID from sops for the first time. If it differs from what the coordinator's network was actually formed with, zigbee-herdsman sees a config/adapter mismatch — it will either refuse to start or re-form the network, and a re-form means re-pairing every device.

Check on forge first:

```
sudo cat /run/secrets/zigbee2mqtt/pan_id
sudo jq '.pan_id, .extended_pan_id' /var/lib/zigbee2mqtt/coordinator_backup.json
```

If they don't match, the low-risk path is to update the sops secret to the network's actual PAN ID rather than let the secret force a re-form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)