### PR TITLE
feat(observability): add Grafana Faro RUM collector for W.W.W.

### DIFF
--- a/hosts/forge/infrastructure/observability/alloy.nix
+++ b/hosts/forge/infrastructure/observability/alloy.nix
@@ -1,0 +1,159 @@
+# Grafana Alloy — browser telemetry (RUM) collector.
+#
+# Stage 1 of front-end observability for Operation W.W.W.: the app's SPA runs
+# the Grafana Faro Web SDK (see upstream `src/telemetry/faro.ts`) and beacons
+# Web Vitals, JS exceptions, page views, sessions and resource timings here.
+# Alloy normalizes them and pushes them into the SAME Loki that already holds
+# forge's journald logs via Promtail, so a browser error and the Fastify
+# request behind it are one Explore query apart.
+#
+# This runs ALONGSIDE Promtail, it does not replace it. Promtail keeps
+# shipping the journal; Alloy only owns the Faro receiver. Nothing here is
+# stateful — no ZFS dataset, no backup job — the process holds at most a few
+# seconds of in-flight beacons.
+#
+# Traffic path:
+#   guest browser
+#     └─► https://whiskeywhiskeywhiskey.org/relay/collect   (Cloudflare Tunnel)
+#         └─► Caddy `handle_path /relay/*`  (strips the prefix)
+#             └─► 127.0.0.1:12347/collect   (faro.receiver, this file)
+#                 └─► 127.0.0.1:3100        (Loki)
+#
+# The `/relay` prefix is defined on the app's own vhost in
+# `hosts/forge/services/whiskeywhiskeywhiskey.nix`. Same-origin on purpose:
+# no CORS preflight, no second Cloudflare hostname, and a path that content
+# blockers don't recognize as an analytics endpoint.
+#
+# NOTE: /relay/collect is UNAUTHENTICATED by necessity — it is called by
+# anonymous guest browsers on the token-gated share pages. faro.receiver's
+# api_key option wouldn't change that (the key would ship in the JS bundle).
+# The controls that matter are the rate limit and payload cap below.
+
+{ config, lib, ... }:
+
+let
+  forgeDefaults = import ../../lib/defaults.nix { inherit config lib; };
+
+  apexDomain = "whiskeywhiskeywhiskey.org";
+
+  # Alloy's own HTTP surface: UI at /, its Prometheus metrics at /metrics.
+  # Loopback only — Prometheus scrapes it from this host.
+  alloyListenAddress = "127.0.0.1";
+  alloyListenPort = 12345;
+
+  # faro.receiver's HTTP server. Loopback only; Caddy is the only caller.
+  faroListenAddress = "127.0.0.1";
+  faroListenPort = 12347;
+
+  lokiPushUrl = "http://127.0.0.1:3100/loki/api/v1/push";
+
+  faroConfig = ''
+    // Browser telemetry from the Operation W.W.W. SPA.
+    //
+    // `extra_log_labels` values that are the EMPTY STRING are promoted from
+    // the beacon payload rather than set statically -- `kind` becomes one of
+    // log | exception | measurement | event | span, which is what makes
+    // {job="faro", kind="exception"} a usable Loki query. Everything else is
+    // pinned here so a forged beacon can't invent its own label values (and
+    // can't blow up Loki's stream cardinality).
+    faro.receiver "www" {
+      extra_log_labels = {
+        kind        = "",
+        job         = "faro",
+        app         = "whiskey-whiskey-whiskey",
+        host        = "forge",
+        environment = "homelab",
+      }
+
+      // JSON lines parse cleanly in Grafana with `| json`; the upstream
+      // default is logfmt, which mangles stack traces.
+      log_format = "json"
+
+      server {
+        listen_address = "${faroListenAddress}"
+        listen_port    = ${toString faroListenPort}
+
+        // Redundant while Caddy proxies this on the app's own origin (a
+        // same-origin POST sends no preflight), but correct if the collector
+        // is ever moved to its own hostname.
+        cors_allowed_origins = ["https://${apexDomain}"]
+
+        // Upstream defaults are 5MiB / 50 rps / burst 100 -- sized for a
+        // commercial front end. This is a household app whose busiest moment
+        // is a dozen guests opening the Briefing Hub at once. Tighten both:
+        // the endpoint is reachable from the public internet and the only
+        // real failure mode is someone filling Loki with junk.
+        max_allowed_payload_size = "512KiB"
+
+        rate_limiting {
+          enabled    = true
+          strategy   = "global"
+          rate       = 10
+          burst_size = 20
+        }
+      }
+
+      // Stack traces stay minified. Vite emits no sourcemaps for the
+      // production build, and turning them on would publish the client
+      // source on the unauthenticated share pages. Left explicitly false
+      // because upstream defaults to download = true with
+      // download_from_origins = ["*"], which is an outbound-fetch surface
+      // driven by attacker-controllable stack frame URLs.
+      sourcemaps {
+        download = false
+      }
+
+      // No `traces` output: tracing is Stage 2 and needs a Tempo to point at.
+      output {
+        logs = [loki.write.faro.receiver]
+      }
+    }
+
+    loki.write "faro" {
+      endpoint {
+        url = "${lokiPushUrl}"
+      }
+    }
+  '';
+in
+{
+  config = {
+    services.alloy = {
+      enable = true;
+      extraFlags = [
+        "--server.http.listen-addr=${alloyListenAddress}:${toString alloyListenPort}"
+        # No usage telemetry back to Grafana Labs.
+        "--disable-reporting"
+      ];
+    };
+
+    # The nixpkgs module reads every *.alloy file under /etc/alloy and wires
+    # them into the unit's reloadTriggers, so editing this re-loads Alloy on
+    # `nixos-rebuild switch` rather than restarting it.
+    environment.etc."alloy/www-faro.alloy".text = faroConfig;
+
+    # Alloy must not start before Loki is accepting pushes, or the first
+    # beacons of a boot are dropped on the floor.
+    systemd.services.alloy = {
+      after = [ "loki.service" ];
+      wants = [ "loki.service" ];
+    };
+
+    # Provisioned RUM dashboard. `path` is a DIRECTORY of dashboard JSON, so
+    # further front-end dashboards drop in alongside this one with no Nix
+    # change. Grafana rescans it every 60s; the files stay editable in the UI
+    # but edits are overwritten on the next rebuild -- the JSON in this repo
+    # is the source of truth.
+    modules.services.grafana.provisioning.dashboards.whiskey-faro = {
+      name = "Operation W.W.W.";
+      folder = "Applications";
+      path = ./dashboards;
+    };
+
+    modules.alerting.rules."alloy-service-down" =
+      forgeDefaults.mkSystemdServiceDownAlert
+        "alloy"
+        "Grafana Alloy"
+        "browser telemetry (Faro) collector";
+  };
+}

--- a/hosts/forge/infrastructure/observability/dashboards/whiskey-faro-rum.json
+++ b/hosts/forge/infrastructure/observability/dashboards/whiskey-faro-rum.json
@@ -1,0 +1,289 @@
+{
+  "uid": "www-faro-rum",
+  "title": "W.W.W. — Browser Telemetry",
+  "description": "Real user monitoring for Operation W.W.W. Signals arrive from the Grafana Faro Web SDK in the SPA, via Alloy's faro.receiver. Counters come from Alloy's own /metrics; everything else is queried out of Loki under {job=\"faro\"}. Share tokens on the #/present and #/hub routes are redacted client-side before send.",
+  "tags": ["whiskey-whiskey-whiskey", "rum", "faro"],
+  "timezone": "browser",
+  "schemaVersion": 41,
+  "version": 1,
+  "editable": true,
+  "refresh": "1m",
+  "time": { "from": "now-24h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Exceptions",
+      "description": "Unhandled JS errors and promise rejections ingested in the selected range.",
+      "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 25 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+          "expr": "increase(faro_receiver_exceptions_total[$__range])",
+          "instant": true,
+          "legendFormat": "exceptions"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Measurements",
+      "description": "Web Vitals samples (LCP, INP, CLS, FCP, TTFB).",
+      "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "decimals": 0, "color": { "mode": "fixed", "fixedColor": "blue" } },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+          "expr": "increase(faro_receiver_measurements_total[$__range])",
+          "instant": true,
+          "legendFormat": "measurements"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Events",
+      "description": "Page views, route changes, session start/resume, resource timings.",
+      "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "fieldConfig": {
+        "defaults": { "unit": "short", "decimals": 0, "color": { "mode": "fixed", "fixedColor": "purple" } },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+          "expr": "increase(faro_receiver_events_total[$__range])",
+          "instant": true,
+          "legendFormat": "events"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Collector in-flight",
+      "description": "Requests currently being served by Alloy's faro.receiver. A number that never returns to zero means the Loki push is backing up.",
+      "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 10 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+          "expr": "sum(faro_receiver_inflight_requests)",
+          "instant": true,
+          "legendFormat": "in-flight"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Ingest rate by signal type",
+      "description": "From Alloy's own counters, so this is what the collector accepted — independent of whether Loki kept it.",
+      "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+          "expr": "rate(faro_receiver_exceptions_total[$__rate_interval])",
+          "legendFormat": "exceptions"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+          "expr": "rate(faro_receiver_events_total[$__rate_interval])",
+          "legendFormat": "events"
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+          "expr": "rate(faro_receiver_measurements_total[$__rate_interval])",
+          "legendFormat": "measurements"
+        },
+        {
+          "refId": "D",
+          "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+          "expr": "rate(faro_receiver_logs_total[$__rate_interval])",
+          "legendFormat": "logs"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Core Web Vitals — p75",
+      "description": "The three Core Web Vitals at the 75th percentile, which is the threshold Google's own scoring uses. LCP and INP are milliseconds; CLS is unitless and plotted on the right axis. Good/needs-work boundaries: LCP 2500ms, INP 200ms, CLS 0.1.",
+      "datasource": { "type": "loki", "uid": "auto-loki-auto" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 0, "showPoints": "never" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "CLS" },
+            "properties": [
+              { "id": "unit", "value": "none" },
+              { "id": "custom.axisPlacement", "value": "right" },
+              { "id": "decimals", "value": 3 }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "auto-loki-auto" },
+          "expr": "quantile_over_time(0.75, {job=\"faro\", kind=\"measurement\"} | json | type=\"web-vitals\" | unwrap value_lcp | __error__=\"\" [$__auto])",
+          "legendFormat": "LCP",
+          "queryType": "range"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "loki", "uid": "auto-loki-auto" },
+          "expr": "quantile_over_time(0.75, {job=\"faro\", kind=\"measurement\"} | json | type=\"web-vitals\" | unwrap value_inp | __error__=\"\" [$__auto])",
+          "legendFormat": "INP",
+          "queryType": "range"
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "loki", "uid": "auto-loki-auto" },
+          "expr": "quantile_over_time(0.75, {job=\"faro\", kind=\"measurement\"} | json | type=\"web-vitals\" | unwrap value_cls | __error__=\"\" [$__auto])",
+          "legendFormat": "CLS",
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "table",
+      "title": "Top exceptions",
+      "description": "Grouped by error message. `page_url` has already had any share token stripped client-side, so a #/present or #/hub row shows the slug and <redacted> in place of the key.",
+      "datasource": { "type": "loki", "uid": "auto-loki-auto" },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 12 },
+      "fieldConfig": {
+        "defaults": { "custom": { "align": "auto", "filterable": true } },
+        "overrides": []
+      },
+      "options": { "showHeader": true, "sortBy": [{ "displayName": "Value", "desc": true }] },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "auto-loki-auto" },
+          "expr": "topk(10, sum by (value, type) (count_over_time({job=\"faro\", kind=\"exception\"} | json [$__range])))",
+          "instant": true,
+          "queryType": "instant"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "logs",
+      "title": "Recent exceptions",
+      "description": "Raw beacons. Expand a line for the minified stacktrace, app_version (the deployed git commit), browser_name/browser_os and session_id.",
+      "datasource": { "type": "loki", "uid": "auto-loki-auto" },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 12 },
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": true,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "auto-loki-auto" },
+          "expr": "{job=\"faro\", kind=\"exception\"}",
+          "queryType": "range"
+        }
+      ]
+    }
+  ]
+}

--- a/hosts/forge/infrastructure/observability/default.nix
+++ b/hosts/forge/infrastructure/observability/default.nix
@@ -8,6 +8,7 @@
   # - Grafana: Metrics and logs visualization dashboards
   # - Loki: Log aggregation and storage
   # - Promtail: Log shipping and collection agent
+  # - Alloy: Browser telemetry (Grafana Faro RUM) receiver -> Loki
 
   imports = [
     ./prometheus.nix
@@ -15,6 +16,7 @@
     ./grafana.nix
     ./loki.nix
     ./promtail.nix
+    ./alloy.nix
   ];
 
   # Enable the thin observability orchestrator

--- a/hosts/forge/infrastructure/observability/prometheus.nix
+++ b/hosts/forge/infrastructure/observability/prometheus.nix
@@ -336,6 +336,17 @@ in
         ];
       }
 
+      # Grafana Alloy — self metrics plus the faro_receiver_* counters
+      # (logs/exceptions/measurements/events accepted, and rejections). This
+      # is the RED view of browser telemetry ingest: if exceptions_total
+      # spikes, the SPA is broken for real users.
+      {
+        job_name = "alloy";
+        static_configs = [
+          { targets = [ "127.0.0.1:12345" ]; labels = { instance = "forge.holthome.net"; host = "forge"; service = "alloy"; }; }
+        ];
+      }
+
       # Alertmanager monitoring
       {
         job_name = "alertmanager";

--- a/hosts/forge/services/whiskeywhiskeywhiskey.nix
+++ b/hosts/forge/services/whiskeywhiskeywhiskey.nix
@@ -84,6 +84,12 @@ let
   listenAddr = "127.0.0.1";
   listenPort = 3417; # matches the port hinted at in the upstream module example
 
+  # Grafana Alloy's faro.receiver, defined in
+  # infrastructure/observability/alloy.nix. Fronted on this vhost at /relay/*
+  # so the SPA can beacon same-origin.
+  faroCollectorHost = "127.0.0.1";
+  faroCollectorPort = 12347;
+
   # systemd StateDirectory name; the upstream module hard-codes
   # `StateDirectory = "whiskey-whiskey-whiskey"`, which yields this path.
   stateDirName = "whiskey-whiskey-whiskey";
@@ -226,6 +232,28 @@ in
           tunnel = "forge";
           dns.zoneName = cloudflareZone;
         };
+
+        # Browser telemetry (Grafana Faro RUM) beacon endpoint.
+        #
+        # `handle_path` strips the /relay prefix, so /relay/collect reaches
+        # Alloy's faro.receiver as its native /collect route (and
+        # /relay/-/ready reaches /-/ready). Despite appearing AFTER the
+        # generated site-level `reverse_proxy` in the rendered Caddyfile,
+        # Caddy's directive ordering runs handle_path first and it is
+        # terminal for matching requests -- verified with `caddy adapt`.
+        #
+        # Same-origin by design: no CORS preflight, no second Cloudflare
+        # hostname to provision, and an innocuous path that content blockers
+        # don't recognize as an analytics endpoint. The SPA hardcodes this
+        # path in src/telemetry/faro.ts -- the two must move together.
+        #
+        # See hosts/forge/infrastructure/observability/alloy.nix for the
+        # receiver, its rate limit and payload cap.
+        extraConfig = ''
+          handle_path /relay/* {
+            reverse_proxy ${faroCollectorHost}:${toString faroCollectorPort}
+          }
+        '';
       };
 
       # Caddy vhost — www → apex 301. handleOnly is required because we do


### PR DESCRIPTION
Stage 1 of front-end observability for Operation W.W.W. — the closest self-hosted analogue to Application Insights that reuses what forge already runs (Prometheus / Grafana / Loki / Alertmanager) rather than standing up a parallel stack.

## What lands

- **`hosts/forge/infrastructure/observability/alloy.nix`** — Grafana Alloy running a single `faro.receiver` on `127.0.0.1:12347`, pushing to the existing Loki under `{job="faro"}`. Runs *alongside* Promtail, does not replace it; Promtail keeps the journal, Alloy only owns the Faro receiver. Stateless, so no ZFS dataset and no backup job.
- **Caddy `/relay/*`** on the app's own vhost → the collector. Same-origin on purpose: no CORS preflight, no second Cloudflare hostname, and a path content blockers don't read as an analytics endpoint.
- **Prometheus scrape** of Alloy's `faro_receiver_*` counters, plus a systemd service-down alert.
- **Provisioned dashboard** — Applications / "W.W.W. — Browser Telemetry" (`www-faro-rum`): ingest rate by signal type, Core Web Vitals p75, top exceptions, raw exception log.

The browser half — the Faro SDK and the share-token redaction — ships separately in carpenike/whiskey-whiskey-whiskey; see its `docs/TELEMETRY.md`.

## Deviations from Alloy defaults, all deliberate

| Setting | Upstream | Here | Why |
| --- | --- | --- | --- |
| `max_allowed_payload_size` | 5 MiB | 512 KiB | endpoint is internet-facing |
| `rate_limiting` | 50 rps / burst 100 | 10 rps / burst 20 | ditto |
| `sourcemaps.download` | `true`, origins `["*"]` | `false` | outbound fetch driven by attacker-controllable stack-frame URLs |
| `log_format` | logfmt | json | logfmt mangles stack traces |

`/relay/collect` is unauthenticated by necessity — anonymous guests on the token-gated share pages call it, and `api_key` would ship in the JS bundle. The rate limit and payload cap are the controls that actually matter.

## Verification

- Full `nixosConfigurations.forge` evaluates; rendered `.alloy` file, systemd unit ordering (after `loki.service`), scrape job, alert rule and dashboard provisioning all inspected via `nix eval`.
- **Caddy ordering checked, not assumed.** The module emits `extraConfig` *after* the generated site-level `reverse_proxy`. Ran the actual rendered vhost through `caddy adapt`: `handle_path /relay/*` is ordered first and is terminal for matching requests, so telemetry reaches Alloy and not Fastify.
- Alloy's `/collect` route, every argument name, and the trailing-comma-in-object grammar checked against the v1.12.2 source.
- Pre-commit hooks pass (statix, deadnix, nixpkgs-fmt, gitleaks, check-json).

**Not verified:** Alloy could not be executed locally — it segfaults on Apple Silicon during `go-m1cpu` cgo init, unrelated to this config. The `.alloy` file is validated by reading the v1.12.2 parser, not by running it. `journalctl -u alloy` on first deploy is the real check.

## Merge order

Land this before the app-side PR, so the collector exists before the SPA starts beaconing. (Out of order is harmless — beacons just 404.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)