### PR TITLE
docs(dr): correct the recovery drill register — the PGP link is not the gap

### DIFF
--- a/docs/disaster-recovery-drills.md
+++ b/docs/disaster-recovery-drills.md
@@ -16,7 +16,9 @@ operator. An automated drill that runs but is not alerted on is not done either
 | --- | --- | --- | --- | --- | --- |
 | pgBackRest repo1 restore | PostgreSQL is restorable from the NAS repository | Weekly (Sat 09:00) | Yes — `pgbackrest-restore-drill-repo1.timer` | See `pgbackrest_restore_drill_last_success_timestamp_seconds{repo="1"}` | — |
 | pgBackRest repo2 restore | PostgreSQL is restorable from Cloudflare R2 | Weekly (Sun 10:00) | Yes — `pgbackrest-restore-drill-repo2.timer` | See `pgbackrest_restore_drill_last_success_timestamp_seconds{repo="2"}` | — |
-| **PGP identity recovery** | **A total site loss is recoverable at all** | **Annual** | **No — requires the offline key** | **NEVER RUN** | **UNPROVEN** |
+| PGP decrypts the sops tree | The offline key still opens `*.sops.yaml` | Continuous | No — but exercised by ordinary use | Every secrets edit | **PASS** (in routine use) |
+| `/persist` restore from nas-1 | A rebuilt host recovers its identity onsite | Per rebuild | No — `task bootstrap:remote-install RECOVER=true` | Multiple rebuilds | **PASS** |
+| **`/persist` restore from R2** | **Recovery survives losing nas-1 too** | **Annual** | **No** | **NEVER RUN** | **UNPROVEN** |
 
 The two pgBackRest drills were built well before they were scheduled; they had
 never run outside a manual `systemctl start` until the timers landed on
@@ -25,19 +27,50 @@ never run outside a manual `systemctl start` until the timers landed on
 `PgBackRestRestoreDrillUnitFailed`) are what keep them from silently stopping
 again.
 
+### Correction, 2026-08-18
+
+This register's first version carried a single row claiming the whole PGP
+recovery path was NEVER RUN and total site loss was UNPROVEN. That was wrong,
+and the way it was wrong is worth keeping: it reasoned from the code alone and
+never asked the operator what he had actually done.
+
+Two of the three links above are exercised and were already exercised then:
+
+* **The PGP key is in routine use.** There is no age identity on the operator's
+  Mac (no `~/.config/sops/age/keys.txt`, no `SOPS_AGE_*` in the environment),
+  so sops there can only decrypt through PGP. Every edit of a `*.sops.yaml`
+  exercises the link. The primary secret key is offline (`sec#`) and the
+  subkeys live on a hardware token (`ssb>`); the encryption subkey
+  `CA1222AB47BE783C` expires **2027-10-22**.
+* **Restoring `/persist` onsite is battle-tested.** `task
+  bootstrap:remote-install host=<host> RECOVER=true` has been run across
+  several rebuilds. It restores `rpool/safe/persist` and `rpool/safe/home`
+  from nas-1 with syncoid, authenticated by the operator's forwarded SSH
+  agent — see `.taskfiles/bootstrap/Taskfile.yaml`.
+
+What neither of those touches is Cloudflare R2. `RECOVER=true` reads from
+nas-1, so every proven recovery to date assumes nas-1 survived. The
+`system-persist-offsite` Restic job that makes an R2 restore possible at all
+only began running on 2026-08-18, so it has never been restored from.
+
+The remaining gap is therefore narrow and specific: **the R2 leg**, which is
+exactly the leg that matters when the failure takes the whole building.
+
 ---
 
-## PGP identity recovery drill
+## Offsite (R2) identity recovery drill
 
 ### What it proves
 
-That the offline PGP key can still decrypt this repository's secrets, and
-therefore that a rebuilt-from-nothing forge can reach its own backups.
+That `/persist` can be recovered from Cloudflare R2 — that is, that recovery
+works when nas-1 is gone too.
 
-This is the **single most load-bearing untested assumption in the whole
-recovery design**. Everything else has a second path; this does not.
+It is deliberately NOT a test of the PGP key. That link is exercised every time
+someone edits a secrets file (see the correction above). What has never been
+done is walking the chain all the way into the offsite repository and pulling
+the identity back out of it.
 
-### Why it is the whole ballgame
+### Why this specific leg
 
 forge's SOPS identity is derived from `/etc/ssh/ssh_host_ed25519_key`
 (`sops.age.sshKeyPaths`, `hosts/forge/secrets.nix`). That key lives in
@@ -49,9 +82,9 @@ forge's SOPS identity is derived from `/etc/ssh/ssh_host_ed25519_key`
 3. Without those, the offsite Restic repository in R2 is unreadable — including
    the `system-persist-offsite` copy of `/persist` itself.
 
-The only thing that breaks the cycle is the offline PGP key
-`DA80 0206 0402 EC39 B195 451D 5CED 8036 2B5A 4EF2`, which `.sops.yaml` lists
-as a recipient on every `*.sops.yaml`. The working chain is:
+The offline PGP key `DA80 0206 0402 EC39 B195 451D 5CED 8036 2B5A 4EF2` is what
+breaks the cycle — `.sops.yaml` lists it as a recipient on every `*.sops.yaml`.
+The chain is:
 
 ```
 offline PGP key
@@ -61,17 +94,30 @@ offline PGP key
   -> forge's age identity is back, and normal recovery can proceed
 ```
 
-Every link after the first is exercised routinely. The first link is not
-exercised by anything, ever. If that key is lost, corrupted, expired, or its
-passphrase forgotten, the offsite backups are ciphertext with no key and the
-household's data is gone despite three tiers of protection reporting green.
+Link 1 is proven by daily use. Link 2 is a file read. **Links 3 and 4 have never
+been performed against R2** — every recovery to date used `RECOVER=true`, which
+pulls from nas-1 instead. So the chain is proven end-to-end only for failures
+that spare the NAS, which excludes precisely the fire/flood/theft cases the
+offsite copy exists for.
+
+Concretely unproven, and each of these has bitten someone somewhere:
+
+* that the R2 credentials in sops are current and still authorise reads
+* that the Restic repository is initialised, reachable and holds a
+  `system-persist-offsite` snapshot with real content
+* that a restored `ssh_host_ed25519_key` round-trips to the same age identity
+  forge actually uses
+* that the exclusions on the job (`**/var/log/**`, `**/var/lib/cache/**`)
+  didn't remove something recovery needs
 
 ### Running the drill
 
 Do this on a machine that is **not** forge, from a checkout of this repo, with
-the offline key's media attached. The point is to prove the key works
-independently of any running host — running it on forge would silently use
-forge's own age identity and prove nothing.
+the hardware token attached. Running it on forge would use forge's own age
+identity and its NFS-mounted repositories, and would prove nothing about
+recovering without them — the whole scenario is that forge no longer exists.
+The operator's Mac is the natural place: it already has the token and no age
+identity, so the isolation this drill needs is its normal state.
 
 1. Confirm the key is present and not expired:
 
@@ -79,8 +125,12 @@ forge's own age identity and prove nothing.
     gpg --list-secret-keys --keyid-format LONG DA8002060402EC39B195451D5CED80362B5A4EF2
     ```
 
-    Check the `expires:` field. A key that expires between drills is a silent
-    failure — extend it now rather than discovering it during an outage.
+    Check `expires:` on the `[E]` encryption subkey — that is the one sops uses.
+    As of 2026-08-18 it is `CA1222AB47BE783C`, expiring **2027-10-22**. Extend it
+    before then rather than discovering it during an outage; a key that expires
+    between drills is a silent failure. `sec#` and `ssb>` are expected here and
+    are not problems: they mean the primary secret is kept offline and the
+    subkeys live on a hardware token, so the token must be attached.
 
 2. Decrypt a secret using **only** that key. Unset any age identity first so a
    stray `SOPS_AGE_KEY_FILE` cannot satisfy the decryption and produce a false
@@ -124,14 +174,36 @@ forge's own age identity and prove nothing.
    drill that ran but was not recorded did not happen, because the next person
    cannot tell.
 
+### After a pass: build `RECOVER_SOURCE=r2`
+
+Running this by hand proves the path exists. It does not make the path
+*usable under stress*, which is the point of a recovery mechanism.
+
+`docs/analysis/forge-backup-recovery-improvement-plan.md` already carries the
+follow-up: *"Add `RECOVER_SOURCE=nas|r2` after offsite system backups exist."*
+That precondition was met on 2026-08-18. Today
+`task bootstrap:remote-install host=<host> RECOVER=true` restores from nas-1
+only — hard-coded to `ryan@nas-1:backup/<host>/zfs-recv/...` — so in a
+lost-the-building scenario the operator is improvising Restic commands from
+memory during the worst week of their year.
+
+Once this drill passes, the commands it used are the specification for that
+task. Write them down there while they are fresh.
+
 ### Failure modes worth naming
 
-- **Key expired.** Extend the expiry and re-encrypt. Cheap now, fatal later.
-- **Passphrase forgotten.** There is no recovery from this. If the passphrase
-  is not independently escrowed, the drill's real finding is that the
-  escrow does not exist.
-- **Media unreadable.** Offline media degrades. If this drill is the only time
-  the media is read, an annual read is also the only thing keeping bit rot
-  visible.
-- **Step 2 passes without prompting.** Not a pass. Re-run in a clean
-  environment; something supplied an age identity.
+- **R2 credentials stale or revoked.** The most likely failure, and invisible
+  day to day: nothing else in the system reads `restic/r2-prod-env` from a
+  machine that is not forge.
+- **Repository unreachable or empty.** A Restic job that runs and reports
+  success still proves nothing until something reads the repository back.
+- **Restored key does not match.** If the fingerprint in step 4 differs from
+  forge's live host key, the offsite copy is of the wrong thing, and every
+  conclusion drawn from "offsite-backup: covered" is wrong with it.
+- **Step 2 passes without prompting.** Not a pass. Re-run with the environment
+  cleared; something supplied an age identity and the isolation was not real.
+- **Key expired.** Not currently a risk — `2027-10-22` — but it becomes one
+  silently. Extend it well before, and re-encrypt.
+- **Passphrase forgotten, or token lost.** There is no recovery from either. If
+  neither the passphrase nor a backup token is independently escrowed, the
+  drill's real finding is that the escrow does not exist.

--- a/hosts/forge/infrastructure/storage.nix
+++ b/hosts/forge/infrastructure/storage.nix
@@ -254,11 +254,18 @@ in
   #     -> restore /persist from this repository
   #     -> forge's own age identity is back
   #
-  # So this job converts "the PGP key is the only path" into "the PGP key
-  # unlocks a path", which is a materially better position but still rests on
-  # that key. The PGP recovery drill is the load-bearing untested step and is
-  # tracked in docs/disaster-recovery-drills.md - do not treat this job as
-  # having closed the risk on its own.
+  # The PGP link itself is NOT the weak point, contrary to what this comment
+  # said when the job landed: there is no age identity on the operator's Mac,
+  # so every edit of a sops file already exercises it. Nor is restoring
+  # /persist untested in general - `task bootstrap:remote-install RECOVER=true`
+  # has done it across several rebuilds.
+  #
+  # What is untested is THIS repository. RECOVER=true pulls from nas-1, so
+  # every proven recovery so far assumed the NAS survived - which is the one
+  # assumption a fire does not grant. Until the offsite drill in
+  # docs/disaster-recovery-drills.md passes, treat this job as an untested
+  # copy rather than a recovery path, and do not let "offsite-backup:
+  # covered" in the protection manifest imply otherwise.
   #
   # r2-offsite only, deliberately. The NAS already holds a full replica of
   # this dataset via Syncoid; a second onsite copy in a different format would


### PR DESCRIPTION
The register landed yesterday claiming the whole PGP recovery path was NEVER
RUN and total site loss UNPROVEN. That was wrong. It reasoned from the code
alone and never asked the operator what he had actually done.

Two of the three links are exercised, and already were:

* The PGP key is in routine use. There is no age identity on the operator's
  Mac (no ~/.config/sops/age/keys.txt, no SOPS_AGE_* in the environment), so
  sops there can only decrypt through PGP — every secrets edit exercises it.
  Primary secret offline (sec#), subkeys on a hardware token (ssb>), encryption
  subkey CA1222AB47BE783C expiring 2027-10-22.
* Restoring /persist is battle-tested. `task bootstrap:remote-install
  RECOVER=true` has run across several rebuilds, restoring rpool/safe/persist
  and rpool/safe/home from nas-1 via syncoid over a forwarded SSH agent.

Neither touches Cloudflare R2. RECOVER=true reads from nas-1, so every proven
recovery to date assumed the NAS survived — the one assumption a fire does not
grant. The system-persist-offsite job that makes an R2 restore possible only
started running 2026-08-18 and has never been restored from.

So the gap is narrow and specific: the R2 leg. The drill is rescoped to that,
the register splits into three rows with honest per-link status, and the
failure modes are rewritten around what can actually fail there (stale R2
credentials, an unread repository, a restored key that doesn't match, exclusions
that removed something recovery needs) rather than around key loss.

Also records the follow-up the improvement plan already anticipated: with
offsite system backups now existing, RECOVER_SOURCE=nas|r2 is buildable, and a
passing drill is its specification. Today RECOVER=true hard-codes nas-1, so a
lost-the-building recovery means improvising restic commands under stress.

storage.nix carried the same wrong claim on the job itself; corrected there too,
including a warning not to read "offsite-backup: covered" in the protection
manifest as evidence the path works.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
