### PR TITLE
fix(backup): delete the retention option nothing reads, guard the paths nothing uses

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -101,6 +101,29 @@ task nix:apply-nixos host=forge NIXOS_DOMAIN=holthome.net
 nix flake check
 ```
 
+> **On an Apple Silicon Mac, this does not check what you think it does.**
+>
+> `nix flake check` only evaluates outputs for the *current* system. On
+> `aarch64-darwin` it skips every `x86_64-linux` check and says so in one line
+> that is easy to miss:
+>
+> ```
+> warning: The check omitted these incompatible systems: aarch64-linux, x86_64-linux
+> ```
+>
+> The Linux checks are the ones that matter here. `deployment-backup-guard`
+> holds the tripwire assertions on forge's timer, restic-job and snapshot-dataset
+> counts, so a change that adds or removes a backup job passes a clean local
+> `nix flake check` and is only caught in CI. Evaluate them explicitly:
+>
+> ```bash
+> nix eval --raw .#checks.x86_64-linux.deployment-backup-guard.drvPath
+> ```
+>
+> Evaluating the `.drvPath` is enough to fire the assertions — it does not build
+> anything, so it works fine on aarch64 where the derivation itself cannot be
+> realised. Substitute any other name from `nix eval .#checks.x86_64-linux --apply builtins.attrNames`.
+
 ### Available Tasks
 
 ```bash

--- a/lib/types/backup.nix
+++ b/lib/types/backup.nix
@@ -29,31 +29,28 @@ in
         description = "Backup frequency";
       };
 
-      retention = mkOption {
-        type = types.submodule {
-          options = {
-            daily = mkOption {
-              type = types.int;
-              default = 7;
-              description = "Number of daily backups to retain";
-            };
-
-            weekly = mkOption {
-              type = types.int;
-              default = 4;
-              description = "Number of weekly backups to retain";
-            };
-
-            monthly = mkOption {
-              type = types.int;
-              default = 6;
-              description = "Number of monthly backups to retain";
-            };
-          };
-        };
-        default = { };
-        description = "Backup retention policy";
-      };
+      # NOTE: there is deliberately no per-service `retention` option here.
+      #
+      # One existed and was never wired to anything: the auto-discovery in
+      # modules/nixos/services/backup/default.nix does not map it, and the
+      # `_internal.allJobs` submodule has no such field, so restic's
+      # forget/prune (modules/nixos/services/backup/restic.nix) has only ever
+      # applied `modules.services.backup.globalSettings.retention`. Forty-six
+      # services on forge carried a declared 7/4/6 that did nothing.
+      #
+      # It was removed rather than implemented on purpose. The declared values
+      # were the shared default everywhere -- no host ever customised them --
+      # and the effective global policy is strictly more generous (14 daily /
+      # 8 weekly / 6 monthly / 2 yearly). Honouring the per-service values
+      # would therefore have *shortened* retention on every one of those
+      # services and made the next `restic forget` prune snapshots that exist
+      # today. A dead option is worth deleting; it is not worth a silent
+      # destructive change.
+      #
+      # Set retention on `modules.services.backup.globalSettings.retention`.
+      # If per-service retention is ever genuinely wanted, it has to be
+      # threaded through discovery, the allJobs submodule, and the forget
+      # command together -- and rolled out knowing it deletes snapshots.
 
       preBackupScript = mkOption {
         type = types.nullOr types.lines;

--- a/modules/nixos/services/backup/default.nix
+++ b/modules/nixos/services/backup/default.nix
@@ -62,6 +62,20 @@ let
   # Combine discovered jobs with manual jobs - this is the single source of truth
   allJobs = discoverServiceBackups // (cfg.restic.jobs or { });
 
+  # Enabled services that hand-declare backup.paths while also using ZFS
+  # snapshots. restic.nix discards those paths in favour of the dataset clone,
+  # so the declaration is a no-op -- see the assertion below.
+  declaredPathsUnderSnapshots = lib.attrNames (lib.filterAttrs
+    (_name: service:
+      (service.enable or false) &&
+      (service.backup or null) != null &&
+      (service.backup.enable or false) &&
+      (service.backup.paths or [ ]) != [ ] &&
+      (service.backup.useSnapshots or false) &&
+      (service.backup.zfsDataset or null) != null
+    )
+    (config.modules.services or { }));
+
   # Submodules are imported below
 in
 {
@@ -478,6 +492,33 @@ in
       {
         assertion = lib.length (lib.filter (repo: repo.primary) (lib.attrValues cfg.repositories)) <= 1;
         message = "Only one repository can be marked as primary";
+      }
+      {
+        # `paths` is silently discarded on a snapshot-based job. restic.nix
+        # replaces it wholesale with the clone mountpoint
+        # (/var/lib/backup-snapshots/<job>) whenever `useSnapshots` is set and
+        # a `zfsDataset` is present -- see `snapshotPaths` there. Whatever the
+        # dataset holds is what gets backed up, regardless of `paths`.
+        #
+        # That is fine for the path auto-derived from `dataDir` during
+        # discovery, which is just a placeholder. It is not fine for a path an
+        # author wrote by hand: that is a statement of intent which will be
+        # ignored without a word. This is how cooklang came to look like data
+        # loss -- its declared recipeDir disagreed with the derived dataDir,
+        # and establishing that the disagreement did not matter meant reading
+        # the generator.
+        #
+        # Trips on nothing today; it exists to stop the next one.
+        assertion = declaredPathsUnderSnapshots == [ ];
+        message = ''
+          These services set backup.paths while also using ZFS snapshots, so the
+          declared paths would be silently ignored: ${lib.concatStringsSep ", " declaredPathsUnderSnapshots}.
+
+          A snapshot-based job always backs up the whole of backup.zfsDataset via
+          its clone mountpoint. Either clear backup.paths and let the dataset
+          define the scope, or set backup.useSnapshots = false to make the
+          declared paths authoritative.
+        '';
       }
     ];
   };


### PR DESCRIPTION
Two more instances of the failure mode behind #831/#832: backup configuration that looks meaningful, evaluates cleanly, and does nothing.

## 1. Per-service `backup.retention` — deleted, not implemented

`lib/types/backup.nix` offered every stateful service a retention policy. **Nothing consumed it.** Discovery in `services/backup/default.nix` never mapped it, `_internal.allJobs` has no such field, and restic's forget/prune ([restic.nix:524](modules/nixos/services/backup/restic.nix:524)) has only ever applied `globalSettings.retention`. 46 services on forge carried a declared 7 daily / 4 weekly / 6 monthly that did nothing.

**Implementing it would have been the destructive choice.** All 46 values were the shared default — no host has ever customised it — and the effective global policy is strictly more generous:

| | declared (ignored) | global (actual) |
|---|---|---|
| daily | 7 | **14** |
| weekly | 4 | **8** |
| monthly | 6 | 6 |
| yearly | — | **2** |

Honouring the declared values would have *shortened* retention on all 46 and made the next `restic forget` prune snapshots that exist today. Deleting a dead option is cheap; silently deleting backups is not.

Removed with a comment recording why, and what threading it through would actually require.

## 2. `backup.paths` — now asserts instead of being silently discarded

[restic.nix:28-35](modules/nixos/services/backup/restic.nix:28) replaces `paths` wholesale with the dataset clone mountpoint whenever `useSnapshots` is set and `zfsDataset` is present. On a snapshot-based job the declared paths are inert.

That's harmless for the path auto-derived from `dataDir` during discovery — only a placeholder. It is **not** harmless for a path an author wrote deliberately: an intent ignored without a word.

This is what made `cooklang` look like data loss while auditing #831 — its declared `recipeDir` (`/data/cooklang/recipes`) disagreed with the derived `dataDir` (`/var/lib/cooklang`), and establishing that the disagreement didn't matter meant reading the generator.

The assertion **trips on nothing today** and exists to stop the next one. Verified it fires with the intended message by extending forge's config:

```
$ nix eval .#nixosConfigurations.forge --apply 'c: (c.extendModules {
    modules = [ { modules.services.cooklang.backup.paths = [ "/data/cooklang/recipes" ]; } ];
  }).config.system.build.toplevel'
error: declared paths would be silently ignored: cooklang.
       A snapshot-based job always backs up the whole of backup.zfsDataset via ...
```

## 3. `docs/index.md` — a related trap, documented

`nix flake check` on `aarch64-darwin` skips every `x86_64-linux` check behind one easily-missed warning line. Those include `deployment-backup-guard`, which holds the tripwires on forge's timer / restic-job / snapshot-dataset counts — so **a change that adds or removes a backup job passes a clean local check and is caught only in CI.** The doc gives the explicit eval that fires them without building.

## Deliberately unchanged

`enclosed`, `searxng` and `tracearr` are enabled on forge with `backup = null`. I checked whether that was an oversight; it isn't. All three are correctly opted out:

- **enclosed** — notes expire by design, no database
- **searxng** — no durable state
- **tracearr** — runs in `external` deployment mode with its `tracearr` database in the pgBackRest-covered PostgreSQL instance

Adding restic jobs there would cost storage and protect nothing.

## Verification

- All eight `nixosConfigurations` evaluate to a toplevel
- forge's `_internal.allJobs` **byte-identical** to the pre-change baseline at 58 jobs — confirming the retention removal is inert
- `checks.x86_64-linux.deployment-backup-guard` still evaluates
- Assertion negative-tested (above)
- nixpkgs-fmt, deadnix, statix clean
- Rebased onto `fc809071` and all of the above re-run against it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
