### PR TITLE
feat(homelab-mcp): grant homelab_list_status to the advisor scope

### DIFF
--- a/hosts/forge/services/homelab-mcp.nix
+++ b/hosts/forge/services/homelab-mcp.nix
@@ -244,6 +244,14 @@ in
               # services/hermes-agent.nix — two deliberate steps, not one.
               "nixos_apply_config"
               "nixos_deploy_status"
+              # homelab_list_status — superset rule: the advisor must be
+              # able to reproduce anything hermes can say (it needed this
+              # read to check hermes's own claims during the 08-12..15
+              # wedge diagnosis). Granted 2026-08-18, Ryan-approved
+              # (finances DECISIONS; mcp#61 is the source-of-truth half —
+              # this line is the one with effect until nix consumes the
+              # scopes.json artifact).
+              "homelab_list_status"
             ];
             # DELIBERATELY NO amazon_* HERE, and do not add them while
             # "filling out the list". Purchase history leaks gifts before they


### PR DESCRIPTION
Closes a superset hole rather than widening access to something new: hermes
already had `homelab_list_status`, and the advisor did not. So the ambient
agent could report homelab status while the agent whose job is to check its
claims could not reproduce them — which is backwards, and was felt during the
08-12..15 wedge diagnosis when verifying what hermes was saying meant going
around the advisor entirely.

The rule this restores: the advisor must be able to reproduce anything hermes
can say. Verified after the change — advisor is now a proper superset of
hermes (54 tools vs 13, none missing).

Deliberately unchanged: hermes still carries no `amazon_*`, `costco_*`,
`samsclub_*` or `school_*`, all confirmed absent after this edit. This grants
one read to the MORE restricted-by-purpose scope, not a general loosening, and
`homelab_list_status` is a status read with no side effects.

Ryan-approved 2026-08-18 (finances DECISIONS). mcp#61 is the source-of-truth
half; this line is the one with effect until nix consumes the scopes.json
artifact, at which point this list should be generated rather than
hand-maintained and this commit's edit site disappears.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
