### PR TITLE
feat(alerting): page when the bunker throws JS errors at users

### DIFF
--- a/hosts/forge/services/whiskeywhiskeywhiskey.nix
+++ b/hosts/forge/services/whiskeywhiskeywhiskey.nix
@@ -322,6 +322,47 @@ in
           "WhiskeyWhiskeyWhiskey"
           "Operation W.W.W. command center";
 
+      # Browser-side error alert.
+      #
+      # Gatus and the systemd alert above both answer "is the server up".
+      # Neither notices the failure mode that actually reaches guests: the
+      # server is healthy, returns 200, and the SPA throws in their browser
+      # -- a bad deploy, a null field the UI didn't guard, a broken share
+      # page on op night. Before this rule the telemetry recorded those
+      # silently and someone had to think to go look at the dashboard.
+      #
+      # Counter comes from Alloy's faro.receiver (see
+      # infrastructure/observability/alloy.nix); `increase` handles the reset
+      # when Alloy restarts.
+      #
+      # Threshold reasoning: real traffic here is a handful of sessions a
+      # week, so a sustained handful of exceptions is not noise -- it is the
+      # app broken for whoever is using it. One transient error should not
+      # page anybody, hence >3 rather than >0, and `for` guards against a
+      # single scrape blip. This is deliberately NOT a rate: at this traffic
+      # volume a per-second rate is always ~0 and would never fire.
+      modules.alerting.rules."${serviceName}-browser-exceptions" = {
+        type = "promql";
+        alertname = "WhiskeyBrowserExceptions";
+        expr = "increase(faro_receiver_exceptions_total[15m]) > 3";
+        for = "5m";
+        severity = "medium";
+        labels = {
+          service = serviceName;
+          category = "application";
+        };
+        annotations = {
+          summary = "Operation W.W.W. is throwing JavaScript errors at users";
+          description =
+            "More than 3 browser exceptions in 15 minutes from the W.W.W. SPA. "
+            + "The server may be perfectly healthy -- this is the client failing. "
+            + "Check the Applications / W.W.W. Browser Telemetry dashboard, or "
+            + "query Loki directly. Stack traces are minified; app_version on each "
+            + "entry is the full git SHA, so compare against the deployed commit.";
+          command = ''logcli query '{job="faro", kind="exception"}' --since=30m'';
+        };
+      };
+
       # Gatus blackbox check from the public side. Lets us know if the full
       # Cloudflare → tunnel → Caddy → app path is healthy.
       modules.services.gatus.contributions.${serviceName} = {


### PR DESCRIPTION
Gatus and the systemd alert both answer "is the server up". Neither notices the failure mode that actually reaches guests: **the server is healthy, returns 200, and the SPA throws in their browser** — a bad deploy, an unguarded null in the UI, a broken share page on op night.

The browser telemetry has been recording those since it shipped, but nothing acted on them. Of forge's 302 alert rules, the only ones touching this stack were `AlloyServiceDown` and `AlloyRestartChurn` — which fire when the *collector* dies, not when the app does.

## The rule

```promql
increase(faro_receiver_exceptions_total[15m]) > 3   for 5m
```

- **`increase`, not `rate`** — real traffic here is a handful of sessions a week, so a per-second rate is always ~0 and would never fire. This was the trap worth avoiding.
- **`> 3`, not `> 0`** — one transient error shouldn't page anybody.
- **`for: 5m`** — guards against a single scrape blip.
- `increase` handles the counter reset when Alloy restarts.

## Why Prometheus and not Loki's ruler

Loki's ruler is enabled in the shared module but has no `alertmanager_url`, so using it would mean changing a module every service depends on, for one rule. The tradeoff is no per-page or per-version grouping in the alert itself — which is why the annotations carry the dashboard link and the `logcli` query to run next.

## Verification

- `promtool check rules` — SUCCESS
- Expression evaluated against forge's **live** Prometheus: 1 series, current 15m increase 0, and the metric has history (2 exceptions ever, both synthetic from the deploy smoke test)

Next in the sequence is server-side RED metrics — the app has no `/metrics` today (that path currently returns the SPA's index.html), so a slow page has no server-side explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)