### PR TITLE
fix(hermes): later startup checkpoint than /healthz (marginal hardening, root cause NOT established)

### DIFF
--- a/hosts/forge/services/hermes-agent.nix
+++ b/hosts/forge/services/hermes-agent.nix
@@ -1133,6 +1133,46 @@ in
               --connect-timeout 2 --max-time 5 \
               "http://127.0.0.1:${toString homelabMcpPort}/healthz" \
               --output /dev/null
+
+            # /healthz is LIVENESS, not MCP READINESS. homelab-mcp answers it
+            # before its MCP route serves, and per upstream #77765 hermes never
+            # recovers a gateway whose INITIAL MCP connection failed — so one
+            # bad moment at startup leaves the finance tools dead until a human
+            # restarts the unit. That disarmed the daily sentinel on 2026-08-29,
+            # after a deploy restarted BOTH units: homelab-mcp via the flake
+            # repin, hermes-agent via restartTriggers because a prompt edit is a
+            # settings change. The /healthz gate above passed and the tools were
+            # still gone.
+            #
+            # So gate on the MCP route itself. Unauthenticated it answers 401
+            # once the auth layer is mounted and serving — verified against the
+            # live server — which is the surface hermes actually needs. 000
+            # (refused), 404 (unmounted) and 5xx (warming) all mean not yet.
+            #
+            # DELIBERATELY DOES NOT FAIL THE UNIT. A preStart exit would
+            # crash-loop, and the crash-loop is invisible: the ServiceDown rule
+            # needs 120s continuous inactive and RestartSec=10 never supplies it
+            # (measured — see the alerting comment below). Failing would take
+            # Signal and Telegram down too and still page nobody, which is
+            # strictly worse than starting degraded. Detection belongs to
+            # hermes-agent-sentinel-heartbeat, which reads the sentinel's own
+            # output rather than systemd's opinion of the unit.
+            mcpReady=""
+            mcpCode="000"
+            for _ in $(${pkgs.coreutils}/bin/seq 1 90); do
+              mcpCode="$(${pkgs.curl}/bin/curl --silent --output /dev/null \
+                --write-out '%{http_code}' --connect-timeout 2 --max-time 5 \
+                --request POST --header 'Content-Type: application/json' \
+                --data '{"jsonrpc":"2.0","id":1,"method":"initialize"}' \
+                "http://127.0.0.1:${toString homelabMcpPort}/mcp" || echo 000)"
+              case "$mcpCode" in
+                200|202|401|403) mcpReady=1; break ;;
+              esac
+              ${pkgs.coreutils}/bin/sleep 2
+            done
+            if [ -z "$mcpReady" ]; then
+              echo "hermes-agent: homelab-mcp /mcp never became ready (~180s, last status $mcpCode). Starting anyway so Signal and Telegram stay up, but THE FINANCE TOOLS ARE PROBABLY DEAD and hermes does not recover on its own — restart this unit once homelab-mcp is serving." >&2
+            fi
           ''}
         '';
 

--- a/hosts/forge/services/hermes-agent.nix
+++ b/hosts/forge/services/hermes-agent.nix
@@ -1134,20 +1134,40 @@ in
               "http://127.0.0.1:${toString homelabMcpPort}/healthz" \
               --output /dev/null
 
-            # /healthz is LIVENESS, not MCP READINESS. homelab-mcp answers it
-            # before its MCP route serves, and per upstream #77765 hermes never
-            # recovers a gateway whose INITIAL MCP connection failed — so one
-            # bad moment at startup leaves the finance tools dead until a human
-            # restarts the unit. That disarmed the daily sentinel on 2026-08-29,
-            # after a deploy restarted BOTH units: homelab-mcp via the flake
-            # repin, hermes-agent via restartTriggers because a prompt edit is a
-            # settings change. The /healthz gate above passed and the tools were
-            # still gone.
+            # A LATER construction checkpoint than /healthz — marginal
+            # hardening, NOT a proven fix. Read the honest limits before
+            # trusting this:
             #
-            # So gate on the MCP route itself. Unauthenticated it answers 401
-            # once the auth layer is mounted and serving — verified against the
-            # live server — which is the surface hermes actually needs. 000
-            # (refused), 404 (unmounted) and 5xx (warming) all mean not yet.
+            # On 2026-08-29 the daily finance sentinel failed with "tool not
+            # available" after a deploy restarted both units. The /healthz gate
+            # above PASSED and the tools were still gone, so whatever happened
+            # was not caught by it.
+            #
+            # The tempting explanation — /healthz is liveness and answers before
+            # the MCP route serves — is WRONG for this server, and the source
+            # says so: homelab_mcp/app.py builds create_app in the order
+            # register_all(tools) -> streamable_http_app() -> contract routes ->
+            # APPEND /healthz -> wire OAuth. /healthz is registered AFTER the
+            # tools and the MCP route, so a 200 already implies the tool
+            # registry exists. THE ROOT CAUSE IS NOT ESTABLISHED.
+            #
+            # What this probe does buy: OAuth wiring is the LAST step of
+            # create_app, so an unauthenticated 401 proves construction reached
+            # further than /healthz did. That is a strictly later checkpoint and
+            # costs nothing.
+            #
+            # What it does NOT prove: the 401 comes from the JWT middleware for
+            # ANY path — /definitely-not-mounted returns 401 too, verified
+            # against the live server — so this is an app-construction signal,
+            # never evidence that a tool call would succeed. An authenticated
+            # tools/list would be the real check; it needs the client_credentials
+            # secret and was judged not worth putting in a preStart until the
+            # actual failure mechanism is known.
+            #
+            # Still true regardless of mechanism: per upstream #77765 hermes
+            # never recovers a gateway whose INITIAL MCP connection failed, so
+            # one bad moment at startup leaves the finance tools dead until a
+            # human restarts the unit.
             #
             # DELIBERATELY DOES NOT FAIL THE UNIT. A preStart exit would
             # crash-loop, and the crash-loop is invisible: the ServiceDown rule
@@ -1164,7 +1184,7 @@ in
                 --write-out '%{http_code}' --connect-timeout 2 --max-time 5 \
                 --request POST --header 'Content-Type: application/json' \
                 --data '{"jsonrpc":"2.0","id":1,"method":"initialize"}' \
-                "http://127.0.0.1:${toString homelabMcpPort}/mcp" || echo 000)"
+                "http://127.0.0.1:${toString homelabMcpPort}/mcp" || true)"
               case "$mcpCode" in
                 200|202|401|403) mcpReady=1; break ;;
               esac


### PR DESCRIPTION
> **Revised after testing.** The original version of this PR claimed `/healthz` is a liveness probe that answers before the MCP route serves. **That is wrong**, and the source says so. Read this section before the rest.

## What I got wrong

`homelab_mcp/app.py` builds `create_app` in this order:

1. `register_all(mcp, ...)` — all tools registered
2. `app = mcp.streamable_http_app()` — MCP route built
3. append contract-hosting routes
4. **append `/healthz`**
5. wire OAuth

`/healthz` is registered **after** the tools and the MCP route, so a 200 already implies the tool registry exists. The gate passed on 2026-08-29 and the finance tools were still gone.

**So the root cause is not established, and this PR does not fix a diagnosed defect.** The real evidence is in hermes' journal from that morning, which nobody has read yet.

## What this actually buys

OAuth wiring is the *last* step of `create_app`, so an unauthenticated **401 proves construction reached further than `/healthz` did**. A strictly later checkpoint, costing nothing.

What it does **not** prove: the 401 comes from the JWT middleware for *any* path — `/definitely-not-mounted` returns 401 too, verified against the live server. It's an app-construction signal, never evidence a tool call would succeed. An authenticated `tools/list` would be the real check; it needs the `client_credentials` secret and isn't worth putting in a `preStart` until the mechanism is known.

## Also fixes a bug in my own code

`curl --write-out` emits `000` on failure **and** the `|| echo 000` fallback fired, so the diagnostic reported `last status 000000`. Now `|| true`.

## Still true regardless of mechanism

Per upstream NousResearch/hermes-agent#77765, hermes never recovers a gateway whose *initial* MCP connection failed — one bad moment at startup leaves the finance tools dead until a human restarts the unit.

## Why it deliberately does not fail the unit

A `preStart` exit would crash-loop, and this config already measured that a crash-loop is invisible: the ServiceDown rule needs 120s continuous inactive and `RestartSec=10` never supplies it. Failing would take Signal and Telegram down and still page nobody.

## Verification

- `nix-instantiate --parse` clean; CI green on the prior commit
- Gate script extracted and run standalone: positive case (live `/mcp`) detects ready with no warning; negative cases (unmounted path, refused port) warn, and the refused case now reports `000` not `000000`
- Note `nix-build` **skips** on this path and `shellcheck` sees nothing, since the script lives inside a Nix string — nothing in CI validates this bash. Both bugs above were found by hand-running it, not by review

Context: carpenike/finances#8

🤖 Generated with [Claude Code](https://claude.com/claude-code)