### PR TITLE
feat(observability): add server RED row and an Audience dashboard

### DIFF
--- a/hosts/forge/infrastructure/observability/dashboards/whiskey-audience.json
+++ b/hosts/forge/infrastructure/observability/dashboards/whiskey-audience.json
@@ -1,0 +1,491 @@
+{
+  "uid": "www-audience",
+  "title": "W.W.W. \u2014 Audience",
+  "description": "Who is using Operation W.W.W., when, and what they open. Sessions, not people: there is no identity field, because most users have no account -- they arrive on a token-gated share link. A session is one browser in one sitting (SPA sessions are sticky via localStorage; guest sessions are per-tab via sessionStorage, so a projector reloading itself is not counted as a returning visitor). Alloy flattens Faro event attributes with an `event_data_` prefix -- a bare `surface=\"...\"` matches nothing. `view_name` filters every signal from a surface; `event_data_surface` counts page views on it.",
+  "tags": [
+    "whiskey-whiskey-whiskey",
+    "rum",
+    "faro",
+    "audience"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 41,
+  "version": 1,
+  "editable": true,
+  "refresh": "5m",
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Sessions",
+      "description": "Distinct browser sessions in the selected range, both guests and signed-in crew.",
+      "datasource": {
+        "type": "loki",
+        "uid": "auto-loki-auto"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "auto-loki-auto"
+          },
+          "expr": "count(count by (session_id) (count_over_time({job=\"faro\"} | json [$__range])))",
+          "instant": true,
+          "queryType": "instant"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Guest sessions",
+      "description": "Sessions from the server-rendered share pages -- people with no account, arriving on a link you sent.",
+      "datasource": {
+        "type": "loki",
+        "uid": "auto-loki-auto"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "green"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "auto-loki-auto"
+          },
+          "expr": "count(count by (session_id) (count_over_time({job=\"faro\"} | json | sdk_name=\"www-guest\" [$__range])))",
+          "instant": true,
+          "queryType": "instant"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Page views",
+      "description": "Explicit page_view events. Faro has no first-class page-view signal, so these are emitted deliberately by both surfaces.",
+      "datasource": {
+        "type": "loki",
+        "uid": "auto-loki-auto"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "auto-loki-auto"
+          },
+          "expr": "sum(count_over_time({job=\"faro\"} | json | event_name=\"page_view\" [$__range]))",
+          "instant": true,
+          "queryType": "instant"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Menu proposals opened",
+      "description": "Sessions that opened a ?menu proposal page. The Sharing tab receipt cannot answer this -- every variant of the share URL records against the same op id.",
+      "datasource": {
+        "type": "loki",
+        "uid": "auto-loki-auto"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "orange"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "auto-loki-auto"
+          },
+          "expr": "count(count by (session_id) (count_over_time({job=\"faro\"} | json | view_name=\"public-op-menu\" [$__range])))",
+          "instant": true,
+          "queryType": "instant"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Sessions over time",
+      "description": "When people actually use it. Buckets, not a line: at this traffic volume a smoothed rate reads as flat zero.",
+      "datasource": {
+        "type": "loki",
+        "uid": "auto-loki-auto"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "fillOpacity": 60,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "count(count by (session_id) (count_over_time({job=\"faro\"} | json | sdk_name=\"www-guest\" [$__auto])))",
+          "legendFormat": "guest",
+          "datasource": {
+            "type": "loki",
+            "uid": "auto-loki-auto"
+          },
+          "queryType": "range"
+        },
+        {
+          "refId": "B",
+          "expr": "count(count by (session_id) (count_over_time({job=\"faro\"} | json | sdk_name!=\"www-guest\" [$__auto])))",
+          "legendFormat": "signed in",
+          "datasource": {
+            "type": "loki",
+            "uid": "auto-loki-auto"
+          },
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Page views by guest surface",
+      "description": "Which share page people land on: the live dossier, the concluded write-up, or the menu proposal sent for review.",
+      "datasource": {
+        "type": "loki",
+        "uid": "auto-loki-auto"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "fillOpacity": 60,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (event_data_surface) (count_over_time({job=\"faro\"} | json | event_name=\"page_view\" | sdk_name=\"www-guest\" [$__auto]))",
+          "legendFormat": "{{event_data_surface}}",
+          "datasource": {
+            "type": "loki",
+            "uid": "auto-loki-auto"
+          },
+          "queryType": "range"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "table",
+      "title": "Menu proposal opens by operation",
+      "description": "Did the people you sent it to actually read it? Counts page views of the ?menu variant, grouped by op slug. Pair with the Sessions stat above -- one reviewer reloading three times is three views but one session.",
+      "datasource": {
+        "type": "loki",
+        "uid": "auto-loki-auto"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "filterable": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Value",
+            "desc": true
+          }
+        ]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "auto-loki-auto"
+          },
+          "expr": "sum by (event_data_slug) (count_over_time({job=\"faro\"} | json | event_name=\"page_view\" | event_data_surface=\"public-op-menu\" [$__range]))",
+          "instant": true,
+          "queryType": "instant"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "table",
+      "title": "Bunker pages by route",
+      "description": "Where signed-in time goes. Route labels are bounded and carry no ids: `#/op/<id>/menu` reports as `op:menu`, and an unrecognised section collapses to `op:other`.",
+      "datasource": {
+        "type": "loki",
+        "uid": "auto-loki-auto"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "filterable": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Value",
+            "desc": true
+          }
+        ]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "loki",
+            "uid": "auto-loki-auto"
+          },
+          "expr": "topk(15, sum by (event_data_route) (count_over_time({job=\"faro\"} | json | event_name=\"page_view\" | sdk_name!=\"www-guest\" [$__range])))",
+          "instant": true,
+          "queryType": "instant"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Guest page load time p75",
+      "description": "What a guest on mobile data actually waits. The host never sees this case on their own laptop. Reported by the inline beacon on the share pages, not by the SPA.",
+      "datasource": {
+        "type": "loki",
+        "uid": "auto-loki-auto"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 1,
+            "fillOpacity": 60,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "quantile_over_time(0.75, {job=\"faro\", kind=\"measurement\"} | json | type=\"page_load\" | unwrap value_load | __error__=\"\" [$__auto])",
+          "legendFormat": "load",
+          "datasource": {
+            "type": "loki",
+            "uid": "auto-loki-auto"
+          },
+          "queryType": "range"
+        },
+        {
+          "refId": "B",
+          "expr": "quantile_over_time(0.75, {job=\"faro\", kind=\"measurement\"} | json | type=\"page_load\" | unwrap value_ttfb | __error__=\"\" [$__auto])",
+          "legendFormat": "TTFB",
+          "datasource": {
+            "type": "loki",
+            "uid": "auto-loki-auto"
+          },
+          "queryType": "range"
+        }
+      ]
+    }
+  ]
+}

--- a/hosts/forge/infrastructure/observability/dashboards/whiskey-faro-rum.json
+++ b/hosts/forge/infrastructure/observability/dashboards/whiskey-faro-rum.json
@@ -1,40 +1,72 @@
 {
   "uid": "www-faro-rum",
-  "title": "W.W.W. — Browser Telemetry",
-  "description": "Real user monitoring for Operation W.W.W. Signals arrive from the Grafana Faro Web SDK in the SPA, via Alloy's faro.receiver. Counters come from Alloy's own /metrics; everything else is queried out of Loki under {job=\"faro\"}. Share tokens on the #/present and #/hub routes are redacted client-side before send.",
-  "tags": ["whiskey-whiskey-whiskey", "rum", "faro"],
+  "title": "W.W.W. \u2014 Application Telemetry",
+  "description": "Real user monitoring for Operation W.W.W. Signals arrive from the Grafana Faro Web SDK in the SPA, via Alloy's faro.receiver. Counters come from Alloy's own /metrics; everything else is queried out of Loki under {job=\"faro\"}. Share tokens on the #/present and #/hub routes are redacted client-side before send. Server-side RED metrics come from fastify-metrics via the whiskeywhiskeywhiskey Prometheus job.",
+  "tags": [
+    "whiskey-whiskey-whiskey",
+    "rum",
+    "faro"
+  ],
   "timezone": "browser",
   "schemaVersion": 41,
   "version": 1,
   "editable": true,
   "refresh": "1m",
-  "time": { "from": "now-24h", "to": "now" },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
   "panels": [
     {
       "id": 1,
       "type": "stat",
       "title": "Exceptions",
       "description": "Unhandled JS errors and promise rejections ingested in the selected range.",
-      "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "auto-prometheus-auto"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
           "decimals": 0,
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "orange", "value": 1 },
-              { "color": "red", "value": 25 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 25
+              }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "colorMode": "value",
         "graphMode": "area",
         "textMode": "auto"
@@ -42,7 +74,10 @@
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "auto-prometheus-auto"
+          },
           "expr": "increase(faro_receiver_exceptions_total[$__range])",
           "instant": true,
           "legendFormat": "exceptions"
@@ -54,14 +89,35 @@
       "type": "stat",
       "title": "Measurements",
       "description": "Web Vitals samples (LCP, INP, CLS, FCP, TTFB).",
-      "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "auto-prometheus-auto"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
       "fieldConfig": {
-        "defaults": { "unit": "short", "decimals": 0, "color": { "mode": "fixed", "fixedColor": "blue" } },
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          }
+        },
         "overrides": []
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "colorMode": "value",
         "graphMode": "area",
         "textMode": "auto"
@@ -69,7 +125,10 @@
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "auto-prometheus-auto"
+          },
           "expr": "increase(faro_receiver_measurements_total[$__range])",
           "instant": true,
           "legendFormat": "measurements"
@@ -81,14 +140,35 @@
       "type": "stat",
       "title": "Events",
       "description": "Page views, route changes, session start/resume, resource timings.",
-      "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
-      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "auto-prometheus-auto"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
       "fieldConfig": {
-        "defaults": { "unit": "short", "decimals": 0, "color": { "mode": "fixed", "fixedColor": "purple" } },
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        },
         "overrides": []
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "colorMode": "value",
         "graphMode": "area",
         "textMode": "auto"
@@ -96,7 +176,10 @@
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "auto-prometheus-auto"
+          },
           "expr": "increase(faro_receiver_events_total[$__range])",
           "instant": true,
           "legendFormat": "events"
@@ -108,25 +191,47 @@
       "type": "stat",
       "title": "Collector in-flight",
       "description": "Requests currently being served by Alloy's faro.receiver. A number that never returns to zero means the Loki push is backing up.",
-      "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
-      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "auto-prometheus-auto"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "short",
           "decimals": 0,
-          "color": { "mode": "thresholds" },
+          "color": {
+            "mode": "thresholds"
+          },
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 10 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
             ]
           }
         },
         "overrides": []
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "colorMode": "value",
         "graphMode": "area",
         "textMode": "auto"
@@ -134,7 +239,10 @@
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "auto-prometheus-auto"
+          },
           "expr": "sum(faro_receiver_inflight_requests)",
           "instant": true,
           "legendFormat": "in-flight"
@@ -145,42 +253,74 @@
       "id": 5,
       "type": "timeseries",
       "title": "Ingest rate by signal type",
-      "description": "From Alloy's own counters, so this is what the collector accepted — independent of whether Loki kept it.",
-      "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "description": "From Alloy's own counters, so this is what the collector accepted \u2014 independent of whether Loki kept it.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "auto-prometheus-auto"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "reqps",
-          "custom": { "drawStyle": "line", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never" }
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
         },
         "overrides": []
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "auto-prometheus-auto"
+          },
           "expr": "rate(faro_receiver_exceptions_total[$__rate_interval])",
           "legendFormat": "exceptions"
         },
         {
           "refId": "B",
-          "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "auto-prometheus-auto"
+          },
           "expr": "rate(faro_receiver_events_total[$__rate_interval])",
           "legendFormat": "events"
         },
         {
           "refId": "C",
-          "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "auto-prometheus-auto"
+          },
           "expr": "rate(faro_receiver_measurements_total[$__rate_interval])",
           "legendFormat": "measurements"
         },
         {
           "refId": "D",
-          "datasource": { "type": "prometheus", "uid": "auto-prometheus-auto" },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "auto-prometheus-auto"
+          },
           "expr": "rate(faro_receiver_logs_total[$__rate_interval])",
           "legendFormat": "logs"
         }
@@ -189,48 +329,89 @@
     {
       "id": 6,
       "type": "timeseries",
-      "title": "Core Web Vitals — p75",
+      "title": "Core Web Vitals \u2014 p75",
       "description": "The three Core Web Vitals at the 75th percentile, which is the threshold Google's own scoring uses. LCP and INP are milliseconds; CLS is unitless and plotted on the right axis. Good/needs-work boundaries: LCP 2500ms, INP 200ms, CLS 0.1.",
-      "datasource": { "type": "loki", "uid": "auto-loki-auto" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "datasource": {
+        "type": "loki",
+        "uid": "auto-loki-auto"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "ms",
-          "custom": { "drawStyle": "line", "lineWidth": 2, "fillOpacity": 0, "showPoints": "never" }
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "never"
+          }
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "CLS" },
+            "matcher": {
+              "id": "byName",
+              "options": "CLS"
+            },
             "properties": [
-              { "id": "unit", "value": "none" },
-              { "id": "custom.axisPlacement", "value": "right" },
-              { "id": "decimals", "value": 3 }
+              {
+                "id": "unit",
+                "value": "none"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "decimals",
+                "value": 3
+              }
             ]
           }
         ]
       },
       "options": {
-        "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "loki", "uid": "auto-loki-auto" },
+          "datasource": {
+            "type": "loki",
+            "uid": "auto-loki-auto"
+          },
           "expr": "quantile_over_time(0.75, {job=\"faro\", kind=\"measurement\"} | json | type=\"web-vitals\" | unwrap value_lcp | __error__=\"\" [$__auto])",
           "legendFormat": "LCP",
           "queryType": "range"
         },
         {
           "refId": "B",
-          "datasource": { "type": "loki", "uid": "auto-loki-auto" },
+          "datasource": {
+            "type": "loki",
+            "uid": "auto-loki-auto"
+          },
           "expr": "quantile_over_time(0.75, {job=\"faro\", kind=\"measurement\"} | json | type=\"web-vitals\" | unwrap value_inp | __error__=\"\" [$__auto])",
           "legendFormat": "INP",
           "queryType": "range"
         },
         {
           "refId": "C",
-          "datasource": { "type": "loki", "uid": "auto-loki-auto" },
+          "datasource": {
+            "type": "loki",
+            "uid": "auto-loki-auto"
+          },
           "expr": "quantile_over_time(0.75, {job=\"faro\", kind=\"measurement\"} | json | type=\"web-vitals\" | unwrap value_cls | __error__=\"\" [$__auto])",
           "legendFormat": "CLS",
           "queryType": "range"
@@ -242,17 +423,41 @@
       "type": "table",
       "title": "Top exceptions",
       "description": "Grouped by error message. `page_url` has already had any share token stripped client-side, so a #/present or #/hub row shows the slug and <redacted> in place of the key.",
-      "datasource": { "type": "loki", "uid": "auto-loki-auto" },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 12 },
+      "datasource": {
+        "type": "loki",
+        "uid": "auto-loki-auto"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
       "fieldConfig": {
-        "defaults": { "custom": { "align": "auto", "filterable": true } },
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "filterable": true
+          }
+        },
         "overrides": []
       },
-      "options": { "showHeader": true, "sortBy": [{ "displayName": "Value", "desc": true }] },
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Value",
+            "desc": true
+          }
+        ]
+      },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "loki", "uid": "auto-loki-auto" },
+          "datasource": {
+            "type": "loki",
+            "uid": "auto-loki-auto"
+          },
           "expr": "topk(10, sum by (value, type) (count_over_time({job=\"faro\", kind=\"exception\"} | json [$__range])))",
           "instant": true,
           "queryType": "instant"
@@ -264,8 +469,16 @@
       "type": "logs",
       "title": "Recent exceptions",
       "description": "Raw beacons. Expand a line for the minified stacktrace, app_version (the deployed git commit), browser_name/browser_os and session_id.",
-      "datasource": { "type": "loki", "uid": "auto-loki-auto" },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 12 },
+      "datasource": {
+        "type": "loki",
+        "uid": "auto-loki-auto"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
       "options": {
         "showTime": true,
         "showLabels": false,
@@ -279,9 +492,276 @@
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "loki", "uid": "auto-loki-auto" },
+          "datasource": {
+            "type": "loki",
+            "uid": "auto-loki-auto"
+          },
           "expr": "{job=\"faro\", kind=\"exception\"}",
           "queryType": "range"
+        }
+      ]
+    },
+    {
+      "id": 100,
+      "type": "row",
+      "title": "Server (Fastify)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "panels": []
+    },
+    {
+      "id": 101,
+      "type": "timeseries",
+      "title": "Request rate by route",
+      "description": "What the API is actually serving. Route labels are patterns, so /api/ops/:id is one series no matter how many operations exist.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "auto-prometheus-auto"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (route) (rate(http_request_duration_seconds_count{job=\"whiskeywhiskeywhiskey\"}[$__rate_interval]))",
+          "legendFormat": "{{route}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "auto-prometheus-auto"
+          }
+        }
+      ]
+    },
+    {
+      "id": 102,
+      "type": "timeseries",
+      "title": "Errors by status",
+      "description": "5xx is the app failing; 4xx is mostly bots and expired share links, which is why they are split rather than summed into one error rate.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "auto-prometheus-auto"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(http_request_duration_seconds_count{job=\"whiskeywhiskeywhiskey\",status_code=~\"5..\"}[$__rate_interval]))",
+          "legendFormat": "5xx",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "auto-prometheus-auto"
+          }
+        },
+        {
+          "refId": "B",
+          "expr": "sum(rate(http_request_duration_seconds_count{job=\"whiskeywhiskeywhiskey\",status_code=~\"4..\"}[$__rate_interval]))",
+          "legendFormat": "4xx",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "auto-prometheus-auto"
+          }
+        }
+      ]
+    },
+    {
+      "id": 103,
+      "type": "timeseries",
+      "title": "Latency p95 by route",
+      "description": "The server-side half of a slow page. When the browser panel above shows a bad LCP, this says whether the API was the reason.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "auto-prometheus-auto"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le, route) (rate(http_request_duration_seconds_bucket{job=\"whiskeywhiskeywhiskey\"}[$__rate_interval])))",
+          "legendFormat": "{{route}}",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "auto-prometheus-auto"
+          }
+        }
+      ]
+    },
+    {
+      "id": 104,
+      "type": "timeseries",
+      "title": "Event loop lag p99 / heap",
+      "description": "Saturation. SQLite work and the Anthropic calls are synchronous enough that a blocked event loop shows here before users notice it anywhere else.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "auto-prometheus-auto"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "heap used"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "nodejs_eventloop_lag_p99_seconds{job=\"whiskeywhiskeywhiskey\"}",
+          "legendFormat": "event loop p99",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "auto-prometheus-auto"
+          }
+        },
+        {
+          "refId": "B",
+          "expr": "nodejs_heap_size_used_bytes{job=\"whiskeywhiskeywhiskey\"}",
+          "legendFormat": "heap used",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "auto-prometheus-auto"
+          }
         }
       ]
     }


### PR DESCRIPTION
The RUM dashboard was built in the first hour of this work and only ever covered browser signals. Since then the app grew server-side RED metrics, explicit `page_view` events, guest-page telemetry and a role label — none of which anything displayed.

## Two changes

**`www-faro-rum` gains a "Server (Fastify)" row** — request rate by route, 4xx/5xx split, p95 latency by route, event-loop lag + heap. Retitled *"W.W.W. — Application Telemetry"* since it's no longer browser-only. **The uid is unchanged**, so existing links and bookmarks keep working.

4xx and 5xx are separate series rather than one error rate: this origin takes constant bot traffic and serves expired share links, so a combined rate would sit permanently elevated and mean nothing.

**A new `www-audience` dashboard** for the who/when/what questions — asked at a different time, and for a different reason, than "is it broken":

- Sessions, guest sessions, page views, menu proposals opened
- Sessions over time, split guest vs signed-in
- Page views by guest surface (dossier / concluded / proposal)
- **Menu proposal opens by operation** — did the people you sent it to actually read it
- Bunker pages by route
- Guest page load time p75 — what someone on mobile data waits, which the host never sees on their own laptop

## The field-naming trap, worth recording

Alloy flattens a Faro event's `attributes` map into log fields with an **`event_data_`** prefix. A bare `surface="public-op-menu"` matches **nothing** — it must be `event_data_surface`. Meta fields keep their own prefixes (`view_name`, `session_id`, `app_version`).

I'd shipped the wrong form in `docs/TELEMETRY.md` and in two PR descriptions; that's corrected in carpenike/whiskey-whiskey-whiskey#60.

The panels use `event_data_surface` to count page **views** and `view_name` to filter **every** signal from a surface — the guest beacon stamps the surface onto `meta.view`, so `view_name` also catches that page's errors and load timings.

## Verification

All **30** queries across both dashboards were extracted and executed against forge's live Loki and Prometheus with the Grafana template variables substituted. **30/30 parse and return successfully.**

Series counts are 0 for anything depending on the app build that hasn't deployed yet (server metrics, `page_view`, guest telemetry) — expected, not a defect. Note the `whiskeywhiskeywhiskey` scrape target currently reads `down` with *"unsupported Content-Type text/html"* for the same reason: the running app still answers `/metrics` with the SPA fallback. It clears itself when carpenike/nix-config#923 lands.

No Nix change needed — `dashboardsDir` copies `*.json` from the directory, so the new file is picked up on the next rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)