### PR TITLE
chore(hermes-agent): rebase fork pin onto upstream v0.20.2

### DIFF
--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -2,7 +2,7 @@
 
 This document tracks temporary workarounds, package overrides, and unstable package usage that should be periodically reviewed. These exist due to upstream bugs, missing features in stable, or test failures in the Nix build sandbox.
 
-**Last Reviewed**: 2026-07-17
+**Last Reviewed**: 2026-08-16 (hermes-agent entry only; full review still due)
 **Next Review**: 2026-08-17 (monthly)
 
 ---
@@ -39,13 +39,13 @@ When reviewing workarounds:
 
 | Field | Value |
 | --- | --- |
-| **Added** | 2026-07-27 |
+| **Added** | 2026-07-27 (rebased onto upstream v0.20.2 on 2026-08-16) |
 | **Location** | `flake.nix` (`inputs.hermes-agent`) and `flake.lock` |
 | **Affects** | Forge Signal gateway, Forge evaluation, CI flake checks, automated input updates, and fixed-port MCP OAuth reauthorization |
-| **Reason** | The released Signal adapter targets direct signal-cli SSE/JSON-RPC endpoints that do not exist in signal-cli-rest-api 0.100; Hermes's filtered-source refactor breaks cold-store evaluation; and the OAuth paste fallback closes a socket while its blocking `handle_request()` thread still owns the fixed callback port, causing the SDK's next callback to fail with `Address already in use`. |
-| **Workaround** | Pin `hermes-agent` to immutable fork commit [`7d9119b66`](https://github.com/carpenike/hermes-agent/commit/7d9119b66d831235260caa24cf0abf27887b8c32), combining the REST/WebSocket adapter from upstream PR #53696, v0.100 raw-to-REST group-recipient encoding, the cold-store fix from PR #72689, and managed OAuth listener shutdown. |
-| **Validation** | The focused Signal REST route suite passes on `x86_64-linux` (`22 passed`), and the full OAuth test file passes (`112 passed`), including immediate fixed-port rebinding after a pasted callback. Validate nix-config with `task nix:build-nixos host=forge`, then verify Signal reply and scoped MCP login on forge. |
-| **Check** | After upstream PRs #53696 and #72689 merge and OAuth callback listeners use managed shutdown, restore `url = "github:NousResearch/hermes-agent"`, update only the Hermes lock node, and rerun the cold-store, Signal, and fixed-port OAuth checks before removing this entry. |
+| **Reason** | The released Signal adapter targets direct signal-cli SSE/JSON-RPC endpoints that do not exist in signal-cli-rest-api 0.100; upstream's `importNpmLock { npmRoot = fileset.toSource ...; }` breaks cold-store evaluation; and the OAuth paste fallback closes a socket while its blocking `handle_request()` thread still owns the fixed callback port, causing the SDK's next callback to fail with `Address already in use`. Upstream v0.20.2 independently added `allow_reuse_address` before bind (#44590), which may cover the OAuth symptom — the fork keeps the managed-shutdown fix regardless. |
+| **Workaround** | Pin `hermes-agent` to immutable fork commit [`9dfd2fc32`](https://github.com/carpenike/hermes-agent/commit/9dfd2fc325f60d24d349ad47a5cf571899cede3c) (branch `nix-config/v2026.8.16`): upstream **v0.20.2** + the current PR #53696 head (REST/WebSocket adapter) + v0.100 raw-to-REST group-recipient encoding + the PR #72689 cold-store fix ported to the refactored `hermesNpmLib` (only `npmRoot = repoRoot` remains needed; desktop/tui/web eval-time reads were removed upstream) + managed OAuth listener shutdown. |
+| **Validation** | 2026-08-16 on the rebased tree: Signal suites + full OAuth file pass (`144 passed, 1 skipped`); merge-adjacent suites (`test_status`, `test_send_message_tool`, `test_signal_media`, `test_mcp_reconnect_signal`) pass (`116 passed, 5 skipped`); `nix eval .#packages.x86_64-linux.default.name` → `hermes-agent-0.20.2`. All service-module assumptions re-verified on 0.20.2: NixOS module options, cron CLI flags/output format (`Name:`/`[paused]`/`[active]`, 12-hex IDs), `cron.jobs.get_job/update_job` + `context_from`, `HERMES_PYTHON` shell-wrapper export, `platform_toolsets`, `channel_overrides` in the cached-agent signature, oauth `client_secret`/`redirect_port` config keys, `[SILENT]` filter, `cron.wrap_response`, `errors.log` path, `## Response`/`## Error` output markers. Validate nix-config with `task nix:build-nixos host=forge`, then verify Signal reply and scoped MCP login on forge. |
+| **Check** | After upstream PRs #53696 and #72689 merge, restore `url = "github:NousResearch/hermes-agent"`, update only the Hermes lock node, and rerun the cold-store, Signal, and fixed-port OAuth checks before removing this entry. When rebasing again, test whether upstream's `allow_reuse_address` fix makes the fork OAuth commit unnecessary. |
 | **Upstream** | [NousResearch/hermes-agent#53696](https://github.com/NousResearch/hermes-agent/pull/53696), [NousResearch/hermes-agent#72689](https://github.com/NousResearch/hermes-agent/pull/72689), [fork OAuth fix](https://github.com/carpenike/hermes-agent/commit/7d9119b66d831235260caa24cf0abf27887b8c32) |
 | **Impact** | Without the pin, Hermes cannot connect to forge's Signal transport; fresh CI runners/cold Forge stores can fail before building; and pasted OAuth callbacks cannot complete reliably with a fixed redirect port. |
 

--- a/flake.lock
+++ b/flake.lock
@@ -139,11 +139,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772408722,
-        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -259,17 +259,17 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1785527271,
-        "narHash": "sha256-nLDXn+2i0irBsDEc3alUt1c8J9YyL+lNtmL+Yj7iEns=",
+        "lastModified": 1786935583,
+        "narHash": "sha256-vkyhzbbcFuKtKdRZQqYxIMZYPQH87yvG2FgOcCCVTiw=",
         "owner": "carpenike",
         "repo": "hermes-agent",
-        "rev": "7d9119b66d831235260caa24cf0abf27887b8c32",
+        "rev": "9dfd2fc325f60d24d349ad47a5cf571899cede3c",
         "type": "github"
       },
       "original": {
         "owner": "carpenike",
         "repo": "hermes-agent",
-        "rev": "7d9119b66d831235260caa24cf0abf27887b8c32",
+        "rev": "9dfd2fc325f60d24d349ad47a5cf571899cede3c",
         "type": "github"
       }
     },
@@ -579,11 +579,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772555609,
-        "narHash": "sha256-3BA3HnUvJSbHJAlJj6XSy0Jmu7RyP2gyB/0fL7XuEDo=",
+        "lastModified": 1785115949,
+        "narHash": "sha256-8AM37BfyGaL2v/SZyg4PupRxJ01Y4htvM+WrTjWrPpo=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "c37f66a953535c394244888598947679af231863",
+        "rev": "62c0d86027edb1c4f39a5facc09876348144f7c9",
         "type": "github"
       },
       "original": {
@@ -600,11 +600,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772865871,
-        "narHash": "sha256-/ZTSg97aouL0SlPHaokA4r3iuH9QzHVuWPACD2CUCFY=",
+        "lastModified": 1784591072,
+        "narHash": "sha256-zP/WaDxrRu8GANZM61+V2LT/7ycEEdoyLWn7M6WzU7M=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "e537db02e72d553cea470976b9733581bcf5b3ed",
+        "rev": "e3b599ca2e7fcf93d4edf65d7f19bbf6491724f3",
         "type": "github"
       },
       "original": {
@@ -782,11 +782,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773039484,
-        "narHash": "sha256-+boo33KYkJDw9KItpeEXXv8+65f7hHv/earxpcyzQ0I=",
+        "lastModified": 1785277507,
+        "narHash": "sha256-9Tq3UDX2hD/aveW/HvkBlAmEwJTOlY5HQXJM+L5BGmE=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "b68be7cfeacbed9a3fa38a2b5adc0cfb81d9bb1f",
+        "rev": "5a836d395cbf5fc22670eb98dd4aa4fc4d406977",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -131,14 +131,16 @@
 
     # Hermes Agent — persistent AI agent and messaging gateway
     # https://github.com/NousResearch/hermes-agent
-    # WORKAROUND (2026-07-30): Pin Signal REST/WebSocket support, the cold-store
-    # evaluation fix, and fixed-port OAuth callback cleanup.
+    # WORKAROUND (2026-07-30, rebased 2026-08-16 onto v0.20.2): Pin Signal
+    # REST/WebSocket support, the cold-store evaluation fix, and fixed-port
+    # OAuth callback cleanup. Fork branch nix-config/v2026.8.16 =
+    # upstream v2026.8.16 + PR #53696 + ported #72689 + OAuth listener fix.
     # Upstream: https://github.com/NousResearch/hermes-agent/pull/53696
     #           https://github.com/NousResearch/hermes-agent/pull/72689
-    # Fork fix: https://github.com/carpenike/hermes-agent/commit/7d9119b66d831235260caa24cf0abf27887b8c32
+    # Fork fix: https://github.com/carpenike/hermes-agent/commit/9dfd2fc325f60d24d349ad47a5cf571899cede3c
     # Check: Return upstream after both PRs and callback cleanup land.
     hermes-agent = {
-      url = "github:carpenike/hermes-agent/7d9119b66d831235260caa24cf0abf27887b8c32";
+      url = "github:carpenike/hermes-agent/9dfd2fc325f60d24d349ad47a5cf571899cede3c";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
 

--- a/hosts/forge/services/hermes-agent.nix
+++ b/hosts/forge/services/hermes-agent.nix
@@ -784,8 +784,9 @@ in
           TELEGRAM_ALLOWED_USERS = "8903896206";
         };
 
-        # Hermes v0.19 scopes MCP servers per platform by server alias, not by
-        # individual tool. Keep finance and general-purpose tools on separate
+        # Hermes scopes MCP servers per platform by server alias, not by
+        # individual tool (verified on v0.19 and v0.20.2). Keep finance and
+        # general-purpose tools on separate
         # aliases even though they share an endpoint and bounded OAuth scope.
         mcpServers.holthome = {
           url = "https://mcp.${config.networking.domain}/mcp";
@@ -867,8 +868,10 @@ in
             # A user's private Telegram chat ID equals their numeric user ID.
             allowed_chats = [ "8903896206" ];
             group_policy = "disabled";
-            # Hermes v0.19 resolves channel overrides every turn and includes
-            # their full text in the cached-agent signature, so persona edits
+            # Hermes resolves channel overrides every turn and includes their
+            # full text in the cached-agent signature (verified on v0.19 and
+            # v0.20.2: _get_channel_override feeds the ephemeral prompt into
+            # _agent_config_signature), so persona edits
             # do not require session resets. Acceptance MUST use the production
             # identity below with thread_id=null: synthetic thread IDs create a
             # different session and do not exercise Ryan's persistent DM history.


### PR DESCRIPTION
## Summary

Moves the `hermes-agent` flake input from the v0.19.1-era fork commit (`7d9119b66`, 4,162 commits behind upstream) to fork branch [`nix-config/v2026.8.16`](https://github.com/carpenike/hermes-agent/tree/nix-config/v2026.8.16) (`9dfd2fc32`), which is upstream **v0.20.2** plus the three still-unmerged overrides:

- **Signal REST/WebSocket adapter** — current head of [NousResearch/hermes-agent#53696](https://github.com/NousResearch/hermes-agent/pull/53696) (still open; upstream main still targets the SSE/JSON-RPC endpoints removed in signal-cli-rest-api 0.100), plus the raw-to-REST group-recipient encoding fix.
- **Cold-store evaluation fix** — [NousResearch/hermes-agent#72689](https://github.com/NousResearch/hermes-agent/pull/72689) ported to upstream's refactored `hermesNpmLib`; the refactor removed the other eval-time reads, so only `npmRoot = repoRoot` remains.
- **Managed OAuth listener shutdown** — kept even though upstream added `allow_reuse_address` (#44590), which may independently cover the fixed-port symptom; noted in workarounds.md to re-test at the next rebase.

## Validation

- Signal + OAuth suites on the rebased tree: **144 passed, 1 skipped**; merge-adjacent suites (`test_status`, `test_send_message_tool`, `test_signal_media`, `test_mcp_reconnect_signal`): **116 passed, 5 skipped**
- `nix eval .#packages.x86_64-linux.default.name` → `hermes-agent-0.20.2`
- `hermes-agent-0.20.2`, the CLI wrapper, and both seed units built on forge; binary runs
- Every v0.19-era assumption in `hosts/forge/services/hermes-agent.nix` re-verified against 0.20.2 source (cron CLI output format the seed scripts parse, `cron.jobs.get_job/update_job` + `context_from`, `HERMES_PYTHON` wrapper export, `platform_toolsets`, channel-override cache signature, oauth `client_secret`/`redirect_port` keys, `[SILENT]` filter, `errors.log`/cron output paths)

## Notes

- The full forge closure currently fails on a **pre-existing, unrelated** `cooklang-tailwind-assets` npm-deps hash mismatch (registry drift from the nvfetcher bump); tracked separately.
- Post-deploy checks that need the real environment: Signal reply in the family group, scoped MCP OAuth login on forge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)