### PR TITLE
fix(cooklang): refresh npmDepsHash for the v0.34.0 bump

### DIFF
--- a/pkgs/cooklang-cli.nix
+++ b/pkgs/cooklang-cli.nix
@@ -15,7 +15,7 @@ let
     pname = "cooklang-frontend-assets";
     inherit (src) version;
     inherit (src) src;
-    npmDepsHash = "sha256-HbuCSCgEz9FZsb5DJ37twFdxsuin0k4osqb8BP6XEI0=";
+    npmDepsHash = "sha256-ZSRd4tcAsR1tKZ8ZBcb95C1FWEaijsA0WQ5EME0cOfo=";
 
     # Two build scripts, so npmBuildScript (singular) does not fit.
     buildPhase = ''


### PR DESCRIPTION
**Unblocks all forge deploys.** Currently every `nixos-rebuild` fails, including the nightly `nixos-upgrade`.

## Cause

nvfetcher bumped CookCLI to `v0.34.0` in [`b7a26ded`](https://github.com/carpenike/nix-config/commit/b7a26ded) (#876), updating `pkgs/_sources/generated.nix`. But `npmDepsHash` in `pkgs/cooklang-cli.nix` is **hand-maintained** — nvfetcher has no visibility into the vendored npm tree — so the new source got paired with the v0.33.x hash:

```
hash mismatch in fixed-output derivation
  cooklang-frontend-assets-v0.34.0-npm-deps.drv
  specified: sha256-HbuCSCgEz9FZsb5DJ37twFdxsuin0k4osqb8BP6XEI0=
  got:       sha256-ZSRd4tcAsR1tKZ8ZBcb95C1FWEaijsA0WQ5EME0cOfo=
```

## Why it looked worse than it was

The failure propagates `cooklang-frontend-assets` → `cooklang-cli` → `unit-cooklang.service` → `system-units` → `etc` → `nixos-system-forge`, so the output reads as a system-wide build failure and invites blaming whatever else happened to be building in the same batch. It also explains the **Update nvfetcher** workflow failure at 05:42 today.

## Verification

Full `task nix:build-nixos host=forge` on the target (x86_64-linux):

```
patching script interpreter paths in …/cooklang-cli-v0.34.0
building …/unit-cooklang.service.drv
building …/nixos-system-forge-25.11.20260630.b6018f8.drv
Done. The new configuration is /nix/store/ixwdh2265cimc1q832lyc2ar12vfcs35-nixos-system-forge-…
```

Exit 0, no hash mismatches. `task nix:validate` clean, 0/6747 files need reformatting.

## Recurrence

This is the **second** CookCLI bump to break this way — [`2732d7ab`](https://github.com/carpenike/nix-config/commit/2732d7ab) restored the v0.33.1 build for the same reason. The source rev and `npmDepsHash` are updated by different mechanisms with nothing linking them, so every upstream release can reproduce it.

Worth teaching the nvfetcher workflow to run `prefetch-npm-deps` and write `npmDepsHash` in the same job, so the update PR either arrives correct or fails in CI rather than at deploy time. Deliberately **not** folded in here — a build-blocking fix should stay minimal and obviously correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)