### PR TITLE
fix(observability): give the Faro dashboard a real store path

### DIFF
--- a/hosts/forge/infrastructure/observability/alloy.nix
+++ b/hosts/forge/infrastructure/observability/alloy.nix
@@ -29,7 +29,7 @@
 # api_key option wouldn't change that (the key would ship in the JS bundle).
 # The controls that matter are the rate limit and payload cap below.
 
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
 let
   forgeDefaults = import ../../lib/defaults.nix { inherit config lib; };
@@ -46,6 +46,23 @@ let
   faroListenPort = 12347;
 
   lokiPushUrl = "http://127.0.0.1:3100/loki/api/v1/push";
+
+  # Grafana's dashboard provider needs a path that EXISTS ON FORGE AT RUNTIME.
+  #
+  # `path = ./dashboards` does not: inside a flake it resolves to a subpath of
+  # the evaluated flake source (/nix/store/<hash>-source/hosts/...), which is a
+  # build-time input, not part of the system closure. It survived `nix eval`
+  # and the deploy, then Grafana logged "failed to walk provisioned dashboards
+  # ... no such file or directory" every 60s and the dashboard never appeared.
+  #
+  # Copying the JSON into a derivation of its own gives the provisioner a real
+  # store path that the closure references and the deploy therefore copies.
+  # (Same shape as the teslamate module, which points at a fetched source
+  # derivation rather than at repo-relative paths.)
+  dashboardsDir = pkgs.runCommandLocal "whiskey-faro-dashboards" { } ''
+    mkdir -p "$out"
+    cp ${./dashboards}/*.json "$out"/
+  '';
 
   faroConfig = ''
     // Browser telemetry from the Operation W.W.W. SPA.
@@ -139,15 +156,15 @@ in
       wants = [ "loki.service" ];
     };
 
-    # Provisioned RUM dashboard. `path` is a DIRECTORY of dashboard JSON, so
-    # further front-end dashboards drop in alongside this one with no Nix
-    # change. Grafana rescans it every 60s; the files stay editable in the UI
-    # but edits are overwritten on the next rebuild -- the JSON in this repo
-    # is the source of truth.
+    # Provisioned RUM dashboard. `dashboardsDir` wraps a DIRECTORY of dashboard
+    # JSON, so further front-end dashboards drop into ./dashboards alongside
+    # this one with no change here. Grafana rescans every 60s; the files stay
+    # editable in the UI but edits are overwritten on the next rebuild -- the
+    # JSON in this repo is the source of truth.
     modules.services.grafana.provisioning.dashboards.whiskey-faro = {
       name = "Operation W.W.W.";
       folder = "Applications";
-      path = ./dashboards;
+      path = dashboardsDir;
     };
 
     modules.alerting.rules."alloy-service-down" =


### PR DESCRIPTION
Follow-up to #913. The RUM dashboard never appeared in Grafana after deploy.

## What went wrong

`path = ./dashboards` resolves, inside a flake, to a subpath of the evaluated flake source — `/nix/store/<hash>-source/hosts/forge/infrastructure/observability/dashboards`. That's a build-time input, not part of the system closure, so nothing ever copied it to forge.

It passed `nix eval`, passed `flake check`, and the deploy reported success. Then Grafana logged this once a minute, forever:

```
logger=provisioning.dashboard type=file name="Operation W.W.W." level=error
msg="failed to walk provisioned dashboards"
error="stat /nix/store/l01n...-source/hosts/forge/infrastructure/observability/dashboards:
       no such file or directory"
```

A silent-at-eval, loud-at-runtime failure — exactly the class that eval-only validation can't catch.

## Fix

Copy the JSON into a derivation of its own, so the provisioner gets a path the closure actually references and the deploy actually copies. Same shape as the `teslamate` module, which points Grafana at a fetched source derivation rather than at repo-relative paths.

## Verification

- Built the derivation and listed its output: contains `whiskey-faro-rum.json`, uid `www-faro-rum`, 8 panels.
- The eval'd provisioning path is now a bare `/nix/store/<hash>-whiskey-faro-dashboards` instead of a subpath of `-source`.

Everything else from #913 is confirmed healthy on forge: `alloy.service` active with 0 restarts, both components evaluated clean, `127.0.0.1:12347` listening, Prometheus `alloy` target `up`, and `GET https://whiskeywhiskeywhiskey.org/relay/-/ready` returns 200 `ready` in 130ms through the full Cloudflare → Caddy → Alloy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)