### PR TITLE
fix(ci): build every PR, not only those already targeting main

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -3,8 +3,28 @@ name: Build Nix systems
 on:
   workflow_dispatch:  # Manual trigger only
   pull_request:
-    branches:
-      - main
+    # Deliberately NOT filtered on `branches: [main]`.
+    #
+    # With that filter, a stacked PR based on another feature branch never
+    # triggered this workflow at all. Retargeting it onto main afterwards
+    # emits only `pull_request.edited` -- the head SHA is unchanged, so there
+    # is no `synchronize` -- and `edited` is not in the default trigger types
+    # ([opened, synchronize, reopened]). The PR then sat at
+    # mergeStateStatus=CLEAN with just Nix Lint / Pre-commit Checks green
+    # while flake-check and every nix-build matrix job had *never* run. That
+    # is a merge-on-green trap: CLEAN that reads as fully validated but
+    # carries zero build and zero eval validation. It nearly landed the
+    # deletion of a 2,386-line module unbuilt (see #831 / #832).
+    #
+    # Building every PR regardless of base closes it at the source: a stacked
+    # PR is validated from the moment it opens, so retargeting is a non-event
+    # and no `edited` handling is needed. Adding `edited` instead would have
+    # been worse -- it also fires on every title/body edit, and guarding those
+    # into skipped jobs makes GitHub report them as success, which would flip
+    # a red PR green on a typo fix.
+    #
+    # Cost: PRs targeting a non-main base now run the matrix. That is the
+    # intended trade -- a stacked PR should be validated, not exempt.
     paths:
       # Only trigger on actual Nix changes, NOT workflow changes
       - "**.nix"


### PR DESCRIPTION
## The bug

`nix-build.yml` filtered on `branches: [main]`, which silently exempted stacked PRs from **all** build and eval validation while still letting them report as mergeable.

1. A PR based on another feature branch doesn't match the filter, so this workflow never runs for it.
2. The parent merges; the PR is retargeted onto `main`. GitHub emits `pull_request.edited` **and nothing else** — the head SHA is unchanged, so there's no `synchronize` — and `edited` isn't in the default trigger types (`[opened, synchronize, reopened]`). The workflow still doesn't run.
3. The PR now reports `mergeStateStatus=CLEAN` with only `Nix Lint` and `Pre-commit Checks` green, while `flake-check` and every `nix-build` matrix job have **never executed**.

`CLEAN` reads as fully validated, so this is a merge-on-green trap rather than a visible gap.

It's worse than it looks for the heavy hosts: `forge` and `luna` are excluded from the per-PR build matrix by design, and `nix flake check --no-build` is the only validation they ever get — and `flake-check` lives in this same workflow, so it's skipped too.

This was found live: #832 reached `CLEAN` with zero validation while deleting a 2,386-line NixOS module.

## The fix

Drop the filter. A stacked PR is now built from the moment it opens, against whatever base it has, so retargeting is a non-event and no `edited` handling is needed.

**Cost:** PRs targeting a non-main base now run the matrix. That's the intended trade — a stacked PR should be validated, not exempt.

## Why not add `edited` to the trigger types

Considered and rejected. `edited` also fires on every title and body edit, so it would launch the multi-host matrix on typo fixes unless guarded — and guarding those runs into skipped jobs **reintroduces the same class of bug**: GitHub reports a skipped job as success, and the latest check run per name wins, so editing the title of a red PR would flip it green.

That approach also needs a concurrency-group workaround, since group membership is evaluated before any job `if:` — a no-op run would otherwise join the per-PR group and cancel an in-flight build under `cancel-in-progress: true`. Dropping the filter needs none of that.

## Sibling workflows — checked, no change needed

`nix-lint.yml` (lines 3-5) and `pre-commit.yml` (lines 9-14) declare **no `branches:` filter at all**. That's why they ran on #832 while its base was still a feature branch. They never had this trap.

## Verification

- `actionlint` clean (exit 0)
- Parsed the result with `yq` to confirm `types` is back to default, the concurrency expression is unchanged, and no job carries an `if:` guard — the only delta vs `main` is the removed filter plus the explanatory comment
- The `opened` / `synchronize` / `reopened` path is byte-for-byte unchanged in behavior

**Not verifiable here:** this workflow's `paths` filter deliberately excludes workflow files (`**.nix`, `flake.lock`, `pkgs/_sources/**` only), so this PR cannot trigger its own build. The fix is proven by the next stacked PR, not by CI on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
