### PR TITLE
fix(cooklang): restore the v0.33.1 build and drop the self-updater

### DIFF
--- a/pkgs/cooklang-cli.nix
+++ b/pkgs/cooklang-cli.nix
@@ -7,15 +7,28 @@ let
   sourceData = pkgs.callPackage ./_sources/generated.nix { };
   src = sourceData.cooklang-cli;
 
-  tailwindAssets = pkgs.buildNpmPackage {
-    pname = "cooklang-tailwind-assets";
+  # Front-end assets are gitignored upstream, so the source tarball lacks them.
+  # Since 0.33.0 build.rs hard-fails when either is missing (upstream #404), so
+  # both the Tailwind stylesheet and the CodeMirror editor bundle have to be
+  # produced here and dropped into the Rust source tree before cargo runs.
+  frontendAssets = pkgs.buildNpmPackage {
+    pname = "cooklang-frontend-assets";
     inherit (src) version;
     inherit (src) src;
-    npmDepsHash = "sha256-tBOBa2plgJ0dG5eDD9Yc9YS+Dh6rhBdqU6JiZUjTUY4=";
-    npmBuildScript = "build-css";
+    npmDepsHash = "sha256-HbuCSCgEz9FZsb5DJ37twFdxsuin0k4osqb8BP6XEI0=";
+
+    # Two build scripts, so npmBuildScript (singular) does not fit.
+    buildPhase = ''
+      runHook preBuild
+      npm run build-css
+      npm run build-js
+      runHook postBuild
+    '';
+
     installPhase = ''
       runHook preInstall
       install -Dm644 static/css/output.css $out/static/css/output.css
+      install -Dm644 static/js/editor.bundle.js $out/static/js/editor.bundle.js
       runHook postInstall
     '';
   };
@@ -29,8 +42,22 @@ rustPlatform.buildRustPackage {
 
   nativeBuildInputs = [ pkgs.perl ];
 
+  # Upstream's default feature set includes `self-update`, which adds a
+  # `cook update` subcommand that downloads a release binary over the running
+  # one. That can only fail against a read-only Nix store, and updates come
+  # from nvfetcher here anyway. Everything else upstream enables by default is
+  # kept, so only `cook update` disappears.
+  buildNoDefaultFeatures = true;
+  buildFeatures = [
+    "server"
+    "sync"
+    "import"
+    "lsp"
+  ];
+
   preBuild = ''
-    install -Dm644 ${tailwindAssets}/static/css/output.css static/css/output.css
+    install -Dm644 ${frontendAssets}/static/css/output.css static/css/output.css
+    install -Dm644 ${frontendAssets}/static/js/editor.bundle.js static/js/editor.bundle.js
   '';
 
   doCheck = false;


### PR DESCRIPTION
The cooklang package cannot build on forge. Two independent breakages, both introduced by the v0.32.1 → v0.33.1 nvfetcher bump in fc809071.

## 1. Stale `npmDepsHash`

That commit auto-fixed hashes for `usage` and `cargoHash` for cooklang, but left `npmDepsHash` at its v0.32.1 value. v0.33.x rewrote the front-end toolchain — Tailwind v3 → v4 via `@tailwindcss/cli`, plus CodeMirror, esbuild and playwright — so the lockfile no longer hashes to the recorded value and the npm deps fetch fails outright.

## 2. `build.rs` now hard-fails on missing assets

Fixing the hash alone still does not build. Upstream [#404](https://github.com/cooklang/cookcli/issues/404) added a `build.rs` check that aborts when either compiled front-end asset is missing, and both are gitignored so the source tarball ships neither. This package only ever built the stylesheet, so cargo now fails on `static/js/editor.bundle.js`.

`npmBuildScript` takes a single script, so the asset derivation runs `build-css` and `build-js` from an explicit `buildPhase` and installs both; `preBuild` drops both into the Rust source tree. Renamed `tailwindAssets` → `frontendAssets`, since it is no longer Tailwind only.

## 3. Disable `self-update`

Upstream's default features include `self-update`, which adds a `cook update` subcommand that overwrites the running binary in place. Against a read-only Nix store that can only fail, and updates arrive through nvfetcher regardless. It is cleanly `#[cfg]`-gated in `main.rs`, so disabling it removes the subcommand rather than leaving one that errors at runtime. Every other default feature is kept explicitly, so only `cook update` disappears. `cargoHash` is unchanged, because vendoring is driven by `Cargo.lock` and is feature-independent.

## Verification

Built end to end and smoke-tested by running `cook server` against a test recipe:

- `/` → 200, `/static/css/output.css` → 200 (63 KB), `/static/js/editor.bundle.js` → 200 (374 KB), so the assets are genuinely embedded rather than silently empty
- `cook --version` → `cookcli 0.33.1`; `server`, `import`, `lsp` and the sync `login`/`logout` commands all present, `cook update` gone
- `nix eval .#nixosConfigurations.forge.config.system.build.toplevel.drvPath` succeeds; statix and nixpkgs-fmt clean

Built on aarch64-darwin — no x86_64-linux builder was reachable. Both failure modes are platform-independent (a lockfile hash and a `build.rs` file-existence check), and the flake's nixpkgs matches the channel used, same nodejs 22.22.2, so the npm hash will match on forge.

**Heads-up on CI scope:** forge is excluded from the per-PR build matrix by design, so a green run here does not actually build this package. The Flake Health run and the deploy itself are what exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)