### PR TITLE
refactor(backup): drop service declarations into the namespace that generates nothing

### DIFF
--- a/modules/nixos/services/actual/default.nix
+++ b/modules/nixos/services/actual/default.nix
@@ -304,16 +304,6 @@ in
         extraConfig = cfg.reverseProxy.extraConfig or "";
       };
 
-      # Backup integration
-      modules.backup.restic.jobs.${serviceName} = lib.mkIf (cfg.backup != null && cfg.backup.enable) {
-        enable = true;
-        paths = [ cfg.dataDir ];
-        repository = cfg.backup.repository;
-        tags = cfg.backup.tags or [ "finance" serviceName "budget" ];
-        useSnapshots = cfg.backup.useSnapshots or true;
-        zfsDataset = cfg.backup.zfsDataset or null;
-      };
-
       # Firewall - only allow localhost access (internal service behind reverse proxy)
       networking.firewall.interfaces.lo.allowedTCPPorts = [ cfg.port ];
     })

--- a/modules/nixos/services/cooklang-federation/default.nix
+++ b/modules/nixos/services/cooklang-federation/default.nix
@@ -684,17 +684,6 @@ in
       }
     ))
 
-    (mkIf (cfg.enable && cfg.backup != null && cfg.backup.enable) {
-      modules.backup.restic.jobs.cooklangFederation = {
-        enable = true;
-        repository = cfg.backup.repository;
-        paths = [ cfg.dataDir ];
-        tags = cfg.backup.tags or [ "cooklang" "federation" ];
-        excludePatterns = cfg.backup.excludePatterns or [ "**/cache/**" "**/*.log" ];
-        useSnapshots = cfg.backup.useSnapshots or true;
-      };
-    })
-
     (mkIf (cfg.enable && cfg.preseed.enable) (
       storageHelpers.mkPreseedService {
         serviceName = serviceName;

--- a/modules/nixos/services/cooklang/default.nix
+++ b/modules/nixos/services/cooklang/default.nix
@@ -707,17 +707,6 @@ in
       ];
     })
 
-    (mkIf (cfg.enable && cfg.backup != null && cfg.backup.enable) {
-      modules.backup.restic.jobs.cooklang = {
-        enable = true;
-        repository = cfg.backup.repository;
-        paths = [ cfg.recipeDir ];
-        tags = cfg.backup.tags or [ "cooklang" "recipes" ];
-        excludePatterns = cfg.backup.excludePatterns or [ "**/cache/**" "**/*.log" ];
-        useSnapshots = cfg.backup.useSnapshots or true;
-      };
-    })
-
     (mkIf (cfg.enable && preseedEnabled) (
       storageHelpers.mkPreseedService {
         serviceName = serviceName;

--- a/modules/nixos/services/emqx/default.nix
+++ b/modules/nixos/services/emqx/default.nix
@@ -669,20 +669,6 @@ in
           };
         };
 
-        modules.backup.restic.jobs = lib.mkIf (cfg.backup != null && cfg.backup.enable) {
-          emqx = {
-            enable = true;
-            repository = cfg.backup.repository;
-            frequency = cfg.backup.frequency;
-            retention = cfg.backup.retention;
-            paths = if cfg.backup.paths != [ ] then cfg.backup.paths else [ cfg.dataDir ];
-            excludePatterns = cfg.backup.excludePatterns;
-            useSnapshots = cfg.backup.useSnapshots or true;
-            zfsDataset = cfg.backup.zfsDataset or datasetPath;
-            tags = cfg.backup.tags;
-          };
-        };
-
         modules.services.caddy.virtualHosts."${serviceName}-dashboard" = mkIf (cfg.dashboard.enable && cfg.dashboard.reverseProxy != null && cfg.dashboard.reverseProxy.enable) (
           let
             defaultBackend = {

--- a/modules/nixos/services/frigate/default.nix
+++ b/modules/nixos/services/frigate/default.nix
@@ -410,19 +410,6 @@ in
           };
         };
 
-        modules.backup.restic.jobs.frigate = lib.mkIf (cfg.backup != null && cfg.backup.enable) {
-          enable = true;
-          repository = cfg.backup.repository;
-          paths = [ cfg.dataDir ];
-          excludePatterns = (cfg.backup.excludePatterns or [ ]) ++ [
-            "${recordingsPath}/**"
-            "${cfg.cacheDir}/**"
-          ];
-          frequency = cfg.backup.frequency or "daily";
-          tags = cfg.backup.tags or [ "frigate" "nvr" ];
-          useSnapshots = cfg.backup.useSnapshots or true;
-          zfsDataset = cfg.backup.zfsDataset or (if parentDataset == null then null else "${parentDataset}/frigate");
-        };
       })
 
       # Preseed service for disaster recovery

--- a/modules/nixos/services/gatus/default.nix
+++ b/modules/nixos/services/gatus/default.nix
@@ -510,19 +510,6 @@ in
       extraConfig = cfg.reverseProxy.extraConfig or "";
     };
 
-    # Prometheus scrape config (Gatus has native /metrics)
-    # Auto-discovery via observability module will pick this up from cfg.metrics
-
-    # Backup integration
-    modules.backup.restic.jobs.${serviceName} = lib.mkIf (cfg.backup != null && cfg.backup.enable) {
-      enable = true;
-      paths = [ cfg.dataDir ];
-      repository = cfg.backup.repository;
-      tags = cfg.backup.tags or [ "monitoring" serviceName "sqlite" ];
-      useSnapshots = cfg.backup.useSnapshots or true;
-      zfsDataset = cfg.backup.zfsDataset or null;
-    };
-
     # Firewall - only allow localhost access (internal service)
     networking.firewall.interfaces.lo.allowedTCPPorts = [ cfg.port ];
   };

--- a/modules/nixos/services/go2rtc/default.nix
+++ b/modules/nixos/services/go2rtc/default.nix
@@ -307,17 +307,6 @@ in
         extraConfig = cfg.reverseProxy.extraConfig;
       };
 
-      # Backup integration (if configured)
-      modules.backup.restic.jobs.go2rtc = lib.mkIf (cfg.backup != null && cfg.backup.enable) {
-        enable = true;
-        repository = cfg.backup.repository;
-        paths = [ cfg.dataDir ];
-        frequency = cfg.backup.frequency;
-        retention = cfg.backup.retention;
-        tags = cfg.backup.tags or [ "go2rtc" "streaming" "config" ];
-        useSnapshots = cfg.backup.useSnapshots;
-        zfsDataset = cfg.backup.zfsDataset;
-      };
     }
 
     # Preseed service for disaster recovery

--- a/modules/nixos/services/grafana-oncall/default.nix
+++ b/modules/nixos/services/grafana-oncall/default.nix
@@ -664,24 +664,6 @@ in
         extraConfig = cfg.reverseProxy.extraConfig or null;
       };
 
-      # NOTE: Homepage and Gatus contributions should be set in host config,
-      # not auto-generated here. See hosts/forge/README.md for contribution pattern.
-
-      # Backup job registration
-      modules.backup.restic.jobs.${serviceName} = mkIf (cfg.backup != null && cfg.backup.enable) {
-        enable = true;
-        repository = cfg.backup.repository;
-        frequency = cfg.backup.frequency or "daily";
-        retention = cfg.backup.retention or { };
-        paths = [ cfg.dataDir ];
-        excludePatterns = (cfg.backup.excludePatterns or [ ]) ++ [
-          "redis/dump.rdb" # Redis can be recreated
-          "*.log"
-        ];
-        useSnapshots = cfg.backup.useSnapshots or true;
-        zfsDataset = cfg.backup.zfsDataset or datasetPath;
-        tags = cfg.backup.tags or [ serviceName ];
-      };
     })
 
     # Preseed service for disaster recovery (separate mkMerge block)

--- a/modules/nixos/services/kometa/default.nix
+++ b/modules/nixos/services/kometa/default.nix
@@ -939,22 +939,6 @@ in
         };
       };
 
-      # =============================================================================
-      # Backup Integration
-      # =============================================================================
-
-      modules.backup.restic.jobs = lib.mkIf (cfg.backup != null && cfg.backup.enable) {
-        kometa = {
-          enable = true;
-          paths = [ cfg.dataDir ];
-          repository = cfg.backup.repository;
-          frequency = cfg.backup.frequency;
-          tags = cfg.backup.tags;
-          excludePatterns = cfg.backup.excludePatterns;
-          useSnapshots = cfg.backup.useSnapshots;
-          zfsDataset = cfg.backup.zfsDataset;
-        };
-      };
     })
 
     # Preseed service

--- a/modules/nixos/services/litellm/default.nix
+++ b/modules/nixos/services/litellm/default.nix
@@ -971,24 +971,6 @@ in
       };
 
       # ========================================================================
-      # Backup Integration
-      # ========================================================================
-
-      modules.backup.restic.jobs = mkIf (cfg.backup != null && cfg.backup.enable) {
-        ${serviceName} = {
-          enable = true;
-          repository = cfg.backup.repository;
-          frequency = cfg.backup.frequency;
-          retention = cfg.backup.retention;
-          paths = if cfg.backup.paths != [ ] then cfg.backup.paths else [ cfg.dataDir ];
-          excludePatterns = cfg.backup.excludePatterns;
-          useSnapshots = cfg.backup.useSnapshots or true;
-          zfsDataset = cfg.backup.zfsDataset or datasetPath;
-          tags = cfg.backup.tags;
-        };
-      };
-
-      # ========================================================================
       # Reverse Proxy (Caddy) Integration
       # ========================================================================
 

--- a/modules/nixos/services/mealie/default.nix
+++ b/modules/nixos/services/mealie/default.nix
@@ -623,19 +623,6 @@ mylib.mkContainerService {
           (cfg.reverseProxy.backend or { }));
       };
 
-      # Backup integration using the standardized restic job pattern
-      modules.backup.restic.jobs.mealie = mkIf (cfg.backup != null && cfg.backup.enable) {
-        enable = true;
-        repository = cfg.backup.repository;
-        frequency = cfg.backup.frequency;
-        retention = cfg.backup.retention;
-        paths = if cfg.backup.paths != [ ] then cfg.backup.paths else [ cfg.dataDir ];
-        excludePatterns = cfg.backup.excludePatterns;
-        tags = cfg.backup.tags;
-        useSnapshots = cfg.backup.useSnapshots or true;
-        zfsDataset = cfg.backup.zfsDataset or cfg.datasetPath;
-      };
-
       # Preserve the pre-factory notification wording
       modules.notifications.templates."mealie-failure" =
         mkIf (config.modules.notifications.enable or false && cfg.notifications != null && cfg.notifications.enable) {

--- a/modules/nixos/services/n8n/default.nix
+++ b/modules/nixos/services/n8n/default.nix
@@ -246,16 +246,6 @@ in
       extraConfig = cfg.reverseProxy.extraConfig or "";
     };
 
-    # Backup integration
-    modules.backup.restic.jobs.${serviceName} = lib.mkIf (cfg.backup != null && cfg.backup.enable) {
-      enable = true;
-      paths = if cfg.backup.paths != [ ] then cfg.backup.paths else [ cfg.dataDir ];
-      repository = cfg.backup.repository;
-      tags = cfg.backup.tags or [ "automation" serviceName "sqlite" ];
-      useSnapshots = cfg.backup.useSnapshots or true;
-      zfsDataset = cfg.backup.zfsDataset or null;
-    };
-
     # Firewall - only allow localhost access (behind reverse proxy)
     networking.firewall.interfaces.lo.allowedTCPPorts = [ cfg.port ];
   };

--- a/modules/nixos/services/open-webui/default.nix
+++ b/modules/nixos/services/open-webui/default.nix
@@ -661,17 +661,6 @@ in
         # Note: Do NOT use Caddy auth layer - Open WebUI handles auth via OIDC
       };
 
-      # Backup integration
-      modules.backup.restic.jobs.${serviceName} = mkIf (cfg.backup != null && cfg.backup.enable) {
-        enable = true;
-        paths = [ cfg.dataDir ];
-        repository = cfg.backup.repository;
-        tags = cfg.backup.tags or [ serviceName "ai-chat" ];
-        excludePatterns = cfg.backup.excludePatterns or [
-          "**/cache/**"
-          "**/*.log"
-        ];
-      };
     })
   ];
 }

--- a/modules/nixos/services/plex/default.nix
+++ b/modules/nixos/services/plex/default.nix
@@ -514,20 +514,6 @@ in
         mode = "0750"; # rwxr-x--- allows backup user (group member) to read
       };
 
-      # Backup auto-registration (shared between both modes)
-      modules.backup.restic.jobs.plex = lib.mkIf (cfg.backup != null && cfg.backup.enable) {
-        enable = true;
-        repository = cfg.backup.repository;
-        paths = [ cfg.dataDir ];
-        excludePatterns = cfg.backup.excludePatterns;
-        tags = cfg.backup.tags;
-        resources = {
-          memory = "512M";
-          memoryReservation = "256M";
-          cpus = "1.0";
-        };
-      };
-
       # Firewall configuration (shared between both modes)
       networking.firewall = lib.mkMerge [
         # Always allow localhost access (for Caddy reverse proxy)

--- a/modules/nixos/services/profilarr/default.nix
+++ b/modules/nixos/services/profilarr/default.nix
@@ -255,19 +255,6 @@ in
           };
         };
 
-        # Backup integration using standardized restic pattern
-        modules.backup.restic.jobs = lib.mkIf (cfg.backup != null && cfg.backup.enable) {
-          profilarr = {
-            enable = true;
-            paths = [ cfg.dataDir ];
-            repository = cfg.backup.repository;
-            frequency = cfg.backup.frequency;
-            tags = cfg.backup.tags;
-            excludePatterns = cfg.backup.excludePatterns;
-            useSnapshots = cfg.backup.useSnapshots;
-            zfsDataset = cfg.backup.zfsDataset;
-          };
-        };
       })
 
       # Preseed service

--- a/modules/nixos/services/recyclarr/default.nix
+++ b/modules/nixos/services/recyclarr/default.nix
@@ -807,19 +807,6 @@ in
         };
       };
 
-      # Backup integration using standardized restic pattern
-      modules.backup.restic.jobs = lib.mkIf (cfg.backup != null && cfg.backup.enable) {
-        recyclarr = {
-          enable = true;
-          paths = [ cfg.dataDir ];
-          repository = cfg.backup.repository;
-          frequency = cfg.backup.frequency;
-          tags = cfg.backup.tags;
-          excludePatterns = cfg.backup.excludePatterns;
-          useSnapshots = cfg.backup.useSnapshots;
-          zfsDataset = cfg.backup.zfsDataset;
-        };
-      };
     })
 
     # Preseed service

--- a/modules/nixos/services/scrypted/default.nix
+++ b/modules/nixos/services/scrypted/default.nix
@@ -664,20 +664,6 @@ in
             "Scrypted runs privileged with hardware passthrough; NVR recordings are written as uid 0";
         };
 
-        modules.backup.restic.jobs.${serviceName} = lib.mkIf (cfg.backup != null && cfg.backup.enable) {
-          enable = true;
-          repository = cfg.backup.repository;
-          paths = if (cfg.backup.paths != [ ]) then cfg.backup.paths else [ cfg.dataDir ];
-          excludePatterns = (cfg.backup.excludePatterns or [ ]) ++ lib.optionals cfg.nvr.enable [ "${cfg.nvr.path}/**" ];
-          frequency = cfg.backup.frequency;
-          retention = cfg.backup.retention;
-          tags = if (cfg.backup.tags != [ ]) then cfg.backup.tags else [ "scrypted" "nvr" "config" ];
-          useSnapshots = cfg.backup.useSnapshots;
-          zfsDataset = cfg.backup.zfsDataset;
-          preBackupScript = cfg.backup.preBackupScript;
-          postBackupScript = cfg.backup.postBackupScript;
-        };
-
         # EMQX MQTT integration - auto-register user and ACLs
         modules.services.emqx.integrations.${serviceName} = lib.mkIf
           (cfg.mqtt.enable && cfg.mqtt.registerEmqxIntegration && cfg.mqtt.passwordFile != null)

--- a/modules/nixos/services/searxng/default.nix
+++ b/modules/nixos/services/searxng/default.nix
@@ -331,16 +331,6 @@ in
         extraConfig = cfg.reverseProxy.extraConfig or "";
       };
 
-      # Backup integration
-      modules.backup.restic.jobs.${serviceName} = mkIf (cfg.backup != null && cfg.backup.enable) {
-        enable = true;
-        paths = [ cfg.dataDir ];
-        repository = cfg.backup.repository;
-        tags = cfg.backup.tags or [ "infrastructure" serviceName "search" ];
-        useSnapshots = cfg.backup.useSnapshots or true;
-        zfsDataset = cfg.backup.zfsDataset or null;
-      };
-
       # Firewall - only allow localhost access (internal service via reverse proxy)
       networking.firewall.interfaces.lo.allowedTCPPorts = [ cfg.port ];
     })

--- a/modules/nixos/services/seerr/default.nix
+++ b/modules/nixos/services/seerr/default.nix
@@ -95,18 +95,5 @@ mylib.mkContainerService {
       serviceConfig.RestartSec = "10s";
     };
 
-    # Backup integration using the standardized restic job pattern
-    modules.backup.restic.jobs = lib.mkIf (cfg.backup != null && cfg.backup.enable) {
-      seerr = {
-        enable = true;
-        paths = [ cfg.dataDir ];
-        repository = cfg.backup.repository;
-        frequency = cfg.backup.frequency;
-        tags = cfg.backup.tags;
-        excludePatterns = cfg.backup.excludePatterns;
-        useSnapshots = cfg.backup.useSnapshots;
-        zfsDataset = cfg.backup.zfsDataset;
-      };
-    };
   };
 }

--- a/modules/nixos/services/tdarr/default.nix
+++ b/modules/nixos/services/tdarr/default.nix
@@ -435,19 +435,6 @@ in
           extraConfig = cfg.reverseProxy.extraConfig;
         };
 
-        # Backup integration using standardized restic pattern (ONLY config/database, NOT cache)
-        modules.backup.restic.jobs = lib.mkIf (cfg.backup != null && cfg.backup.enable) {
-          tdarr = {
-            enable = true;
-            paths = [ cfg.dataDir ]; # Only backup config/database, not cache
-            repository = cfg.backup.repository;
-            frequency = cfg.backup.frequency;
-            tags = cfg.backup.tags;
-            excludePatterns = cfg.backup.excludePatterns;
-            useSnapshots = cfg.backup.useSnapshots;
-            zfsDataset = cfg.backup.zfsDataset;
-          };
-        };
       })
 
       # Preseed service

--- a/modules/nixos/services/teslamate/default.nix
+++ b/modules/nixos/services/teslamate/default.nix
@@ -643,20 +643,6 @@ in
         };
       };
 
-      modules.backup.restic.jobs = lib.mkIf (cfg.backup != null && cfg.backup.enable) {
-        teslamate = {
-          enable = true;
-          repository = cfg.backup.repository;
-          frequency = cfg.backup.frequency;
-          retention = cfg.backup.retention;
-          paths = if cfg.backup.paths != [ ] then cfg.backup.paths else [ cfg.dataDir ];
-          excludePatterns = cfg.backup.excludePatterns;
-          useSnapshots = cfg.backup.useSnapshots or true;
-          zfsDataset = cfg.backup.zfsDataset or datasetPath;
-          tags = cfg.backup.tags;
-        };
-      };
-
       modules.services.caddy.virtualHosts.${serviceName} = mkIf (cfg.reverseProxy != null && cfg.reverseProxy.enable) (
         let
           defaultBackend = {

--- a/modules/nixos/services/thelounge/default.nix
+++ b/modules/nixos/services/thelounge/default.nix
@@ -345,16 +345,6 @@ in
         extraConfig = cfg.reverseProxy.extraConfig or "";
       };
 
-      # Backup integration
-      modules.backup.restic.jobs.${serviceName} = lib.mkIf (cfg.backup != null && cfg.backup.enable) {
-        enable = true;
-        paths = [ cfg.dataDir ];
-        repository = cfg.backup.repository;
-        tags = cfg.backup.tags or [ "communication" serviceName "irc" ];
-        useSnapshots = cfg.backup.useSnapshots or true;
-        zfsDataset = cfg.backup.zfsDataset or null;
-      };
-
       # Firewall - only allow localhost access (internal service behind reverse proxy)
       networking.firewall.interfaces.lo.allowedTCPPorts = [ cfg.port ];
     })

--- a/modules/nixos/services/zigbee2mqtt/default.nix
+++ b/modules/nixos/services/zigbee2mqtt/default.nix
@@ -630,17 +630,6 @@ in
           mode = "0750";
         };
 
-        modules.backup.restic.jobs.${serviceName} = mkIf (cfg.backup != null && cfg.backup.enable) {
-          enable = true;
-          repository = cfg.backup.repository;
-          frequency = cfg.backup.frequency;
-          tags = cfg.backup.tags;
-          paths = [ cfg.dataDir ];
-          excludePatterns = cfg.backup.excludePatterns;
-          useSnapshots = cfg.backup.useSnapshots;
-          zfsDataset = cfg.backup.zfsDataset;
-        };
-
         networking.firewall.interfaces.lo.allowedTCPPorts =
           [ cfg.frontend.port ];
 

--- a/modules/nixos/services/zwave-js-ui/default.nix
+++ b/modules/nixos/services/zwave-js-ui/default.nix
@@ -399,17 +399,6 @@ in
           in
           baseDataset;
 
-        modules.backup.restic.jobs.${serviceName} = mkIf (cfg.backup != null && cfg.backup.enable) {
-          enable = true;
-          repository = cfg.backup.repository;
-          frequency = cfg.backup.frequency;
-          tags = cfg.backup.tags;
-          paths = [ cfg.dataDir ];
-          excludePatterns = cfg.backup.excludePatterns;
-          useSnapshots = cfg.backup.useSnapshots;
-          zfsDataset = cfg.backup.zfsDataset;
-        };
-
         networking.firewall.interfaces.lo.allowedTCPPorts = [ cfg.ui.port ];
 
         users.groups.${cfg.group} = { };


### PR DESCRIPTION
## Why

Twenty-four service modules declared a restic job into `modules.backup.restic.jobs.<name>`. That namespace's config block is gated on `modules.backup.enable`, which is `false` on every host, so **none of these declarations ever produced a systemd unit**. They evaluated cleanly and generated nothing — the same silent failure that left beszel-hub with no restic job until #830.

This is the first of two PRs retiring `modules/nixos/backup.nix`. It removes the consumers so the module can be deleted in the follow-up.

## Audit: no backup was lost

Each of the 24 declarations was checked individually rather than assumed:

| Group | Count | Status |
|---|---|---|
| Already covered by a live `service-<name>` job from auto-discovery | 18 | Duplicate — discovery reads the same `cfg.backup.*` values these blocks re-projected |
| No discovered job, but service disabled on every host | 6 | Nothing to lose |

The 18 duplicates: actual, cooklang, cooklangFederation, emqx, gatus, go2rtc, grafana-oncall, kometa, mealie, plex, recyclarr, scrypted, seerr, tdarr, teslamate, thelounge, zigbee2mqtt, zwave-js-ui.

The 6 disabled: frigate, litellm, n8n, open-webui, profilarr, searxng. `searxng` is enabled on forge but sets `backup = null`, an explicit opt-out that gated the old declaration too.

**No real gaps were found, so nothing is migrated — this is a pure deletion.**

### One near-miss worth recording

`cooklang` looked like a genuine gap. Its declaration backed up `recipeDir` (`/data/cooklang/recipes`) while discovery derives `paths` from `dataDir` (`/var/lib/cooklang`).

It is not one. `restic.nix:28-35` replaces `paths` wholesale with the dataset clone mount when `useSnapshots && zfsDataset != null`, and cooklang's discovered job has both. The recipes are backed up via the `tank/services/cooklang` clone regardless of what `paths` says.

Corollary: `paths` is dead config on any snapshot-based job. Worth knowing before trusting it in a future review.

## Verification

- `modules.services.backup._internal.allJobs` dumped for all six hosts before and after — **JSON byte-identical**, 58 jobs on forge and 0 elsewhere
- All eight `nixosConfigurations` evaluate to a toplevel
- `nix flake check --no-build` passes
- nixpkgs-fmt, deadnix, statix clean across all 24 files

24 files changed, 305 deletions(-) — no insertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
