### PR TITLE
feat(forge): PocketID as authorization server for the WWW MCP connector

### DIFF
--- a/hosts/forge/services/pocketid.nix
+++ b/hosts/forge/services/pocketid.nix
@@ -67,6 +67,19 @@ in
           LOG_JSON = true;
           METRICS_ENABLED = true;
           UI_CONFIG_DISABLED = true;
+          # Client ID Metadata Documents (CIMD), required for the Claude mobile
+          # connector to reach whiskeywhiskeywhiskey.org/api/mcp. An EMPTY
+          # allowlist (the default) disables metadata-document clients and makes
+          # discovery advertise `client_id_metadata_document_supported: false`,
+          # which sends Claude down the Dynamic Client Registration path that
+          # Pocket ID does not implement.
+          #
+          # Scoped to the /oauth/ subtree deliberately, NOT `https://claude.ai/**`:
+          # published Claude artifacts are served under claude.ai/code/artifact/...,
+          # so a whole-origin wildcard would let a crafted artifact register itself
+          # as an OAuth client. `**` is a globstar and crosses path segments; a
+          # single `*` would not.
+          CIMD_URL_ALLOWLIST = ''["https://claude.ai/oauth/**"]'';
           FILE_BACKEND = "filesystem"; # Required to be "filesystem", "database", or "s3" in v1.16.0+
           UPLOAD_PATH = "${dataDir}/uploads";
           KEYS_STORAGE = "database";

--- a/hosts/forge/services/whiskeywhiskeywhiskey.nix
+++ b/hosts/forge/services/whiskeywhiskeywhiskey.nix
@@ -124,6 +124,32 @@ in
           WWW_APK_DIR = "${dataDir}/apk";
           WWW_PHOTO_DIR = "${dataDir}/op-photos";
 
+          # OAuth RESOURCE-SERVER mode (docs/POCKETID_RESOURCE_SERVER.md).
+          # With these set, the bunker stops acting as its own authorization
+          # server for MCP and accepts access tokens minted by Pocket ID, so the
+          # Claude MOBILE app can attach as a connector (mobile does real OAuth
+          # and cannot use the mcp-remote stdio bridge). The RFC 9728 protected
+          # resource metadata flips to advertise Pocket ID as the issuer.
+          #
+          # WWW_EXTERNAL_AS_RESOURCE is REQUIRED whenever the issuer is set —
+          # the server refuses to boot with only one of them. It is the expected
+          # `aud` on every incoming token and is the control that stops a token
+          # Pocket ID minted for some other client being replayed here, so it
+          # must match the Pocket ID API resource EXACTLY (see the API named
+          # "Whiskey Whiskey Whiskey MCP"; Pocket ID strips trailing slashes and
+          # so does the resource-server code).
+          #
+          # Deliberately NOT setting WWW_EXTERNAL_AS_REQUIRED_SCOPE: Claude picks
+          # scopes from the 401's `scope` param, else the PRM's `scopes_supported`,
+          # else the AS metadata. This server sends neither, so Claude will never
+          # request `mcp:access` and requiring it would reject every real token.
+          # The audience check is the sound control on its own.
+          #
+          # Rollback: drop these two lines and redeploy. The embedded
+          # authorization server is still present and resumes serving.
+          WWW_EXTERNAL_AS_ISSUER = pocketIdIssuer;
+          WWW_EXTERNAL_AS_RESOURCE = "https://${apexDomain}/api/mcp";
+
           # Op cover-image generation (HOF-063). Non-secret default provider
           # selector; the matching API keys are secrets injected via the SOPS
           # env template (see hosts/forge/secrets.nix). The feature is INERT


### PR DESCRIPTION
Makes `whiskeywhiskeywhiskey.org` a plain OAuth **resource server** that accepts PocketID-minted access tokens, so the Claude **mobile** app can attach as a connector. Mobile does real OAuth and cannot use the `mcp-remote` stdio bridge, which is what motivated this.

The application code shipped dormant in whiskey PR #48 (deployed rev `05c02e4`); this is the deployment-side cutover.

## Changes

**`pocketid.nix`** — set `CIMD_URL_ALLOWLIST`. An empty allowlist (the default) disables metadata-document clients and makes discovery advertise `client_id_metadata_document_supported: false`, which sends Claude down the Dynamic Client Registration path PocketID does not implement. Because this host runs `UI_CONFIG_DISABLED = true`, the value **cannot** be set through the admin API or web UI (`PUT` returns `ui_config_disabled`) — it is only settable here.

Scoped to `https://claude.ai/oauth/**` rather than the whole origin on purpose: published Claude artifacts are served under `claude.ai/code/artifact/...`, so a whole-origin wildcard would let a crafted artifact serve a self-referential CIMD document and register itself as an OAuth client. `**` is a globstar and crosses path segments; a single `*` would not.

**`whiskeywhiskeywhiskey.nix`** — set `WWW_EXTERNAL_AS_ISSUER` and `WWW_EXTERNAL_AS_RESOURCE`. The resource is the expected `aud` on every incoming token and must match the PocketID API resource exactly; it is what stops a token minted for another client being replayed here.

`WWW_EXTERNAL_AS_REQUIRED_SCOPE` is deliberately left **unset**. Claude picks scopes from the 401 challenge, else the PRM `scopes_supported`, else the AS metadata. This server sends neither, so Claude never requests `mcp:access` and requiring it would reject every real token. The audience check is the sound control on its own.

## Out-of-band prerequisite (already done)

An API is registered in PocketID with resource `https://whiskeywhiskeywhiskey.org/api/mcp`, permission `mcp:access`, and "allow all metadata document clients" enabled. PocketID rejects any RFC 8707 `resource` naming an unregistered API at `/authorize` — with a misleading `invalid_request` that blames `resource` *or* `scope`. This is PocketID database state, so it survived the revert described below.

## Verification

Applied locally to forge (generation 1594) and verified: discovery advertised CIMD `true`; the RFC 9728 PRM listed `https://id.holthome.net`; the 401 challenge pointed at the PRM; PocketID `healthz` 204 with all 22 OIDC clients intact; SSO unaffected across the `caddy-security` fleet.

That local generation was then superseded by the nightly `nixos-upgrade` at 04:04, which rebuilds from `github:carpenike/nix-config` main and reverted both settings — which is why this needs to land here rather than on a local deploy.

**Not yet proven:** the Claude mobile connector round trip against PocketID. A connector re-add while the revert was in effect fell through to the embedded AS via DCR (`POST /oauth/register`), confirming the discovery chain works but exercising the old path.

## Rollback

Drop the two `WWW_EXTERNAL_AS_*` lines and redeploy. The embedded authorization server is still present and resumes serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)