### PR TITLE
feat(observability): scrape W.W.W. server metrics, block /metrics publicly

### DIFF
--- a/hosts/forge/infrastructure/observability/prometheus.nix
+++ b/hosts/forge/infrastructure/observability/prometheus.nix
@@ -336,6 +336,19 @@ in
         ];
       }
 
+      # Operation W.W.W. — server-side RED metrics (request rate, error rate,
+      # duration histogram) labelled by route pattern. The browser telemetry
+      # next door says a page was slow; this says whether the API behind it
+      # was. Scraped on the app's own port, NOT through Caddy, which returns
+      # 404 for /metrics publicly (see services/whiskeywhiskeywhiskey.nix).
+      # Port must match `listenPort` there.
+      {
+        job_name = "whiskeywhiskeywhiskey";
+        static_configs = [
+          { targets = [ "127.0.0.1:3417" ]; labels = { instance = "forge.holthome.net"; host = "forge"; service = "whiskeywhiskeywhiskey"; }; }
+        ];
+      }
+
       # Grafana Alloy — self metrics plus the faro_receiver_* counters
       # (logs/exceptions/measurements/events accepted, and rejections). This
       # is the RED view of browser telemetry ingest: if exceptions_total

--- a/hosts/forge/services/whiskeywhiskeywhiskey.nix
+++ b/hosts/forge/services/whiskeywhiskeywhiskey.nix
@@ -249,7 +249,21 @@ in
         #
         # See hosts/forge/infrastructure/observability/alloy.nix for the
         # receiver, its rate limit and payload cap.
+        # The app's Prometheus endpoint is unauthenticated by design --
+        # Prometheus scrapes it over loopback at 127.0.0.1:3417/metrics, which
+        # keeps SOPS out of the scrape path. That is only safe because the
+        # exposure is closed HERE: without this rule, /metrics would publish
+        # the route table and traffic shape of the bunker to anyone who asks.
+        # 404 rather than 403 so the endpoint's existence isn't confirmed.
+        #
+        # `handle` is terminal and Caddy orders it ahead of the generated
+        # site-level reverse_proxy, the same mechanism the /relay route relies
+        # on -- verified with `caddy adapt` against the rendered vhost.
         extraConfig = ''
+          handle /metrics {
+            respond 404
+          }
+
           handle_path /relay/* {
             reverse_proxy ${faroCollectorHost}:${toString faroCollectorPort}
           }


### PR DESCRIPTION
Second half of the app's observability, and the last piece of the original plan. The Faro browser telemetry can already say a page was slow or threw; nothing could say whether the **API behind it** was slow. The upstream app now exposes Prometheus RED metrics — request rate, error rate, duration histogram — labelled by route pattern.

Pairs with carpenike/whiskey-whiskey-whiskey#57. **Merge this first**, so `/metrics` is never publicly reachable, not even briefly.

## Two pieces

**Scrape job** pointed at the app's own port, not through Caddy. Loopback scraping needs no credentials and keeps SOPS out of the scrape path.

**Caddy rule** returning 404 for `/metrics` on the public vhost. This is what makes the unauthenticated endpoint safe — without it, `/metrics` publishes the bunker's route table and traffic shape to anyone who asks. 404 rather than 403 so the endpoint's existence isn't confirmed.

## Ordering, verified not assumed

`handle` is terminal and Caddy orders it ahead of the generated site-level `reverse_proxy`. Ran `caddy adapt` against the rendered vhost; the adapted route table is, in order:

```
path /metrics  -> static_response:404
path /relay/*  -> rewrite + reverse_proxy 127.0.0.1:12347
(no match)     -> reverse_proxy 127.0.0.1:3417
```

So the 404 wins for that one path and nothing else changes.

## Caveat

The scrape target port must stay in step with `listenPort` in `services/whiskeywhiskeywhiskey.nix`. Noted in a comment at both sites; not worth plumbing a shared binding for one integer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)