### PR TITLE
fix(paperless): grant the MCP bridge read access to owned documents

### DIFF
--- a/docs/services/paperless-operations.md
+++ b/docs/services/paperless-operations.md
@@ -66,6 +66,54 @@ Its table includes the suggested-tags custom field.
 Accepted tags persist because taxonomy reconciliation seeds required tags but
 does not prune user-created tags.
 
+## Service Account Read Access
+
+Paperless grants access to a document in exactly three cases: the caller owns
+it, the caller holds an explicit object permission on it, or the document has
+no owner at all. There is no global read role, and the admin **Default
+Permissions** screen does not apply to documents — only to objects such as tags
+and mail rules.
+
+The two intake paths differ, which is the trap:
+
+| Intake path | Owner | Visible to a plain service account |
+| --- | --- | --- |
+| Consume directory (`/mnt/data/paperless/consume`) | none | yes, by fallthrough |
+| Web UI upload | the uploading user | **no** |
+
+A non-superuser account therefore reads scanner intake fine and goes blind on
+everything uploaded through the browser. This is how `homelab-mcp` came to see
+16 of 44 documents on 2026-08-17: nothing was broken, the archive had simply
+shifted toward UI uploads.
+
+`paperless-finance-bootstrap` closes both halves:
+
+- it maintains the `document-readers` group and the `readerAccounts` list in
+  [`hosts/forge/services/paperless-ai.nix`](https://github.com/carpenike/nix-config/blob/main/hosts/forge/services/paperless-ai.nix);
+- the `DOCUMENT_ADDED` workflow action assigns that group view permission on
+  every new document, covering UI uploads;
+- a backfill grants the group view permission on documents already in the
+  archive, skipping the trash.
+
+Grants go to the group, never to an account directly. Adding a reader is one
+line in `readerAccounts`; it inherits the entire backfill on joining, with no
+second pass over the archive.
+
+To add a reader:
+
+1. Create the Paperless user and issue its API token in the web UI.
+2. Store the token in that consumer's sops secret.
+3. Add the username to `readerAccounts` and deploy.
+
+The account is created by hand because its token cannot be, so `readerAccounts`
+is the only declarative record that it exists. A username listed there that has
+no matching Paperless user logs a warning and is skipped rather than failing the
+unit — the bootstrap runs `before` Paperless-AI, and a missing reader must not
+take the AI pipeline down with it.
+
+Verify from the bridge's side with `paperless_search`; its result count should
+match `Document.objects.count()`.
+
 ## Managed Taxonomy
 
 Baseline tags:

--- a/hosts/forge/services/paperless-ai.nix
+++ b/hosts/forge/services/paperless-ai.nix
@@ -17,6 +17,19 @@ let
   dataDir = "/var/lib/paperless-ai";
   listenPort = 3001;
   serviceEnabled = config.modules.services.paperless-ai.enable or false;
+  # Non-superuser service accounts that must be able to READ the archive.
+  # Paperless grants document access to an owner, to an explicit object
+  # permission, or to anything with no owner at all -- and nothing else. The
+  # web UI stamps the uploading user as owner while the consume directory
+  # leaves it null, so an account listed here sees a document only by accident
+  # until the grants below exist. See docs/services/paperless-operations.md.
+  readerGroup = "document-readers";
+  readerAccounts = [
+    # homelab-mcp's paperless_search / paperless_get tools. The account and its
+    # API token are created by hand (the token lives in homelab-mcp/env in
+    # sops), so this list is the only declarative record that it exists.
+    "homelab-mcp"
+  ];
   canonicalCorrespondents = [
     "Adventist HealthCare"
     "Comptroller of Maryland"
@@ -77,8 +90,13 @@ let
     import json
 
     from django.contrib.auth import get_user_model
+    from django.contrib.auth.models import Group
+    from django.contrib.auth.models import Permission
+    from django.contrib.contenttypes.models import ContentType
+    from guardian.models import GroupObjectPermission
     from documents.models import CustomField
     from documents.models import Correspondent
+    from documents.models import Document
     from documents.models import SavedView
     from documents.models import SavedViewFilterRule
     from documents.models import Tag
@@ -89,6 +107,7 @@ let
     custom_fields = json.loads(${builtins.toJSON (builtins.toJSON customFields)})
     canonical_correspondents = json.loads(${builtins.toJSON (builtins.toJSON canonicalCorrespondents)})
     saved_views = json.loads(${builtins.toJSON (builtins.toJSON savedViews)})
+    reader_accounts = json.loads(${builtins.toJSON (builtins.toJSON readerAccounts)})
 
     for correspondent_name in canonical_correspondents:
       if not Correspondent.objects.filter(name__iexact=correspondent_name).exists():
@@ -115,6 +134,61 @@ let
     )
     if owner is None:
       raise RuntimeError("Paperless admin user ryan@ryanholt.net does not exist")
+
+    # Read access for service accounts, granted to a GROUP rather than to each
+    # account. Membership then carries the whole backfill: a reader added later
+    # sees every existing document the moment it joins, with no second pass
+    # over the archive. Granting per user would need one backfill per account.
+    reader_group, _ = Group.objects.get_or_create(name=${builtins.toJSON readerGroup})
+
+    for username in reader_accounts:
+      reader = User.objects.filter(username=username).first()
+      if reader is None:
+        # Deliberately not fatal. These accounts are created by hand, and this
+        # unit runs `before` podman-paperless-ai -- raising here would take the
+        # whole AI pipeline down over a missing reader. The group and its
+        # grants are still created, so the next deploy after the account exists
+        # picks it up and it inherits the backfill immediately.
+        print("WARNING: paperless reader account " + username + " does not exist; skipping group membership")
+        continue
+      reader.groups.add(reader_group)
+
+    # Backfill. The workflow below stamps view permissions on documents added
+    # after it, which does nothing for what is already in the archive -- 28 of
+    # 44 documents on 2026-08-17, every one of them a web-UI upload. Filter to
+    # the missing rows rather than assigning blind: this unit runs on every
+    # deploy, and guardian's bulk assign does not deduplicate.
+    #
+    # Document.objects and NOT Document.global_objects: the default manager
+    # excludes the trash, and granting read on a deleted document would only
+    # resurrect it in the bridge's search results.
+    document_type = ContentType.objects.get_for_model(Document)
+    view_document = Permission.objects.get(
+      content_type=document_type,
+      codename="view_document",
+    )
+    already_granted = set(
+      GroupObjectPermission.objects.filter(
+        group=reader_group,
+        permission=view_document,
+        content_type=document_type,
+      ).values_list("object_pk", flat=True)
+    )
+    GroupObjectPermission.objects.bulk_create(
+      [
+        GroupObjectPermission(
+          group=reader_group,
+          permission=view_document,
+          content_type=document_type,
+          object_pk=str(document_pk),
+        )
+        for document_pk in Document.objects.values_list("pk", flat=True)
+        if str(document_pk) not in already_granted
+      ],
+      # Belt and braces against a document consumed between the read above and
+      # the write here; the table has a unique constraint on the triple.
+      ignore_conflicts=True,
+    )
 
     for definition in saved_views:
       tag = Tag.objects.get(name=definition["tag"])
@@ -171,6 +245,11 @@ let
       type=WorkflowAction.WorkflowActionType.ASSIGNMENT,
     )
     action.assign_tags.set([Tag.objects.get(name="workflow:needs-review")])
+    # The forward half of the read grant above. DOCUMENT_ADDED fires for
+    # web-UI uploads as well as consume-directory intake, so this covers the
+    # path that produced the invisible documents -- an owned document is
+    # readable by the group from the moment it lands.
+    action.assign_view_groups.set([reader_group])
     workflow.triggers.set([trigger])
     workflow.actions.set([action])
   '';


### PR DESCRIPTION
## Problem

`homelab-mcp`'s `paperless_search` returned 16 documents while the archive held 44. Documents uploaded after 2026-08-07 were invisible to the bridge.

Paperless grants document access in exactly three cases: the caller owns it, the caller holds an explicit object permission on it, or the document has no owner at all. There is no global read role, and the admin **Default Permissions** screen [does not apply to documents](https://github.com/paperless-ngx/paperless-ngx/blob/dev/docs/usage.md).

The two intake paths diverge:

| Intake path | Owner | Visible to a plain service account |
| --- | --- | --- |
| Consume directory | none | yes, by fallthrough |
| Web UI upload | uploading user | **no** |

Verified on forge: 28 of 44 live documents owned by `ryan@ryanholt.net`, 16 unowned, and **zero** rows in `guardian_userobjectpermission` / `guardian_groupobjectpermission`. `homelab-mcp` is a non-superuser with no group membership, so the 16 unowned documents were the entire visible set.

Nothing had broken. The archive shifted toward UI uploads and the bridge went quietly blind as it did — it had never worked for that path.

## Change

Three additions to the existing `paperless-finance-bootstrap` unit:

1. A `document-readers` group plus a `readerAccounts` list — the only declarative record that these hand-created accounts exist, since their API tokens live in sops.
2. `assign_view_groups` on the existing `DOCUMENT_ADDED` workflow action, the forward fix.
3. An idempotent backfill of `view_document` across documents already in the archive.

Grants target the group rather than each account, so a reader added later inherits the whole backfill on joining instead of needing a second pass.

## Notes on the details

- **`Document.objects`, not `global_objects`** — the default manager excludes the trash; granting read on a deleted document would resurface it in bridge searches.
- **Backfill filters to missing rows** — this unit runs on every deploy and guardian's bulk assign does not deduplicate. `ignore_conflicts=True` covers a document consumed between the read and the write.
- **A missing account warns rather than raises** — the unit runs `before` `podman-paperless-ai`, so failing here would take the AI pipeline down over a missing reader.

## Verification

- `nix eval` of the full forge config succeeds; `statix` clean.
- Generated Python compiles.
- Every Django symbol resolved against the live instance (read-only): `guardian.models.GroupObjectPermission`, `view_document` perm id 56, `WorkflowAction.assign_view_groups` confirmed as a real m2m field.
- `DOCUMENT_ADDED` confirmed to fire on web-UI uploads — ids 42–49 all carry `finance:statement`/`finance:loan` and `workflow:ai-processed`, so the action reaches the path that produced the invisible documents.

After deploy, `paperless_search` should return 44 rather than 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
