### PR TITLE
fix(alerting): close the remaining routes to an alert that cannot fire

### DIFF
--- a/hosts/forge/infrastructure/nas-monitoring.nix
+++ b/hosts/forge/infrastructure/nas-monitoring.nix
@@ -198,6 +198,8 @@
       type = "promql";
       alertname = "NASNFSDown";
       expr = ''node_systemd_unit_state{instance=~"nas-.*",name="nfs-server.service",state="active"} == 0'';
+      # Unit lives on the nas-* hosts, not on the host evaluating this rule.
+      systemd = { unit = "nfs-server.service"; external = true; };
       for = "2m";
       severity = "critical";
       labels = { service = "nfs"; category = "availability"; };
@@ -216,6 +218,8 @@
       type = "promql";
       alertname = "NASSanoidFailed";
       expr = ''node_systemd_unit_state{instance=~"nas-.*",name="sanoid.service",state="failed"} == 1'';
+      # Unit lives on the nas-* hosts, not on the host evaluating this rule.
+      systemd = { unit = "sanoid.service"; external = true; };
       for = "5m";
       severity = "high";
       labels = { service = "sanoid"; category = "backup"; };
@@ -230,6 +234,8 @@
       type = "promql";
       alertname = "NASSyncoidFailed";
       expr = ''node_systemd_unit_state{instance=~"nas-.*",name="syncoid.service",state="failed"} == 1'';
+      # Unit lives on the nas-* hosts, not on the host evaluating this rule.
+      systemd = { unit = "syncoid.service"; external = true; };
       for = "5m";
       severity = "high";
       labels = { service = "syncoid"; category = "backup"; };

--- a/hosts/forge/infrastructure/storage.nix
+++ b/hosts/forge/infrastructure/storage.nix
@@ -329,6 +329,7 @@ in
 
     # ZFS Snapshot Age Monitoring (24hr threshold)
     zfs-snapshot-too-old = {
+      type = "promql";
       alertname = "zfs-snapshot-too-old";
       expr = ''
         time() - zfs_snapshot_latest_timestamp > 86400
@@ -345,6 +346,7 @@ in
 
     # ZFS Snapshot Age Critical (48hr threshold)
     zfs-snapshot-critical = {
+      type = "promql";
       alertname = "zfs-snapshot-critical";
       expr = ''
         time() - zfs_snapshot_latest_timestamp > 172800
@@ -389,6 +391,7 @@ in
           node_textfile_mtime_seconds{file=~".*/zfs_snapshots\\.prom"}
         )
       '';
+      systemd.unit = "zfs-snapshot-metrics.timer";
       for = "5m";
       severity = "high";
       labels = { category = "monitoring"; service = "zfs"; };

--- a/hosts/forge/services/frigate.nix
+++ b/hosts/forge/services/frigate.nix
@@ -111,6 +111,7 @@ in
         type = "promql";
         alertname = "Go2RTCServiceDown";
         expr = ''node_systemd_unit_state{name="go2rtc.service",state="active"} == 0'';
+        systemd.unit = "go2rtc.service";
         for = "2m";
         severity = "medium";
         labels = {

--- a/hosts/forge/services/paperless-ai.nix
+++ b/hosts/forge/services/paperless-ai.nix
@@ -978,6 +978,7 @@ in
           type = "promql";
           alertname = "PaperlessAiReprocessFailed";
           expr = ''node_systemd_unit_state{name="paperless-ai-reprocess.service",state="failed"} == 1'';
+          systemd.unit = "paperless-ai-reprocess.service";
           for = "5m";
           severity = "high";
           labels = { service = "paperless-ai"; category = "processing"; };

--- a/hosts/forge/services/paperless.nix
+++ b/hosts/forge/services/paperless.nix
@@ -303,6 +303,7 @@ in
           type = "promql";
           alertname = "PaperlessExporterFailed";
           expr = ''node_systemd_unit_state{name="paperless-exporter.service",state="failed"} == 1'';
+          systemd.unit = "paperless-exporter.service";
           for = "5m";
           severity = "high";
           labels = { service = "paperless"; category = "backup"; };

--- a/hosts/forge/services/pgbackrest.nix
+++ b/hosts/forge/services/pgbackrest.nix
@@ -1362,6 +1362,7 @@ in
           pgbackrest_scrape_timestamp_seconds
         )
       '';
+      systemd.unit = "pgbackrest-metrics.timer";
       for = "10m";
       severity = "high";
       labels = { service = "pgbackrest"; category = "monitoring"; };
@@ -1527,8 +1528,10 @@ in
 
     # pgBackRest Config Generator Failure Monitoring
     pgbackrest-config-generator-failed = {
+      type = "promql";
       alertname = "PgBackRestConfigGeneratorFailed";
       expr = ''node_systemd_unit_state{name="pgbackrest-config-generator.service",state="failed"} == 1'';
+      systemd.unit = "pgbackrest-config-generator.service";
       for = "5m";
       severity = "high";
       labels = { service = "pgbackrest"; category = "config"; };

--- a/hosts/forge/services/postgresql.nix
+++ b/hosts/forge/services/postgresql.nix
@@ -276,6 +276,7 @@ in
           type = "promql";
           alertname = "PostgreSQLServiceDown";
           expr = ''node_systemd_unit_state{name="postgresql.service",state="active"} == 0'';
+          systemd.unit = "postgresql.service";
           for = "2m";
           severity = "critical";
           labels = { service = "postgresql"; category = "service"; };

--- a/hosts/forge/services/tautulli.nix
+++ b/hosts/forge/services/tautulli.nix
@@ -77,6 +77,7 @@ in
         name = "tautulli";
         alertname = "TautulliUnhealthy";
         expr = ''node_systemd_unit_state{name="tautulli-healthcheck.service", state="failed", instance=~".*forge.*"} == 1'';
+        unit = "tautulli-healthcheck.service";
         for = "0m";
         severity = "critical";
         category = "availability";

--- a/lib/monitoring-helpers.nix
+++ b/lib/monitoring-helpers.nix
@@ -118,7 +118,9 @@
       };
     };
 
-  # Generic threshold alert with custom expression
+  # Generic threshold alert with custom expression.
+  # Pass `unit` when the expression pins a single literal systemd unit, so
+  # modules.alerting can assert that unit exists on the host.
   mkThresholdAlert =
     { name
     , alertname
@@ -129,10 +131,12 @@
     , category ? "custom"
     , summary
     , description
+    , unit ? null
     ,
     }: {
       type = "promql";
       inherit alertname expr for severity;
+      systemd.unit = unit;
       labels = {
         inherit service category;
       };

--- a/modules/nixos/alerting/default.nix
+++ b/modules/nixos/alerting/default.nix
@@ -116,7 +116,20 @@ let
             unit = mkOption {
               type = types.nullOr types.str;
               default = null;
-              description = "Target systemd unit (e.g., \"sonarr.service\") for OnFailure wiring.";
+              description = ''
+                Target systemd unit this rule is about (e.g., "sonarr.service"),
+                used for OnFailure wiring and asserted to exist on this host
+                unless `external` is set.
+              '';
+            };
+            external = mkOption {
+              type = types.bool;
+              default = false;
+              description = ''
+                Set when `unit` lives on another host (e.g., alerts scoped with
+                instance=~"nas-.*"), which exempts it from the local unit
+                existence assertion.
+              '';
             };
             onFailure.enable = mkOption {
               type = types.bool;
@@ -321,9 +334,6 @@ in
 
       promqlRules = declaredPromqlRules // churnRules;
 
-      churnUnits = lib.unique (mapAttrsToList (_: rule: rule.restartChurn.unit)
-        (filterAttrs (_: rule: rule.type == "promql" && rule.restartChurn.unit != null) cfg.rules));
-
       prometheusRuleFile = pkgs.writeText "prometheus-alert-rules.yml" (
         lib.generators.toYAML { } {
           groups = [{
@@ -374,27 +384,6 @@ in
             assertion = builtins.hasAttr cfg.receivers.pushover.userSecret config.sops.secrets;
             message = "modules.alerting: Pushover user secret '${cfg.receivers.pushover.userSecret}' not found in sops.secrets. Either define the secret or disable alerting.";
           }
-          # A rule naming a unit that does not exist is worse than no rule: it
-          # matches no series, so it can never fire, while making the service
-          # look monitored. Five such rules were live before this check --
-          # beszel, cloudflared, emqx and searx all pointed at units that were
-          # never defined, and recyclarr had a container alert for a oneshot
-          # that runs under a timer.
-          {
-            assertion =
-              let
-                bad = lib.filter (u: !(config.systemd.services ? ${lib.removeSuffix ".service" u})) churnUnits;
-              in
-              bad == [ ];
-            message =
-              let
-                bad = lib.filter (u: !(config.systemd.services ? ${lib.removeSuffix ".service" u})) churnUnits;
-              in
-              "modules.alerting: rule(s) reference systemd units that are not defined on this host: "
-              + lib.concatStringsSep ", " bad
-              + ". Such rules can never fire. Correct the service name passed to"
-              + " mkSystemdServiceDownAlert/mkServiceDownAlert, or drop the rule.";
-          }
         ]
         ++
         # PromQL rules must have expr set
@@ -403,6 +392,23 @@ in
             {
               assertion = (cfg.rules.${r}.type != "promql") || (cfg.rules.${r}.expr != null);
               message = "modules.alerting.rules.${r}: PromQL rule must set 'expr'.";
+            }
+          )
+          ruleNames)
+        ++
+        # ...and the converse: an expr on a non-promql rule is silently dropped,
+        # because prometheusRuleFile is built from `filterAttrs (type == "promql")`.
+        # `type` defaults to "event", so omitting it next to an expr yields a rule
+        # that looks configured but never reaches Prometheus at all.
+        (map
+          (r:
+            {
+              assertion = (cfg.rules.${r}.expr == null) || (cfg.rules.${r}.type == "promql");
+              message = ''
+                modules.alerting.rules.${r}: sets 'expr' but has type = "${cfg.rules.${r}.type}",
+                so it is filtered out of the Prometheus rule file and can never fire.
+                Set type = "promql", or drop 'expr' if this really is an event rule.
+              '';
             }
           )
           ruleNames)
@@ -416,6 +422,65 @@ in
             }
           )
           ruleNames)
+        ++
+        # A rule naming a unit that does not exist is worse than no rule: it
+        # matches no series, so it can never fire, while making the service look
+        # monitored. Five such rules were live before #824 added this check --
+        # beszel, cloudflared, emqx and searx pointed at units that were never
+        # defined, and recyclarr had a container alert for a timer-driven oneshot.
+        #
+        # Two independent places name a unit, and both are checked here rather
+        # than in separate assertions: restartChurn.unit, which the down-alert
+        # helpers populate and which also generates the paired churn rule, and
+        # systemd.unit, a plain declaration carried by hand-written rules that go
+        # through neither helper. Checking only the former left the hand-written
+        # rules -- including every .timer -- unguarded.
+        (
+          let
+            # Unit suffix -> the config attrset that declares units of that type.
+            # Suffixes absent here (.mount, .swap, .device) are skipped rather than
+            # failed: they are keyed by path or generated by systemd, not declared
+            # under an attrset we can look a name up in. .mount matters especially,
+            # because config.systemd.mounts is a LIST and `?` on a list silently
+            # returns false -- checking it would fail every mount rule.
+            unitScopes = {
+              "service" = config.systemd.services;
+              "timer" = config.systemd.timers;
+              "socket" = config.systemd.sockets;
+              "path" = config.systemd.paths;
+              "target" = config.systemd.targets;
+            };
+            suffixOf = unit: lib.last (lib.splitString "." unit);
+            # Template instances (foo@bar.service) are declared as "foo@".
+            declaredNames = unit:
+              let base = lib.removeSuffix ".${suffixOf unit}" unit;
+              in [ base ] ++ lib.optional (lib.hasInfix "@" base)
+                "${builtins.head (lib.splitString "@" base)}@";
+            # (ruleName, unit, sourceAttr) for every checkable unit reference.
+            claims = lib.concatMap
+              (r:
+                let rule = cfg.rules.${r}; in
+                lib.optional (rule.systemd.unit != null && !rule.systemd.external)
+                  { inherit r; unit = rule.systemd.unit; source = "systemd.unit"; }
+                ++ lib.optional (rule.type == "promql" && rule.restartChurn.unit != null)
+                  { inherit r; unit = rule.restartChurn.unit; source = "restartChurn.unit"; })
+              ruleNames;
+          in
+          map
+            (c: {
+              assertion =
+                !(unitScopes ? ${suffixOf c.unit})
+                || lib.any (n: unitScopes.${suffixOf c.unit} ? ${n}) (declaredNames c.unit);
+              message = ''
+                modules.alerting.rules.${c.r}: ${c.source} '${c.unit}' is not defined on this host.
+                The rule would never fire. Point it at the real unit name (check
+                `systemctl list-units`), or set
+                modules.alerting.rules.${c.r}.systemd.external = true if the unit lives
+                on another host.
+              '';
+            })
+            claims
+        )
         ++
         # Check for duplicate alertnames across all rules
         (
@@ -598,6 +663,19 @@ in
               ];
               # Only inhibit if same dataset and target
               equal = [ "dataset" "target_host" ];
+            }
+            # Same pattern for snapshot age: the 24h (high) and 48h (critical)
+            # thresholds share one metric, so every dataset past 48h trips both.
+            # These alertnames are lowercase and do not match ZFSReplication.*.
+            {
+              source_matchers = [
+                "alertname=\"zfs-snapshot-critical\""
+              ];
+              target_matchers = [
+                "alertname=\"zfs-snapshot-too-old\""
+              ];
+              # Only inhibit the pair describing the same dataset on the same host
+              equal = [ "dataset" "instance" ];
             }
             # Suppress replication noise when the target host is down
             # Requires an InstanceDown alert for the target host

--- a/modules/nixos/deployment-guard.nix
+++ b/modules/nixos/deployment-guard.nix
@@ -669,6 +669,7 @@ in
             nixos_deploy_backup_guard_last_check_timestamp_seconds
           )
         '';
+        systemd.unit = "nixos-deploy-backup-guard-metrics.timer";
         for = "5m";
         severity = "high";
         labels = { service = "nixos-deploy"; category = "monitoring"; };

--- a/modules/nixos/services/beszel/default.nix
+++ b/modules/nixos/services/beszel/default.nix
@@ -282,9 +282,13 @@ in
         environmentFile = hubCfg.environmentFile;
       };
 
-      # Override systemd service for ZFS integration and stable user
-      # Use mkMerge to preserve ExecStart from native module
-      systemd.services.beszel = {
+      # Override systemd service for ZFS integration and stable user.
+      # The upstream unit is named beszel-hub (not beszel) — see
+      # nixos/modules/services/monitoring/beszel-hub.nix. It already applies the
+      # full hardening set (ProtectSystem=strict, ProtectHome=read-only,
+      # PrivateTmp, NoNewPrivileges, ReadWritePaths=dataDir), so only the
+      # DynamicUser/ZFS deltas belong here.
+      systemd.services.beszel-hub = {
         after = [ "local-fs.target" "zfs-mount.service" ];
         wants = [ "zfs-mount.service" ];
 
@@ -295,12 +299,9 @@ in
             User = lib.mkForce hubCfg.user;
             Group = lib.mkForce hubCfg.group;
 
-            # Security hardening
-            ReadWritePaths = [ hubCfg.dataDir ];
-            ProtectSystem = "strict";
-            ProtectHome = true;
-            PrivateTmp = true;
-            NoNewPrivileges = true;
+            # Keep StateDirectory in agreement with the ZFS dataset's declared
+            # mode; systemd's default (0755) would otherwise loosen it.
+            StateDirectoryMode = "0750";
           }
         ];
       };


### PR DESCRIPTION
> **Rebased onto main after #824.** That PR independently fixed the same bug class while this one was open — including one instance I missed (`recyclarr`). Roughly half of this PR was superseded; I took main's side on every conflicting hunk and dropped my `mkSystemdUnitDownAlert` helper. What remains is the part #824 doesn't cover. See "Relationship to #824" below.

## Summary

Two silent-failure modes in the alerting config, plus one live bug that #824's fix does not reach.

An alert rule can look fully configured and still be incapable of firing. #824 closed one route to that (a rule naming a unit that doesn't exist) for rules built by the two down-alert helpers. This closes the remaining routes.

## 1. The beszel hub override is still broken on main

`modules/nixos/services/beszel/default.nix` overrides `systemd.services.beszel`, but the upstream nixpkgs module creates `beszel-hub.service`. NixOS materialises the override as a unit of its own, so the config lands on a unit with no `ExecStart` that nothing starts:

```
nix eval ...systemd.services.beszel.serviceConfig
  -> {DynamicUser:false, User:"beszel", ProtectSystem:"strict", ...}   # no ExecStart at all
nix eval ...systemd.services.beszel-hub.serviceConfig
  -> the real ExecStart, and DynamicUser still true
```

#824 fixed the *alert* that pointed at the same phantom name. **The module override is a separate instance of the same bug and is still live** — the hub runs under `DynamicUser` today, with the ZFS ordering absent and none of its intended hardening. The new assertion doesn't catch it, because it checks alert rules, not module overrides.

Removing the redundant hardening isn't tidying: `ProtectHome = true` would have been a *hard eval error* once the override landed on the real unit, since `true` against upstream's `"read-only"` fails `mergeEqualOption`.

## 2. Unit check didn't reach hand-written rules

#824 keys its assertion on `restartChurn.unit`, which only the two helpers populate. Twelve rules written as plain attrsets name a literal unit and were unguarded. This adds `systemd.unit` as a plain declaration — deliberately *not* `restartChurn.unit`, since a restart-churn alert is meaningless for a timer-driven oneshot — and folds both sources into **one** checker rather than shipping two assertions with different keys and different blind spots.

That also fixes a latent bug: #824's check does `removeSuffix ".service"` then looks the result up in `config.systemd.services`, so a `.timer` is checked against the wrong attrset and always fails. Harmless today (its helpers only emit `.service`), real the moment someone tags a timer.

- `.mount`/`.swap`/`.device` are **skipped, not failed** — `config.systemd.mounts` is a *list*, and `?` on a list silently returns false, so checking it would fail every mount rule.
- `systemd.external` exempts units on another host. Two of the three `nas-*` rules (`nfs-server.service`, `sanoid.service`) would have **passed** a local check because forge happens to declare units by those names — green for entirely the wrong reason.
- Messages name the offending rule and which attribute carried the bad unit.

Coverage on forge: 74 `restartChurn` + 8 `systemd.unit` + 3 external.

## 3. Three rules were never emitted at all

`prometheusRuleFile` is built from `filterAttrs (type == "promql")`, and `type` defaults to `"event"` — so an `expr` written without a type is dropped before Prometheus sees it. The module already asserted the forward direction ("a promql rule must set `expr`"); this adds the converse, and it found three rules that had never once been emitted: `zfs-snapshot-too-old`, `zfs-snapshot-critical`, `pgbackrest-config-generator-failed`.

Their metrics are real — `flake.nix` already asserts the exporter emits `zfs_snapshot_latest_timestamp`, and the sibling `zfs-snapshot-never-created` queries it with the type set correctly. These two were simply missing the line their neighbour had.

## Relationship to #824

| | #824 | This PR |
|---|---|---|
| Four phantom-unit **alerts** | fixed | took main's version |
| `recyclarr` alert | removed | — |
| Restart-churn alerts | added | untouched |
| Unit assertion | helper-built rules, `.service` only | unified: + hand-written rules, suffix-aware |
| beszel **module** override | — | **fixed here** |
| `type`-defaulted-out rules | — | **fixed here** |

The `service` label on the four alerts is now #824's value (`podman-emqx`, `uwsgi`, …). I'd originally preserved the friendly names via a helper split; re-litigating a merged decision inside a conflict resolution isn't the right place for it.

## Reviewer notes

- **One change you may want to drop:** activating both ZFS age rules means every dataset past 48h trips *both* the 24h `high` and the 48h `critical`. The existing inhibit rule for this exact shape matches `alertname=~"ZFSReplication.*"` and these lowercase-hyphenated names slip past it, so I added a matching pair keyed on `dataset`+`instance`. Reasonable to want the doubled signal while these rules are new.
- **`promtool check rules` will not run on this PR.** It's wired in as `system.checks`, which is a direct input of forge's `toplevel` — but forge is a *heavy* host, deliberately excluded from the per-PR build matrix (`.github/workflows/nix-build.yml`). The `flake-check` job here is `nix flake check --no-build`, eval only. So promtool first runs in the nightly **Flake Health** workflow (08:00 UTC, builds the full forge closure) or on `task nix:apply-nixos host=forge` — whichever comes first. I also could not run it locally: it's an `x86_64-linux` derivation and the only builder reachable from my machine is `aarch64-linux`.

  The three newly emitted rules have exprs unchanged from what was already in the tree; only the `type` line is new. All 57 snapshot datasets are newly in scope for the two ZFS age rules — worth watching the first evaluation cycle.
- **Deploy check for beszel.** Upstream ran the hub with `DynamicUser=true` and `StateDirectory=beszel`, which makes systemd relocate state to `/var/lib/private/beszel` via `rename()` — and `/var/lib/beszel` is a ZFS mountpoint, which `rename()` cannot move. The hub may have been failing to start outright rather than merely running unhardened. Before switching:

  ```bash
  systemctl status beszel-hub.service; ls -la /var/lib/beszel /var/lib/private/beszel
  ```

  Data under `/var/lib/private/beszel` must be moved onto the dataset by hand — the reverse migration hits the same mountpoint problem.
- Six rules stay unwired by design: `pgbackrest-backup-failed`, `pgbackrest-expiration-failed`, `syncoid-unit-failed`, `zfs-replication-info-missing`, `systemd-timer-stale`, `systemd-unit-failed` all use regex/wildcard matchers and can't be pinned to one unit.

## Verification

Re-run after the rebase rather than carried over, since the checker was rewritten around #824's data model:

- Unified checker tested in **all three directions** — bad `systemd.unit` `.service`, bad `systemd.unit` `.timer`, bad `restartChurn.unit` via `mkSystemdServiceDownAlert`. Each fires and names the rule.
- Type assertion tested by removing a `type` line.
- All six hosts evaluate clean.
- `nixpkgs-fmt`, `deadnix`, `statix` clean (removed #824's `churnUnits` binding, now unused after unification, which deadnix would have flagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
