### PR TITLE
fix(beszel): declare the hub backup into the namespace that generates jobs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -814,11 +814,11 @@
                 ];
               in
               # 124 -> 125 and 57 -> 58 below: beszel-hub's backup gained a
-              # restic job (restic-backup-beszel.timer). Its declaration used to
-              # go to the deprecated modules.backup.* namespace, which generates
-              # nothing, so the service had no backup at all. These counts are
-              # tripwires on the deployment guard's timer set -- a backup job
-              # appearing or vanishing should force exactly this review.
+                # restic job (restic-backup-beszel.timer). Its declaration used to
+                # go to the deprecated modules.backup.* namespace, which generates
+                # nothing, so the service had no backup at all. These counts are
+                # tripwires on the deployment guard's timer set -- a backup job
+                # appearing or vanishing should force exactly this review.
               assert builtins.length expectedTimers == 125;
               assert builtins.elem "pgbackrest-incr-backup.timer" expectedTimers;
               assert builtins.elem "restic-backup-service-plex.timer" expectedTimers;

--- a/flake.nix
+++ b/flake.nix
@@ -813,7 +813,13 @@
                   "zfs-snapshot-never-created"
                 ];
               in
-              assert builtins.length expectedTimers == 124;
+              # 124 -> 125 and 57 -> 58 below: beszel-hub's backup gained a
+              # restic job (restic-backup-beszel.timer). Its declaration used to
+              # go to the deprecated modules.backup.* namespace, which generates
+              # nothing, so the service had no backup at all. These counts are
+              # tripwires on the deployment guard's timer set -- a backup job
+              # appearing or vanishing should force exactly this review.
+              assert builtins.length expectedTimers == 125;
               assert builtins.elem "pgbackrest-incr-backup.timer" expectedTimers;
               assert builtins.elem "restic-backup-service-plex.timer" expectedTimers;
               assert builtins.elem "sanoid.timer" expectedTimers;
@@ -822,7 +828,7 @@
               assert builtins.all (name: builtins.hasAttr name forge.modules.alerting.rules) requiredAlerts;
               assert builtins.length (builtins.attrNames snapshotDatasets) == 57;
               assert !(builtins.hasAttr "tank/services" snapshotDatasets);
-              assert builtins.length (builtins.attrNames enabledResticJobs) == 57;
+              assert builtins.length (builtins.attrNames enabledResticJobs) == 58;
               assert builtins.all (name: builtins.hasAttr name forge.modules.alerting.rules) requiredFreshnessAlerts;
               assert pkgs.lib.hasInfix "zfs_snapshot_dataset_info" snapshotMetricsScript;
               assert pkgs.lib.hasInfix "zfs_snapshot_latest_timestamp" snapshotMetricsScript;

--- a/modules/nixos/services/beszel/default.nix
+++ b/modules/nixos/services/beszel/default.nix
@@ -333,7 +333,20 @@ in
       };
 
       # Backup integration
-      modules.backup.restic.jobs.${hubServiceName} = lib.mkIf (hubCfg.backup != null && hubCfg.backup.enable) {
+      # Declared into modules.services.backup (the live namespace), NOT the
+      # deprecated modules.backup.*, whose config block is gated on
+      # modules.backup.enable -- false on every host, so this job was declared
+      # into a module that generates nothing and beszel had no restic backup at
+      # all while reading as configured.
+      #
+      # It cannot be picked up by auto-discovery either. That walks
+      # modules.services.<name> requiring both `enable` and `backup` at the top
+      # level (modules/nixos/services/backup/default.nix), and beszel has
+      # neither: its options live under `hub` and `agent`, so the backup config
+      # sits at modules.services.beszel.hub.backup, one level too deep. Hence a
+      # manual job rather than moving the option -- restructuring beszel's
+      # options to suit discovery would be a much larger change.
+      modules.services.backup.restic.jobs.${hubServiceName} = lib.mkIf (hubCfg.backup != null && hubCfg.backup.enable) {
         enable = true;
         paths = [ hubCfg.dataDir ];
         repository = hubCfg.backup.repository;


### PR DESCRIPTION
`beszel-hub` runs on forge with backup configured, and had **no restic backup job at all**.

Its declaration went to `modules.backup.restic.jobs`, whose config block is gated on `modules.backup.enable` — `false` on all six hosts. The option was set, evaluated clean, and generated nothing. Everywhere you'd look at the config, the service reads as backed up.

## Why discovery didn't catch it

Auto-discovery in [default.nix](modules/nixos/services/backup/default.nix) walks `modules.services.<name>` requiring **both** `enable` and `backup` at the top level. Beszel has neither — its options live under `hub` and `agent`, so the backup config sits at `modules.services.beszel.hub.backup`, one level too deep, and there is no `modules.services.beszel.enable` at all.

That's why this is a manual job in `modules.services.backup.restic.jobs` rather than a moved option. Restructuring beszel's options to fit discovery is a much larger change and belongs with the wider migration.

The job submodules are field-identical between the two namespaces — `enable`, `repository`, `paths`, `tags`, `excludePatterns`, `pre`/`postBackupScript`, `frequency`, `resources`, `useSnapshots`, `zfsDataset` — so only the attribute path changes.

## Scope: beszel is the only service affected

Cross-checking all 26 modules that declare into the deprecated namespace against forge's live jobs first suggested eight gaps. Seven weren't real:

| service | why it's fine |
|---|---|
| frigate, litellm, n8n, open-webui, profilarr | disabled on forge |
| searxng | `backup = null`, so its guarded declaration contributes nothing |
| cooklang-federation | artifact of comparing a hyphenated name against the camelCase attribute — `service-cooklangFederation` exists and is healthy |

The other 18 modules declare into *both* namespaces and are covered by discovery, so their inert declarations are duplicates rather than gaps.

## Verification

- 57 → 58 jobs; `restic-backup-beszel.service` and `.timer` generated
- Job resolves to `paths=["/var/lib/beszel"]`, `repository=nas-primary`, `useSnapshots=true`, `zfsDataset="tank/services/beszel"` — the dataset exists on forge and is the mountpoint for `/var/lib/beszel`
- `resources` 2G/1G, inherited from the host default
- All six hosts evaluate; nixpkgs-fmt, deadnix and statix clean

Beszel was already covered by sanoid snapshots and syncoid replication to nas-1, so this was a missing versioned/offsite tier, not an unprotected dataset. Worth noting it's the second bug of this shape in beszel this week — #827 fixed its systemd override landing on a phantom `beszel.service` — arrived at by a completely unrelated mechanism.

## Follow-up

Deleting the deprecated `modules/nixos/backup.nix` is tracked separately. It looks like a dead-file deletion but is a 26-module migration: its option *definitions* are still consumed across the tree even though its config never runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
