### PR TITLE
fix(backup): restore the 2G ceiling sonarr and termix opted out of

### DIFF
--- a/hosts/forge/services/sonarr.nix
+++ b/hosts/forge/services/sonarr.nix
@@ -37,15 +37,19 @@ in
         };
 
         # Enable backups via the custom backup module integration.
-        # Increased memory from default 512M to 1G - Sonarr's 1.3GB dataset
-        # caused OOM kills during restic indexing (2026-02-03)
+        #
+        # No `resources` override: the host default in
+        # hosts/forge/infrastructure/backup.nix (2G/1G) applies. This block used
+        # to pin 1G/512M, which was an INCREASE from the module default of 512M
+        # when it was added for OOM kills during restic indexing (2026-02-03),
+        # but became a DOWNGRADE once the host floor was raised to 2G in
+        # 2026-05. Per-service resources win over the host default -- see the
+        # fallback at modules/nixos/services/backup/default.nix:51 -- so sonarr
+        # stayed at 1G while the other 57 restic jobs moved to 2G, and it was
+        # OOM-killed again on 2026-08-16 loading the repo index.
         backup = forgeDefaults.backup // {
           useSnapshots = true;
           zfsDataset = "tank/services/sonarr";
-          resources = {
-            memory = "1G";
-            memoryReservation = "512M";
-          };
         };
 
         # Enable failure notifications via the custom notifications module.

--- a/hosts/forge/services/termix.nix
+++ b/hosts/forge/services/termix.nix
@@ -43,13 +43,12 @@ in
           # No caddySecurity since Termix has native OIDC
         };
 
-        # Enable backups (increased memory: default 512M triggers OOM during index loading)
-        backup = forgeDefaults.mkBackupWithSnapshots "termix" // {
-          resources = {
-            memory = "1G";
-            memoryReservation = "512M";
-          };
-        };
+        # Enable backups. No `resources` override -- the host default (2G/1G)
+        # applies. The 1G/512M pinned here was an increase over the old 512M
+        # module default, but a downgrade below the 2G host floor set in
+        # 2026-05, and termix was OOM-killed loading the repo index on
+        # 2026-08-16. See the matching note in sonarr.nix.
+        backup = forgeDefaults.mkBackupWithSnapshots "termix";
 
         # Enable failure notifications
         notifications.enable = true;

--- a/modules/nixos/services/backup/default.nix
+++ b/modules/nixos/services/backup/default.nix
@@ -78,6 +78,31 @@ in
 
     # Internal option to share consolidated jobs between submodules
     _internal = {
+      # Single source of truth for a backup job's systemd unit name.
+      #
+      # restic.nix generates the units and monitoring.nix names them in alert
+      # `command` annotations. Those were independent string literals and
+      # drifted: the annotations said `restic-backups-` (plural) against units
+      # that are `restic-backup-` (singular), so every restic alert on forge
+      # shipped a runbook command that matched nothing. Nothing catches this --
+      # #827's unit-existence assertion checks `expr`, not annotations, and
+      # could not have validated these anyway because the job name is a Go
+      # template resolved by Alertmanager, not a literal.
+      #
+      # The plural form was not an obvious typo either: `restic-backups.slice`
+      # is a real unit here (restic.nix), and every job runs inside it.
+      #
+      # Passing the template placeholder through this function is what keeps
+      # the two in step -- see its call in monitoring.nix.
+      unitName = lib.mkOption {
+        internal = true;
+        readOnly = true;
+        type = lib.types.functionTo lib.types.str;
+        default = jobName: "restic-backup-${jobName}";
+        defaultText = lib.literalExpression ''jobName: "restic-backup-''${jobName}"'';
+        description = "Systemd unit name (no suffix) for a restic backup job.";
+      };
+
       allJobs = lib.mkOption {
         internal = true;
         type = lib.types.attrsOf (lib.types.submodule {

--- a/modules/nixos/services/backup/monitoring.nix
+++ b/modules/nixos/services/backup/monitoring.nix
@@ -108,6 +108,11 @@ in
       allJobs = cfg._internal.allJobs;
       enabledJobs = lib.filterAttrs (_name: job: job.enable) allJobs;
 
+      # Unit name for the job an alert fired on. Alertmanager resolves the
+      # placeholder at notification time; passing it through the same function
+      # restic.nix generates units with keeps the runbook commands honest.
+      alertUnit = cfg._internal.unitName "{{ $labels.backup_job }}";
+
       # Generate expected metric filenames
       expectedMetricFiles = lib.mapAttrsToList
         (jobName: _jobDef: "restic_backup_${jobName}.prom")
@@ -264,7 +269,7 @@ in
           annotations = {
             summary = "Restic backup job {{ $labels.backup_job }} failed on {{ $labels.hostname }}";
             description = "Backup to {{ $labels.repository }} failed. Immediate investigation required.";
-            command = "systemctl status restic-backups-{{ $labels.backup_job }}.service && journalctl -u restic-backups-{{ $labels.backup_job }}.service --since '24h'";
+            command = "systemctl status ${alertUnit}.service && journalctl -u ${alertUnit}.service --since '24h'";
           };
         };
 
@@ -279,7 +284,7 @@ in
           annotations = {
             summary = "Restic backup job {{ $labels.backup_job }} hasn't run in ${toString monitoringCfg.alerting.thresholds.backupStaleHours}+ hours on {{ $labels.hostname }}";
             description = "Last successful backup: {{ $value | humanizeDuration }} ago. Check timer status and scheduling.";
-            command = "systemctl status restic-backups-{{ $labels.backup_job }}.timer && systemctl list-timers restic-backups-{{ $labels.backup_job }}.timer";
+            command = "systemctl status ${alertUnit}.timer && systemctl list-timers ${alertUnit}.timer";
           };
         };
 
@@ -297,7 +302,7 @@ in
           annotations = {
             summary = "Restic backup job {{ $labels.backup_job }} has no success metric on {{ $labels.hostname }}";
             description = "The job is declaratively enabled but has not reported a successful backup. Check its timer, service, and metric file.";
-            command = "systemctl status restic-backups-{{ $labels.backup_job }}.timer restic-backups-{{ $labels.backup_job }}.service";
+            command = "systemctl status ${alertUnit}.timer ${alertUnit}.service";
           };
         };
 

--- a/modules/nixos/services/backup/restic.nix
+++ b/modules/nixos/services/backup/restic.nix
@@ -15,6 +15,10 @@ let
   # Use centralized job list from default.nix (includes both discovered and manual jobs)
   allJobs = cfg._internal.allJobs;
 
+  # Shared with monitoring.nix so alert runbook commands cannot drift from the
+  # unit names generated here -- see the option in default.nix.
+  unitName = cfg._internal.unitName;
+
   # Create systemd service for each backup job
   mkBackupService = jobName: jobConfig:
     let
@@ -55,7 +59,7 @@ let
 
     in
     {
-      "restic-backup-${jobName}" = {
+      "${unitName jobName}" = {
         description = "Restic backup for ${jobName}";
         wants = [ "backup.target" ];
         requires = [ "network-online.target" "restic-init-${jobConfig.repository}.service" ];
@@ -558,7 +562,7 @@ in
       # Backup timers
       (lib.mkMerge (lib.mapAttrsToList
         (jobName: jobConfig: {
-          "restic-backup-${jobName}" = {
+          "${unitName jobName}" = {
             description = "Timer for ${jobName} backup";
             wantedBy = [ "timers.target" ];
             timerConfig = {


### PR DESCRIPTION
Two restic backup jobs have been failing since 2026-08-15, and every restic alert has been shipping a runbook command that matches nothing.

## The OOM

`service-sonarr` and `service-termix` are OOM-killed loading the repo index, before any data is written:

```
restic-backup-service-sonarr.service: A process of this unit has been killed by the OOM killer.
restic-backup-service-sonarr.service: Failed with result 'oom-kill'.
... Consumed 19.294s CPU time, 1G memory peak
```

`ResticBackupFailed` (critical) and `ResticBackupStale` have been firing since 18:28, with no successful backup for ~1d21h.

Of 59 restic jobs on forge, these two are the only ones still at `MemoryMax=1G` — every other job is at 2G. Both pin `resources` explicitly, and per-service resources beat the host default via the fallback in [default.nix](modules/nixos/services/backup/default.nix). The override was an **increase** when added (sonarr, 2026-02-03, from the old 512M module default) but became a **downgrade** once [backup.nix](hosts/forge/infrastructure/backup.nix) raised the host floor to 2G/1G in 2026-05 for this exact failure mode — *"restic repositories grow … ~511MB RSS just loading the index"*.

Dropping both blocks lets them inherit the host default:

| job | before | after |
|---|---|---|
| `service-sonarr` | 1G / 512M | **2G / 1G** |
| `service-termix` | 1G / 512M | **2G / 1G** |
| `service-actual` (reference) | 2G / 1G | 2G / 1G |

Neither dataset was unprotected in the meantime — ZFS snapshots and syncoid replication to nas-1 both ran clean throughout. This was a degraded restic tier, not a gap.

One caveat: both peaked at exactly 1G, which *was* the cap, so their true requirement is only known to be >1G. 2G matches the 57 jobs that aren't failing. If it recurs at 2G, the index genuinely needs more than that and the answer is pruning or splitting the repo rather than another bump.

## The dead runbook commands

`monitoring.nix` templated `restic-backups-{{ $labels.backup_job }}` (plural) while `restic.nix` generates `restic-backup-<job>` (singular), so all three restic alerts told you to run:

```
systemctl status restic-backups-service-sonarr.service
-> Unit restic-backups-service-sonarr.service could not be found.
```

This cost real time during today's diagnosis: querying the name the alert gave returned "0 unit files listed", which reads exactly like the entire restic system having disappeared. I briefly concluded that before spotting the singular/plural difference.

Worth noting it isn't an obvious typo — `restic-backups.slice` **is** a real unit here ([restic.nix](modules/nixos/services/backup/restic.nix)), and every job runs inside it. The plural prefix is a plausible name that happens to belong to the slice rather than the units.

No existing check could have caught it. #827's unit-existence assertion keys on `expr`, not annotations — and couldn't have validated these anyway, since the job name is a Go template Alertmanager resolves at notification time, not a literal.

So rather than fix three string literals and leave the next rename to drift again, the unit name moves to `_internal.unitName` and both sides call it: `restic.nix` for the service and timer it generates, `monitoring.nix` with the template placeholder passed straight through. Same function, so they can't diverge.

## Verification

- 57 services and 57 timers, names unchanged, no plural units introduced
- All three annotations render singular; `systemctl status restic-backup-service-sonarr.service` resolves on forge, the plural form does not
- `sonarr`/`termix` resolve to `MemoryMax=2G` / `MemoryLow=1G`
- All six hosts evaluate; nixpkgs-fmt, deadnix and statix clean
- `promtool check rules` — 293 rules, run against forge's Prometheus 3.7.2 CLI

As in #828, `forge` is a heavy host excluded from the per-PR build matrix, so its closure isn't built here — per-PR validation is `nix flake check --no-build` alone. The promtool result above is from running it directly on forge.

## Follow-up

While tracing this I confirmed `modules/nixos/backup.nix` (the `modules.backup.*` namespace) is deprecated and `enable = false` on all six hosts — it generates nothing anywhere, and its `restic-backups-` naming is the likely origin of the annotation bug. Deleting it is worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
