### PR TITLE
ci: remove vulnix security scans from build workflows

### DIFF
--- a/.github/workflows/flake-health.yml
+++ b/.github/workflows/flake-health.yml
@@ -84,13 +84,6 @@ jobs:
             -v \
             --log-format raw
 
-      - name: Run vulnix
-        continue-on-error: true
-        run: |
-          nix run nixpkgs/nixos-unstable#vulnix -- \
-            -w https://raw.githubusercontent.com/ckauhaus/nixos-vulnerability-roundup/master/whitelists/nixos-unstable.toml \
-            ./profile | tee security.txt
-
       # Snapshot of *what* was built so the artifact has debuggable provenance
       # without uploading the full expanded closure (which can include filenames
       # like `notify-pushover@system-boot:boot.path` that actions/upload-artifact
@@ -115,7 +108,5 @@ jobs:
           # files), which both blew the artifact size and tripped the NTFS
           # filename validator on `:` in unit-name@instance:value paths.
           # See `closure.txt` for the path manifest.
-          path: |
-            security.txt
-            closure.txt
+          path: closure.txt
           if-no-files-found: ignore

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -269,18 +269,12 @@ jobs:
           fi
           exit 1
 
-      - name: Scan for security issues
-        continue-on-error: true
-        run: |
-          nix run nixpkgs/nixos-unstable#vulnix -- -w https://raw.githubusercontent.com/ckauhaus/nixos-vulnerability-roundup/master/whitelists/nixos-unstable.toml ./result | tee security.txt
-
       - name: Upload build artifacts
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: build-report-${{ matrix.system }}
           path: |
-            security.txt
             stdout.log
             /tmp/nix-build-err.log
           if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Removes the `vulnix` scan step from `nix-build.yml` (per-PR matrix) and `flake-health.yml` (daily heavy-host builds), along with the `security.txt` artifact entries.

## Why

The scan was `continue-on-error` with output going only to a 90-day artifact that nothing and nobody consumed — no gate, no diff, no notification. Step-timing data from recent runs showed it was the dominant CI cost:

| Job | Build | vulnix scan |
|---|---|---|
| forge closure (flake-health) | 368s | 2,114s |
| luna closure (flake-health) | 70s | 1,146s |
| nixpi (PR matrix) | 55s | 1,412s |
| nas-0 (PR matrix) | 69s | 550s |

That's ~80–90% of total CI wall-clock spent on a step with zero enforcement value. Duration was also highly variable (72s → 2,114s day-over-day for the same closure) because the step resolved `nixpkgs/nixos-unstable#vulnix` at run time and re-fetched NVD data on every ephemeral runner — the only unpinned run-time dependency in the build path.

## Impact

- PR matrix jobs: ~10–25 min → ~2–4 min
- Daily flake-health jobs: up to ~40 min → under ~10 min
- The `closure.txt` manifest artifact in flake-health is retained; build-log artifacts in nix-build are retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)