### PR TITLE
fix(backup,monitoring): close offsite, drill and persistence gaps from finances review

### DIFF
--- a/.github/workflows/update-flake-input.yml
+++ b/.github/workflows/update-flake-input.yml
@@ -30,6 +30,7 @@ on:
           - homelab-mcp
           - coachiq
           - ambit
+          - lading
   repository_dispatch:
     types: [flake-input-updated]
 
@@ -56,7 +57,7 @@ jobs:
           # Allowlist gate: a repository_dispatch is attacker-influenceable, so
           # never feed an arbitrary string into `nix flake lock --update-input`.
           case "$name" in
-            whiskey-whiskey-whiskey|replog|marginalia|homelab-mcp|coachiq|ambit) ;;
+            whiskey-whiskey-whiskey|replog|marginalia|homelab-mcp|coachiq|ambit|lading) ;;
             *)
               echo "::error::Unknown or disallowed flake input '$name'"
               exit 1

--- a/docs/disaster-recovery-drills.md
+++ b/docs/disaster-recovery-drills.md
@@ -1,0 +1,137 @@
+# Disaster Recovery Drills
+
+A backup that has never been restored is a hypothesis. This document is the
+register of recovery drills: what each one proves, how to run it, and when it
+last actually ran.
+
+A drill is only "done" when its row in the register below carries a date and an
+operator. An automated drill that runs but is not alerted on is not done either
+— it is the same failure shape as a backup nobody checks.
+
+---
+
+## Register
+
+| Drill | Proves | Cadence | Automated | Last run | Result |
+| --- | --- | --- | --- | --- | --- |
+| pgBackRest repo1 restore | PostgreSQL is restorable from the NAS repository | Weekly (Sat 09:00) | Yes — `pgbackrest-restore-drill-repo1.timer` | See `pgbackrest_restore_drill_last_success_timestamp_seconds{repo="1"}` | — |
+| pgBackRest repo2 restore | PostgreSQL is restorable from Cloudflare R2 | Weekly (Sun 10:00) | Yes — `pgbackrest-restore-drill-repo2.timer` | See `pgbackrest_restore_drill_last_success_timestamp_seconds{repo="2"}` | — |
+| **PGP identity recovery** | **A total site loss is recoverable at all** | **Annual** | **No — requires the offline key** | **NEVER RUN** | **UNPROVEN** |
+
+The two pgBackRest drills were built well before they were scheduled; they had
+never run outside a manual `systemctl start` until the timers landed on
+2026-08-17. Their alert rules (`PgBackRestRestoreDrillFailed`,
+`PgBackRestRestoreDrillStale`, `PgBackRestRestoreDrillMetricsAbsent`,
+`PgBackRestRestoreDrillUnitFailed`) are what keep them from silently stopping
+again.
+
+---
+
+## PGP identity recovery drill
+
+### What it proves
+
+That the offline PGP key can still decrypt this repository's secrets, and
+therefore that a rebuilt-from-nothing forge can reach its own backups.
+
+This is the **single most load-bearing untested assumption in the whole
+recovery design**. Everything else has a second path; this does not.
+
+### Why it is the whole ballgame
+
+forge's SOPS identity is derived from `/etc/ssh/ssh_host_ed25519_key`
+(`sops.age.sshKeyPaths`, `hosts/forge/secrets.nix`). That key lives in
+`/persist`. So in a total loss:
+
+1. `/persist` is gone, therefore forge's age identity is gone.
+2. Without that identity nothing in `*.sops.yaml` can be decrypted — including
+   `restic/password` and `restic/r2-prod-env`.
+3. Without those, the offsite Restic repository in R2 is unreadable — including
+   the `system-persist-offsite` copy of `/persist` itself.
+
+The only thing that breaks the cycle is the offline PGP key
+`DA80 0206 0402 EC39 B195 451D 5CED 8036 2B5A 4EF2`, which `.sops.yaml` lists
+as a recipient on every `*.sops.yaml`. The working chain is:
+
+```
+offline PGP key
+  -> decrypt hosts/forge/secrets.sops.yaml directly from the git repo
+  -> restic/password + restic/r2-prod-env
+  -> restore /persist from the R2 Restic repository
+  -> forge's age identity is back, and normal recovery can proceed
+```
+
+Every link after the first is exercised routinely. The first link is not
+exercised by anything, ever. If that key is lost, corrupted, expired, or its
+passphrase forgotten, the offsite backups are ciphertext with no key and the
+household's data is gone despite three tiers of protection reporting green.
+
+### Running the drill
+
+Do this on a machine that is **not** forge, from a checkout of this repo, with
+the offline key's media attached. The point is to prove the key works
+independently of any running host — running it on forge would silently use
+forge's own age identity and prove nothing.
+
+1. Confirm the key is present and not expired:
+
+    ```bash
+    gpg --list-secret-keys --keyid-format LONG DA8002060402EC39B195451D5CED80362B5A4EF2
+    ```
+
+    Check the `expires:` field. A key that expires between drills is a silent
+    failure — extend it now rather than discovering it during an outage.
+
+2. Decrypt a secret using **only** that key. Unset any age identity first so a
+   stray `SOPS_AGE_KEY_FILE` cannot satisfy the decryption and produce a false
+   pass:
+
+    ```bash
+    env -u SOPS_AGE_KEY -u SOPS_AGE_KEY_FILE sops --decrypt --extract '["restic"]["password"]' hosts/forge/secrets.sops.yaml
+    ```
+
+    This must prompt for the PGP passphrase. If it returns a value **without**
+    prompting, the drill is invalid — something else decrypted it.
+
+3. Prove the recovered credentials actually open the offsite repository. Using
+   the password from step 2 and the R2 credentials from
+   `restic/r2-prod-env` in the same file:
+
+    ```bash
+    restic -r "s3:https://<r2-endpoint>/<r2-bucket>/forge" snapshots --tag identity
+    ```
+
+    A snapshot list containing `system-persist-offsite` is the pass condition.
+    Anything else means the chain is broken somewhere after the key.
+
+4. Restore the identity file to a scratch directory and confirm it is the real
+   thing rather than an empty or truncated file:
+
+    ```bash
+    restic -r "s3:https://<r2-endpoint>/<r2-bucket>/forge" restore latest \
+      --tag identity --target /tmp/dr-drill
+    ssh-keygen -l -f /tmp/dr-drill/**/etc/ssh/ssh_host_ed25519_key
+    ```
+
+    The fingerprint must match forge's live host key. Then remove the scratch
+    directory — it contains a live private key.
+
+    ```bash
+    rm -rf /tmp/dr-drill
+    ```
+
+5. Record the result in the register above: date, operator, and pass/fail. A
+   drill that ran but was not recorded did not happen, because the next person
+   cannot tell.
+
+### Failure modes worth naming
+
+- **Key expired.** Extend the expiry and re-encrypt. Cheap now, fatal later.
+- **Passphrase forgotten.** There is no recovery from this. If the passphrase
+  is not independently escrowed, the drill's real finding is that the
+  escrow does not exist.
+- **Media unreadable.** Offline media degrades. If this drill is the only time
+  the media is read, an annual read is also the only thing keeping bit rot
+  visible.
+- **Step 2 passes without prompting.** Not a pass. Re-run in a clean
+  environment; something supplied an age identity.

--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -17,6 +17,29 @@ When reviewing workarounds:
 
 ---
 
+## Channel Lifecycle Debt
+
+Not a workaround and not a pin — a dependency that stopped moving on its own
+and now owes a migration. Tracked here because it has the same review cadence
+as everything else in this file.
+
+### nixpkgs - nixos-25.11 is EOL, migration to 26.05 owed
+
+| Field | Value |
+| --- | --- |
+| **Recorded** | 2026-08-17 |
+| **Location** | `flake.nix` (`inputs.nixpkgs`) and `flake.lock` |
+| **Affects** | Every host. This is the channel the whole fleet builds from. |
+| **Status** | **NOT A PIN.** Nobody pinned anything. `inputs.nixpkgs` tracks the `nixos-25.11` *branch*, and that branch went EOL upstream and stopped receiving commits. The lock simply froze at the last one. |
+| **Evidence** | The root nixpkgs node is locked at rev `b6018f87da`, `lastModified` 2026-06-30. Walking 400 commits of `flake.lock` shows it advancing on a clean weekly cadence from 25.05 all the way through 2026-07-01 (…Jun 26 → Jun 28 → Jun 29 → Jun 30) and then stopping dead, while lock commits from the weekly job continue to land through 2026-08-18 touching other inputs. The freeze date lines up with 26.05 + one month, which is the NixOS support window. |
+| **Consequence** | The fleet is not receiving security patches on the stable channel, and `update-flake-lock.yml` cannot tell anyone: it runs weekly, finds nothing new for nixpkgs, and reports success. This is a silent-by-construction gap, not a noisy one. |
+| **Do not** | "Document the pin with exit criteria." There is no pin to document, and adding a `follows` or a rev pin would convert a fixable branch problem into a real one. Do not bump `nixpkgs` to `nixos-unstable` either — `nixpkgs-unstable` already exists as a separate input for the packages that need it (see the `unstable-packages` overlay). |
+| **Owed** | Migrate `inputs.nixpkgs` to `github:NixOS/nixpkgs/nixos-26.05`. This touches every host and every overlay and needs its own planned effort with its own verification — build all hosts, re-check every entry in this file (several exist only because of 25.11-era package versions), and re-verify the service modules against the new NixOS release notes. It is deliberately NOT bundled into unrelated work. |
+| **Exit criteria** | `inputs.nixpkgs` tracks a supported channel, `flake.lock`'s nixpkgs node resumes advancing on the weekly job, and this entry is deleted. |
+| **Watch for** | A stale-channel detector would have caught this months earlier than a human review did. Consider a check that fails when the locked nixpkgs `lastModified` is older than ~45 days — the weekly job succeeding is currently indistinguishable from the channel being alive. |
+
+---
+
 ## Pinned Flake Inputs
 
 ### Actual Budget - 26.7 Schema Compatibility Pin

--- a/flake.nix
+++ b/flake.nix
@@ -606,6 +606,7 @@
                 rendered = builtins.fromJSON forge.environment.etc."homelab/protection-manifest.json".text;
                 actual = manifest.datasets."tank/services/actual";
                 homeAssistant = manifest.datasets."tank/services/home-assistant";
+                lading = manifest.datasets."tank/services/lading";
                 musicAssistant = manifest.datasets."tank/services/music-assistant";
                 legacyDirectPreseed = forge.systemd.services.preseed-mealie;
                 legacyFactoryMain = forge.systemd.services.podman-qbittorrent;
@@ -699,20 +700,56 @@
               in
               assert manifest.schemaVersion == 1;
               assert manifest.summary.total >= 60;
-              assert manifest.summary.classified == 46;
+              assert manifest.summary.classified == 47;
               assert manifest.summary.byClass == {
                 critical = 10;
                 ephemeral = 20;
-                standard = 14;
+                # 15 since 2026-08-17: lading gained a declared dataset. It
+                # had been running on the impermanence-rolled-back root with
+                # no dataset and no persistence entry, so its state was wiped
+                # every boot and the manifest could not see it at all.
+                standard = 15;
                 system = 2;
               };
               assert manifest.summary.unknownRepositories == [ ];
               assert builtins.hasAttr "rpool/safe/persist" manifest.datasets;
-              assert manifest.datasets."rpool/safe/persist".missingRequiredTiers == [ "offsite-backup" ];
+              # The system identity dataset: /persist carries the SSH host key
+              # that IS forge's SOPS identity. The `system-persist-offsite`
+              # Restic job closed its offsite gap on 2026-08-17, so this now
+              # asserts full coverage. Recovering from that copy still needs
+              # the offline PGP key to reach the Restic password and R2
+              # credentials - see the comment on the job in
+              # hosts/forge/infrastructure/storage.nix.
+              assert manifest.datasets."rpool/safe/persist".missingRequiredTiers == [ ];
+              # /home is deliberately still onsite-only. It is user data
+              # rather than recovery-critical identity, and it is far larger
+              # than /persist, so its offsite copy is a cost decision that has
+              # not been made rather than an oversight.
               assert manifest.datasets."rpool/safe/home".missingRequiredTiers == [ "offsite-backup" ];
               assert actual.classification == "critical";
-              assert actual.missingRequiredTiers == [ "offsite-backup" ];
+              # The household ledger. Every required tier is satisfied: the
+              # `actual-offsite` Restic job to r2-offsite closed the offsite
+              # gap on 2026-08-17, so this asserts full coverage rather than
+              # codifying a known hole. If it starts failing, an offsite tier
+              # regressed - restore it rather than relaxing the assertion.
+              assert actual.missingRequiredTiers == [ ];
               assert homeAssistant.missingRequiredTiers == [ "offsite-backup" ];
+              # lading holds rotating Costco/Sam's tokens and a live Amazon
+              # cookie jar. The dataset itself is the assertion that matters:
+              # without one, /var/lib/lading sits on the root dataset that
+              # initrd rolls back to @blank every boot, and the manifest
+              # cannot see the dataset to complain. Asserting its presence and
+              # full tier coverage is what stops that regressing unnoticed.
+              assert lading.classification == "standard";
+              assert lading.missingRequiredTiers == [ ];
+              # Deliberately true, unlike the other standard services - which
+              # is exactly why lading is not in standardServicePaths below.
+              # There is no preseed unit, so an empty dataset must be a legal
+              # state: the units re-seed the warehouse tokens from sops and
+              # re-login to Amazon. That path is expensive and challenge-prone,
+              # not impossible.
+              assert lading.policy.allowEmptyBootstrap;
+              assert !(builtins.hasAttr "lading" failClosedUnits);
               assert musicAssistant.coverage.automatedRestore;
               assert builtins.all
                 (name:
@@ -821,16 +858,33 @@
                 # nothing, so the service had no backup at all. These counts are
                 # tripwires on the deployment guard's timer set -- a backup job
                 # appearing or vanishing should force exactly this review.
-              assert builtins.length expectedTimers == 125;
+                #
+                # 2026-08-17, 125 -> 131 timers, 57 -> 58 snapshot datasets and
+                # 58 -> 61 restic jobs. Six new timers, all intended:
+                #   pgbackrest-restore-drill-repo{1,2}.timer  - the restore
+                #     drills existed as services that nothing ever scheduled;
+                #     these arm them.
+                #   restic-backup-actual-offsite.timer        - Actual Budget
+                #     to r2-offsite, closing the ledger's offsite gap.
+                #   restic-backup-system-persist-offsite.timer - /persist (the
+                #     SOPS identity) to r2-offsite.
+                #   restic-backup-lading.timer                - lading's new
+                #     dataset, which also brings the +1 snapshot dataset and
+                #     syncoid-tank-services-lading.timer.
+                # The drill timers land in this set on purpose: the guard
+                # pauses them for a deploy and restores them after, which is
+                # what should happen to a job that takes the pgBackRest
+                # backup lock.
+              assert builtins.length expectedTimers == 131;
               assert builtins.elem "pgbackrest-incr-backup.timer" expectedTimers;
               assert builtins.elem "restic-backup-service-plex.timer" expectedTimers;
               assert builtins.elem "sanoid.timer" expectedTimers;
               assert builtins.elem "syncoid-tank-services-plex.timer" expectedTimers;
               assert forge.systemd.timers.nixos-deploy-backup-guard-metrics.wantedBy == [ "timers.target" ];
               assert builtins.all (name: builtins.hasAttr name forge.modules.alerting.rules) requiredAlerts;
-              assert builtins.length (builtins.attrNames snapshotDatasets) == 57;
+              assert builtins.length (builtins.attrNames snapshotDatasets) == 58;
               assert !(builtins.hasAttr "tank/services" snapshotDatasets);
-              assert builtins.length (builtins.attrNames enabledResticJobs) == 58;
+              assert builtins.length (builtins.attrNames enabledResticJobs) == 61;
               assert builtins.all (name: builtins.hasAttr name forge.modules.alerting.rules) requiredFreshnessAlerts;
               assert pkgs.lib.hasInfix "zfs_snapshot_dataset_info" snapshotMetricsScript;
               assert pkgs.lib.hasInfix "zfs_snapshot_latest_timestamp" snapshotMetricsScript;

--- a/hosts/forge/infrastructure/storage.nix
+++ b/hosts/forge/infrastructure/storage.nix
@@ -232,6 +232,58 @@ in
     };
   };
 
+  # Offsite copy of the system identity dataset.
+  #
+  # WHY THIS EXISTS. /persist holds /etc/ssh/ssh_host_ed25519_key, and forge's
+  # SOPS identity is derived from that key (`sops.age.sshKeyPaths` in
+  # hosts/forge/secrets.nix). Lose it and the host cannot decrypt a single
+  # secret. Until now its only protection was local snapshots plus Syncoid
+  # replication to nas-1 - both onsite, both in the same building, so one
+  # fire, flood or theft took the original and every copy together. That made
+  # the offline PGP key the sole surviving path to a rebuilt site.
+  #
+  # THE BOOTSTRAP ORDER MATTERS, and this job does not break the cycle on its
+  # own. Reading this repository requires the Restic password and the R2
+  # credentials, both of which are SOPS secrets decrypted by the very key
+  # stored inside it. The chain that actually works in a total loss is:
+  #
+  #   offline PGP key (DA80 0206 0402 EC39 ... , a recipient on every
+  #   *.sops.yaml - see .sops.yaml)
+  #     -> decrypt hosts/forge/secrets.sops.yaml straight from the git repo
+  #     -> restic/password + restic/r2-prod-env
+  #     -> restore /persist from this repository
+  #     -> forge's own age identity is back
+  #
+  # So this job converts "the PGP key is the only path" into "the PGP key
+  # unlocks a path", which is a materially better position but still rests on
+  # that key. The PGP recovery drill is the load-bearing untested step and is
+  # tracked in docs/disaster-recovery-drills.md - do not treat this job as
+  # having closed the risk on its own.
+  #
+  # r2-offsite only, deliberately. The NAS already holds a full replica of
+  # this dataset via Syncoid; a second onsite copy in a different format would
+  # add cost and no failure-domain independence.
+  modules.services.backup.restic.jobs.system-persist-offsite = {
+    enable = true;
+    repository = "r2-offsite";
+    paths = [ "/persist" ];
+    tags = [ "system" "identity" "persist" "offsite" "forge" ];
+    frequency = "daily";
+    # Read from a ZFS clone rather than the live tree: /persist is written
+    # continuously (logs, machine state), and this captures a consistent
+    # point-in-time image the same way the service jobs do.
+    useSnapshots = true;
+    zfsDataset = "rpool/safe/persist";
+    excludePatterns = [
+      # Persisted for post-reboot debugging, not for recovery, and by far the
+      # largest thing in the dataset. Excluding it keeps a daily offsite push
+      # of the identity data small enough to be free.
+      "**/var/log/**"
+      # Explicitly cache; rebuildable by definition.
+      "**/var/lib/cache/**"
+    ];
+  };
+
   # ZFS monitoring alerts (co-located with storage configuration following contribution pattern)
   modules.alerting.rules = lib.mkIf config.modules.filesystems.zfs.enable {
     # ZFS pool health degraded

--- a/hosts/forge/services/actual.nix
+++ b/hosts/forge/services/actual.nix
@@ -16,6 +16,8 @@ let
 
   # Service configuration values - single source of truth
   serviceName = "actual";
+  dataDir = "/var/lib/actual";
+  dataset = "tank/services/${serviceName}";
   port = 5006; # Actual Budget default port
   hostName = "budget.${config.networking.domain}";
   externalUrl = "https://${hostName}";
@@ -79,7 +81,7 @@ in
       # Must set owner/group/mode explicitly - StateDirectory can't change
       # permissions on pre-existing ZFS mountpoints
       modules.storage.datasets.services.${serviceName} = {
-        mountpoint = "/var/lib/actual";
+        mountpoint = dataDir;
         recordsize = "16K"; # SQLite database workload
         compression = "lz4";
         owner = config.modules.services.actual.user;
@@ -106,8 +108,33 @@ in
       };
 
       # ZFS snapshot and replication configuration
-      modules.backup.sanoid.datasets."tank/services/${serviceName}" =
+      modules.backup.sanoid.datasets.${dataset} =
         forgeDefaults.mkSanoidDataset serviceName;
+
+      # Offsite copy to R2, on top of the NAS backup that
+      # `mkBackupWithSnapshots` above already configures. This is what
+      # satisfies the "offsite-backup" tier declared below.
+      #
+      # The ledger is the household's only record of its own finances and is
+      # not reconstructible from anywhere else: the bank feeds carry a rolling
+      # window, not history, and every categorisation, payee merge, rule and
+      # reconciliation is hand-made. Onsite tiers all share one failure domain
+      # (forge and nas-1 sit in the same house), so a fire or a theft takes
+      # the snapshots, the replica and the NAS backup together.
+      #
+      # Small enough for this to be cheap — the budget is a single SQLite
+      # database of a few tens of MB — and it uses the same snapshot-clone
+      # read path as the NAS job, so it captures a consistent image rather
+      # than a live database mid-write.
+      modules.services.backup.restic.jobs."${serviceName}-offsite" = {
+        enable = true;
+        repository = "r2-offsite";
+        paths = [ dataDir ];
+        tags = [ serviceName "sqlite" "finances" "offsite" "forge" ];
+        frequency = "daily";
+        useSnapshots = true;
+        zfsDataset = dataset;
+      };
 
       # Service-down alert using forgeDefaults helper (native systemd service)
       modules.alerting.rules."${serviceName}-service-down" =

--- a/hosts/forge/services/homelab-mcp.nix
+++ b/hosts/forge/services/homelab-mcp.nix
@@ -565,6 +565,43 @@ in
 
         modules.alerting.rules."homelab-mcp-service-down" =
           forgeDefaults.mkSystemdServiceDownAlert "homelab-mcp" "HomelabMCP" "Claude tools bridge";
+
+        # External black-box check over the FULL public path:
+        # Cloudflare Tunnel -> cloudflared -> Caddy -> this service. The
+        # service-down alert above watches the systemd unit and the sidecar
+        # check further down probes 127.0.0.1, so between them every hop
+        # INSIDE forge is covered and every hop OUTSIDE it was not: the
+        # tunnel could be down, the DNS record wrong, or the Caddy vhost
+        # misrouted, and both existing signals would stay green while Claude
+        # could not reach a single tool.
+        #
+        # /healthz is the right probe target because it is the one route the
+        # server deliberately serves without a bearer token - unauthenticated,
+        # GET-only, and explicitly exempted from the JWT middleware
+        # (`extra_unauthenticated_paths` in the upstream app.py). It is also
+        # dependency-free: it touches no upstream and no database, so this
+        # check answers "is the path to the process open", not "is Grocy up".
+        # Do not point it at the /mcp route - that requires a JWT and fails
+        # closed forever.
+        modules.services.gatus.contributions.${serviceName} = {
+          name = "Homelab MCP";
+          group = "applications";
+          url = "https://${serviceDomain}/healthz";
+          interval = "60s";
+          conditions = [
+            "[STATUS] == 200"
+            "[BODY].status == ok"
+            # Through a tunnel and a reverse proxy, so a looser bound than the
+            # loopback sidecar check's 5s.
+            "[RESPONSE_TIME] < 5000"
+          ];
+          alerts = [{
+            type = "pushover";
+            sendOnResolved = true;
+            failureThreshold = 3;
+            successThreshold = 1;
+          }];
+        };
       }
     ))
 

--- a/hosts/forge/services/lading.nix
+++ b/hosts/forge/services/lading.nix
@@ -49,14 +49,26 @@
 # writing to this same database — never a second credential in one env file.
 # That keeps a compromised env file worth exactly one account.
 #
-# FLAKE LOCK: Renovate watches homelab-mcp and auto-merges its bumps within
-# minutes; nothing watches carpenike/lading. So after pushing lading you MUST
-# bump its input here by hand — on 2026-08-04 that was missed, and the deployed
-# closure ran ahead of the committed lock, meaning the next apply from a clean
-# checkout would have silently rolled a fix back with no diff to explain it.
-# When in doubt, check the deployed closure rather than the lock:
+# FLAKE LOCK: homelab-mcp's bumps land within minutes because its own repo
+# fires a repository_dispatch at .github/workflows/update-flake-input.yml,
+# which opens and auto-merges the lock PR. That is NOT Renovate — Renovate's
+# nix support is switched off in .github/renovate.json5 ("Flake inputs handled
+# by update-flake-lock.yml workflow"), so adding lading there would do nothing.
+#
+# That path is HALF-ARMED for lading as of 2026-08-17. The nix-config side is
+# done: `lading` is in both allowlists in update-flake-input.yml (the
+# workflow_dispatch choice list and the case gate), so a manual run works
+# today. The push-to-deploy side still needs a notify-nix-config.yml in
+# carpenike/lading that fires `flake-input-updated` with
+# client_payload.input = "lading" — copy the one in homelab-mcp. Until that
+# exists, nothing watches carpenike/lading, so after pushing lading you MUST
+# bump its input here by hand (or run the workflow manually).
+#
+# On 2026-08-04 that was missed, and the deployed closure ran ahead of the
+# committed lock, meaning the next apply from a clean checkout would have
+# silently rolled a fix back with no diff to explain it. When in doubt, check
+# the deployed closure rather than the lock:
 #   grep -c <symbol> /nix/store/*-lading-*/lib/python*/site-packages/lading/...
-# Adding lading to Renovate's watch list would remove the whole class of bug.
 #
 # One-time setup:
 #   1. Add `carpenike/lading` to the fine-grained GitHub PAT behind the
@@ -140,6 +152,10 @@ let
   forgeDefaults = import ../lib/defaults.nix { inherit config lib; };
 
   serviceName = "lading";
+  # Both units' StateDirectory lands here: the health unit takes
+  # StateDirectory=lading and each sync unit takes lading/<account>.
+  dataDir = "/var/lib/${serviceName}";
+  dataset = "tank/services/${serviceName}";
   listenAddr = "127.0.0.1";
   # 9200 is homelab-mcp, 9210 its Actual sidecar, 9220 schoolhouse. Next in
   # that family; the first schoolhouse deploy failed with EADDRINUSE for
@@ -325,6 +341,158 @@ in
     }
 
     (lib.mkIf serviceEnabled {
+      # ── State: a real dataset, not the rolled-back root ───────────────
+      #
+      # THIS DATASET IS LOAD-BEARING. forge is an impermanence host: the root
+      # dataset is rolled back to rpool/local/root@blank in initrd on EVERY
+      # boot, and only two kinds of path survive it — a directory listed in
+      # modules.system.impermanence.directories (just /var/log, /var/lib/cache
+      # and /var/lib/nixos), or a ZFS dataset mounted over the path. Until
+      # this declaration existed lading had NEITHER, so /var/lib/lading was
+      # ordinary root-dataset state and every reboot silently emptied it.
+      #
+      # What that cost, concretely — none of it visible in any dashboard,
+      # because a wiped state directory and a first-ever run look identical:
+      #
+      #   * The Costco and Sam's Club refresh tokens are ROTATING. Azure B2C
+      #     hands back a new one on every use and the live value lives here,
+      #     not in sops. Losing it silently falls back to re-seeding from
+      #     lading/<account>/{costco,samsclub}_tokens, and that seed is good
+      #     for about 90 days. So the failure is deferred, not avoided: the
+      #     first reboot after the seed goes stale is when warehouse receipts
+      #     stop, and the seed's shelf life is being spent by every reboot.
+      #   * The Amazon cookie jar is a LIVE AUTHENTICATED SESSION. Losing it
+      #     forces a full login on the next run — which is exactly the path
+      #     that hit a JavaScript challenge on 2026-08-04 and had to be
+      #     unblocked by hand-copying a jar from another host.
+      #   * Re-seeding Sam's is not a browser snippet. It needs that person's
+      #     PHONE behind a proxy with a CA installed (see syncAccounts above).
+      #
+      # It also meant lading was invisible to the protection manifest, so no
+      # assertion in flake.nix could ever have caught the gap — the manifest
+      # only sees declared datasets.
+      #
+      # ── CUTOVER: READ BEFORE THE FIRST APPLY ─────────────────────────
+      #
+      # On the first apply, ZFS mounts this new EMPTY dataset over
+      # /var/lib/lading. OpenZFS mounts over a non-empty directory happily
+      # (overlay=on), so the live tokens are not deleted — they are HIDDEN
+      # underneath on the root dataset, and the next boot's rollback then
+      # destroys them for good. Applying without this sequence therefore
+      # spends the one thing this change exists to protect:
+      #
+      #   1. systemctl stop lading-sync-ryan.timer lading-sync-steffi.timer
+      #      systemctl stop lading.service
+      #   2. cp -a /var/lib/lading /var/lib/lading.premigration
+      #      (still on the rolled-back root — do not reboot from here)
+      #   3. task nix:apply-nixos host=forge     # dataset created and mounted
+      #   4. cp -a /var/lib/lading.premigration/. /var/lib/lading/
+      #      chown -R lading:lading /var/lib/lading
+      #   5. systemctl start lading.service
+      #      systemctl start lading-sync-ryan.service   # verify on real tokens
+      #      journalctl -u lading-sync-ryan -n 50
+      #      Expect "amazon session authenticated" and a Costco/Sam's fetch
+      #      that does NOT report re-seeding from the sops seed.
+      #   6. Only once that run is clean: rm -rf /var/lib/lading.premigration
+      #      and restart the timers.
+      #
+      # If a reboot intervenes before step 4, the sops seeds still cover you —
+      # but that spends ~90 days of Costco/Sam's shelf life and forces a fresh
+      # Amazon login. Do not treat it as a free fallback.
+      modules.storage.datasets.services.${serviceName} = {
+        mountpoint = dataDir;
+        # Small JSON credential files (cookie jars, token blobs), not bulk.
+        recordsize = "16K";
+        compression = "zstd";
+        properties = {
+          atime = "off";
+          "com.sun:auto-snapshot" = "true";
+        };
+        owner = serviceName;
+        group = serviceName;
+        # 0700, matching signal-api and homelab-mcp rather than the 0755 a
+        # bare StateDirectory would leave: everything in here is a credential
+        # that can place Amazon orders. Both units run as lading, so nothing
+        # legitimate needs to traverse it. systemd cannot chmod a pre-existing
+        # ZFS mountpoint, which is why the mode is set here.
+        mode = "0700";
+
+        protection = {
+          # Standard, not critical. Losing this dataset loses no household
+          # RECORD — the orders, receipts and transactions all live in
+          # PostgreSQL, which pgBackRest covers with PITR to two repositories.
+          # What is lost is session and token state, which is reconstructible.
+          # It is not FREE to reconstruct (a phone behind mitmproxy for Sam's,
+          # a DevTools capture for Costco, a challenge-prone login for
+          # Amazon), which is why it is not ephemeral either.
+          class = "standard";
+          objectives = {
+            # The sync is daily, so a day of token rotation is the most that
+            # can be lost between snapshots without consequence.
+            onsiteRpoSeconds = 86400;
+            offsiteRpoSeconds = null;
+            rtoSeconds = 28800;
+          };
+          requiredTiers = [
+            "local-snapshot"
+            "replication"
+            "nas-backup"
+          ];
+          consistency = "crash-consistent";
+          # Deliberately null. See the note on the `validator` option in
+          # lib/types/protection.nix: nothing consumes this field yet, and
+          # naming a checker that does not exist would assert a guarantee
+          # this dataset does not have.
+          validator = null;
+
+          # true, and this is the honest reading rather than a shortcut.
+          # There is no preseed unit for lading, so `automated-restore` is not
+          # claimed above. An empty dataset IS a supported state: the units
+          # re-seed the warehouse tokens from sops and re-login to Amazon.
+          # That path works — it is just expensive and challenge-prone, which
+          # is the entire argument for keeping the live state instead of
+          # relying on it.
+          allowEmptyBootstrap = true;
+
+          notes = ''
+            Holds rotating Costco/Sam's Club refresh tokens and a live Amazon
+            cookie jar. The sops secrets lading/<account>/{costco,samsclub}_tokens
+            are SEEDS, not backups: they are installed only when no live token
+            exists and expire in roughly 90 days. Treat the contents as
+            credentials — the Amazon session can place orders and change
+            shipping addresses.
+          '';
+        };
+      };
+
+      modules.backup.sanoid.datasets.${dataset} =
+        forgeDefaults.mkSanoidDataset serviceName;
+
+      # NAS backup only, no r2-offsite copy, and that is a decision rather
+      # than an omission.
+      #
+      # The offsite copy of this credential material already exists and is not
+      # here: lading/<account>/{costco,samsclub}_tokens live in
+      # hosts/forge/secrets.sops.yaml, which is in git and encrypted to the
+      # offline PGP key. In the disaster this would protect against — the site
+      # is gone and forge is rebuilt — any live token restored from R2 would
+      # be long past its rotation window anyway, so it would buy nothing the
+      # seeds do not already buy. Pushing a live Amazon session cookie to a
+      # third-party bucket for that non-benefit is the wrong trade.
+      #
+      # If the offsite calculus changes (e.g. the seeds stop being maintained,
+      # or a second membership makes re-seeding materially harder), revisit
+      # this and add `offsite-backup` to requiredTiers at the same time.
+      modules.services.backup.restic.jobs.${serviceName} = {
+        enable = true;
+        repository = forgeDefaults.backup.repository;
+        paths = [ dataDir ];
+        tags = [ serviceName "credentials" "finances" "forge" ];
+        frequency = "daily";
+        useSnapshots = true;
+        zfsDataset = dataset;
+      };
+
       # The health endpoint being down is a nuisance; the SYNC being broken is
       # the failure that matters, and it is silent by construction — a scraper
       # that stopped working looks exactly like a quiet month of not buying

--- a/hosts/forge/services/pgbackrest.nix
+++ b/hosts/forge/services/pgbackrest.nix
@@ -1124,6 +1124,49 @@ in
       };
     };
 
+    # Restore drills. The services above have existed since the drill work
+    # landed, but nothing scheduled them, so they had never run outside a
+    # manual `systemctl start` - a restore capability that is built but not
+    # armed proves nothing. These timers arm them; the
+    # `pgbackrest-restore-drill-*` alert rules below are what make a drill
+    # that quietly stops running visible.
+    #
+    # WEEKLY, not daily, and on the weekend. A drill takes the exclusive
+    # pgBackRest backup lock (see backupLockScript) for its whole run, so
+    # while it works the hourly incremental waits. That is acceptable once a
+    # week at a quiet hour and would not be nightly. Repo2 additionally pulls
+    # a full backup back down from R2, which costs egress.
+    #
+    # Persistent = false, unlike every other timer in this file. Those are
+    # backups: a missed run is data at risk and must catch up at boot. This is
+    # a verification job with an 8h timeout that seizes the backup lock -
+    # firing it automatically moments after a boot, which is exactly when the
+    # host is least idle, trades a real risk for no benefit. A skipped week is
+    # absorbed by the 9-day staleness threshold on the alert below.
+    pgbackrest-restore-drill-repo1 = {
+      description = "Weekly pgBackRest repo1 (NFS) restore drill timer";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        # Saturday, clear of the 02:00/03:00 fulls and the 05:00/06:00 expires.
+        OnCalendar = "Sat 09:00";
+        Persistent = false;
+        RandomizedDelaySec = "30m";
+      };
+    };
+
+    pgbackrest-restore-drill-repo2 = {
+      description = "Weekly pgBackRest repo2 (R2) restore drill timer";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        # A different day from repo1 so two lock-holding drills can never
+        # queue behind each other, and after the Sunday 07:00 repository
+        # check rather than contending with it.
+        OnCalendar = "Sun 10:00";
+        Persistent = false;
+        RandomizedDelaySec = "30m";
+      };
+    };
+
     # Differential backup timer removed - using simplified schedule
     # Daily full (2 AM) + Hourly NFS incremental + Daily R2 incremental (2 PM)
   };
@@ -1523,6 +1566,94 @@ in
       annotations = {
         summary = "pgBackRest spool usage high on {{ $labels.instance }}";
         description = "Archive queue exceeds 8 GiB of its 16 GiB safety limit ({{ $value | humanize1024 }}B). Check both repositories before pgBackRest drops queued WAL and breaks PITR continuity.";
+      };
+    };
+
+    # ── Restore drills ────────────────────────────────────────────────
+    # The drills prove the backups are RESTORABLE, which no other rule here
+    # does: every alert above watches whether a backup was written, not
+    # whether it can be read back. Until the timers above landed, these
+    # metrics were produced by units that nothing ever ran, so the whole
+    # signal was silently absent - which is why the absence rule below
+    # exists alongside the staleness one.
+
+    # Latest drill failed. The drill's cleanup trap writes status=0 on any
+    # failure path, so this covers a bad restore, a corrupt backup, and a
+    # disposable instance that would not start.
+    "pgbackrest-restore-drill-failed" = {
+      type = "promql";
+      alertname = "PgBackRestRestoreDrillFailed";
+      expr = "pgbackrest_restore_drill_status == 0";
+      # Not 0m: a single failure can be an NFS blip or an R2 throttle, and
+      # this is a weekly job, so a few minutes of settle costs nothing.
+      for = "15m";
+      severity = "high";
+      labels = { service = "pgbackrest"; category = "disaster-recovery"; };
+      annotations = {
+        summary = "pgBackRest restore drill failed for repo {{ $labels.repo }} on {{ $labels.instance }}";
+        description = "The disposable restore from repo {{ $labels.repo }} did not complete. The backups in that repository are not proven restorable. Check the drill journal before trusting PITR.";
+        command = "journalctl -u pgbackrest-restore-drill-repo{{ $labels.repo }}.service -xe";
+      };
+    };
+
+    # No successful drill in over 9 days. Tolerates one skipped weekly run
+    # (the timers are Persistent = false, so a reboot spanning the slot skips
+    # that week) but not two. Also covers the never-succeeded case: the drill
+    # writes last_success=0 until its first pass, and time() - 0 is far past
+    # any threshold.
+    "pgbackrest-restore-drill-stale" = {
+      type = "promql";
+      alertname = "PgBackRestRestoreDrillStale";
+      expr = "time() - pgbackrest_restore_drill_last_success_timestamp_seconds > 777600";
+      for = "1h";
+      severity = "medium";
+      labels = { service = "pgbackrest"; category = "disaster-recovery"; };
+      annotations = {
+        summary = "pgBackRest restore drill for repo {{ $labels.repo }} has not succeeded in over 9 days";
+        description = "Restore capability from repo {{ $labels.repo }} is unproven for more than one weekly cycle. Check the drill timer and its last run.";
+        command = "systemctl status pgbackrest-restore-drill-repo{{ $labels.repo }}.timer pgbackrest-restore-drill-repo{{ $labels.repo }}.service";
+      };
+    };
+
+    # The metric series is gone entirely. The staleness rule above is a
+    # comparison against a series, so it matches nothing when the series does
+    # not exist - which is precisely the state this whole item was: drills
+    # built, never run, no metric, and every dashboard green. This rule is
+    # what makes "no signal" distinguishable from "good signal".
+    #
+    # The textfile collector files are pre-created empty by tmpfiles, so an
+    # empty file exports no series rather than a zero.
+    "pgbackrest-restore-drill-metrics-absent" = {
+      type = "promql";
+      alertname = "PgBackRestRestoreDrillMetricsAbsent";
+      expr = "absent(pgbackrest_restore_drill_last_success_timestamp_seconds)";
+      # Long window: node_exporter restarts and the drill's own metric
+      # rewrite (temp file then rename) must not trip this.
+      for = "6h";
+      severity = "medium";
+      labels = { service = "pgbackrest"; category = "disaster-recovery"; };
+      annotations = {
+        summary = "pgBackRest restore drill metrics are absent on forge";
+        description = "No pgbackrest_restore_drill_* series is being scraped, so neither drill has ever written metrics or the textfile collector is not reading them. Restore capability is entirely unverified.";
+        command = "ls -l /var/lib/node_exporter/textfile_collector/pgbackrest-restore-drill-repo*.prom; systemctl list-timers 'pgbackrest-restore-drill-*'";
+      };
+    };
+
+    # Unit-level failure, which catches what the status metric cannot: a
+    # drill killed by the 8h TimeoutStartSec or by the OOM killer never runs
+    # its cleanup trap, so it never writes status=0. Mirrors the
+    # pgbackrest-backup-failed rule above.
+    "pgbackrest-restore-drill-unit-failed" = {
+      type = "promql";
+      alertname = "PgBackRestRestoreDrillUnitFailed";
+      expr = ''node_systemd_unit_state{name=~"pgbackrest-restore-drill-repo[12][.]service",state="failed"} == 1'';
+      for = "0m";
+      severity = "high";
+      labels = { service = "pgbackrest"; category = "disaster-recovery"; };
+      annotations = {
+        summary = "pgBackRest restore drill unit {{ $labels.name }} failed on {{ $labels.instance }}";
+        description = "A restore drill unit entered the failed state. If the status metric is stale rather than 0, the run was killed before its cleanup trap could record the outcome - check for a timeout or an OOM kill, and confirm the disposable instance and its restore directory were cleaned up.";
+        command = "systemctl status {{ $labels.name }}";
       };
     };
 

--- a/lib/types/protection.nix
+++ b/lib/types/protection.nix
@@ -52,11 +52,32 @@ in
         description = "Consistency guarantee required from a recovery point.";
       };
 
+      # NOT ENFORCED. Nothing reads this field: there is no validator runner,
+      # no systemd unit, no check that dispatches on the identifier. Roughly
+      # twenty-five datasets name one ("plex-library-database",
+      # "signal-api-registration", "actual-sqlite-integrity", ...) and not one
+      # of those names resolves to an implementation anywhere in this repo.
+      #
+      # So a non-null value here documents an INTENTION - "this is the check a
+      # human should run after restoring" - and must not be read as a
+      # guarantee that anything verifies the restore. Assuming enforcement
+      # that does not exist is how a restore gets declared good on the
+      # strength of a string.
+      #
+      # Deciding between building a runner and annotating the field as
+      # explicitly aspirational is open work; until then, prefer null over
+      # inventing a plausible-sounding identifier.
       validator = mkOption {
         type = types.nullOr types.str;
         default = null;
         example = "sqlite-integrity";
-        description = "Identifier for the semantic validator required after restore.";
+        description = ''
+          Identifier for the semantic validator required after restore.
+
+          Advisory only: no code consumes this field today. It records the
+          post-restore check an operator should perform, not a check the
+          system runs.
+        '';
       };
 
       allowEmptyBootstrap = mkOption {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,6 +130,7 @@ nav:
       - Backup System: backup-system-onboarding.md
       - Unified Backup Design: unified-backup-design-patterns.md
       - Disaster Recovery: disaster-recovery-preseed-pattern.md
+      - Recovery Drills: disaster-recovery-drills.md
       - Preseed Restore Methods: preseed-restore-methods-guide.md
       - Flake Management: flake-management.md
       - Garbage Collection: nix-garbage-collection.md


### PR DESCRIPTION
Acts on the 2026-08-17 fresh-eyes review of the household finance stack.
Five items landed as described, one was reframed after verification, one
was recorded rather than fixed.

Offsite coverage (r2-offsite had 3 of 61 jobs; two critical datasets absent)

* Actual Budget: the household ledger was class=critical requiring
  offsite-backup, and flake.nix asserted the gap instead of closing it.
  Adds `actual-offsite`, modelled on the signal-api precedent.
* /persist: holds the SSH host key that IS forge's SOPS identity
  (sops.age.sshKeyPaths), and had no restic job at all - only snapshots
  and replication to nas-1, both in the same building. Adds
  `system-persist-offsite`.

  This does not break the bootstrap cycle on its own: reading the R2
  repository needs the restic password and R2 credentials, which are SOPS
  secrets decrypted by the key stored inside it. The offline PGP key is
  still the only entry point. It converts "the PGP key is the only path"
  into "the PGP key unlocks a path" - see docs/disaster-recovery-drills.md,
  which records that drill as NEVER RUN.

pgBackRest restore drills: built but not armed

The repo1/repo2 drill services have existed since the drill work landed;
nothing scheduled them and nothing alerted on their metrics, so they had
never run outside a manual start. Adds weekly timers (Sat/Sun, staggered,
Persistent=false because they seize the backup lock for up to 8h) and four
alerts - failed, stale, unit-failed, and metrics-absent. The absent rule
matters most: a comparison against a series that does not exist matches
nothing, which is exactly the state this was in.

lading: state did not survive a reboot (reframed - worse than reported)

Reported as "tokens in StateDirectory with no declared backup". Verified
against the evaluated config, it was more than that: forge rolls the root
dataset back to @blank in initrd every boot, persisted paths are only
/var/log, /var/lib/cache and /var/lib/nixos, and lading had neither an
impermanence entry nor a ZFS dataset. So /var/lib/lading was wiped on every
reboot - losing the rotating Costco/Sam's refresh tokens (falling back to
sops seeds that expire in ~90 days) and the live Amazon cookie jar (forcing
the login path that hit a JavaScript challenge on 2026-08-04). It was also
invisible to the protection manifest, so no assertion could have caught it.

Adds the dataset, sanoid, a NAS restic job and a protection policy. No
r2-offsite copy, deliberately: the sops seeds already are the offsite copy
of this credential material, and a restored live token would be past its
rotation window anyway.

CUTOVER REQUIRED - do not apply this blind. ZFS mounts the new empty
dataset over the live tokens (overlay=on hides rather than deletes them,
and the next rollback destroys them). The stop/copy/apply/copy-back/verify
sequence is in the module comment.

Monitoring

* mcp.holthome.net had no external check - only a loopback probe of the
  Actual sidecar - so the tunnel, DNS or Caddy vhost could fail with
  everything green. Adds a Gatus check on /healthz, the one route the
  server serves without a bearer token.

Flake input automation

* Adds `lading` to both allowlists in update-flake-input.yml. This arms
  only the manual workflow_dispatch path. PUSH-TO-DEPLOY STILL NEEDS a
  notify-nix-config.yml in carpenike/lading firing `flake-input-updated`;
  that repo is outside this tree. Until then, lading's input must still be
  bumped by hand. The module comment also corrected a wrong fix: Renovate
  cannot watch it, because renovate.json5 disables nix support entirely.

Recorded, not fixed

* nixpkgs: the review called this a stale undocumented pin at 2026-01-08.
  It is neither. That date belongs to nixos-hardware's transitive input;
  the root nixpkgs tracks nixos-25.11 at 2026-06-30. Walking 400 commits of
  flake.lock shows it advancing weekly through 2026-07-01 and then stopping
  dead while the weekly job kept running and finding nothing - the branch
  went EOL upstream. The fix is a channel migration to 26.05, which touches
  every host and overlay and gets its own effort. Recorded in
  docs/workarounds.md under Channel Lifecycle Debt with exit criteria.

* validator: `actual-sqlite-integrity` has no implementation - but neither
  does any of the ~25 other declared validators. Nothing consumes the field.
  Singling out Actual would fix nothing, so the field is now documented as
  advisory in lib/types/protection.nix; building a runner is open work.

Verified: all flake checks evaluate (their asserts pass at instantiation),
no failing NixOS assertions, all 8 hosts evaluate, nixpkgs-fmt/statix/
deadnix clean. The deployment-guard tripwire counts moved 125->131 timers,
57->58 snapshot datasets, 58->61 restic jobs, each accounted for in place.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
